### PR TITLE
Logging Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /dist
 /releases
 /mocks
+.envrc
+config.yaml


### PR DESCRIPTION
- Deprecate `--verbose` but it's still supported
- Expand logging to support all log levels provided by logrus
- Add .envrc and config.yaml to .gitignore