### PR TITLE
Add GoReleaser Support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/amd64"
   - use: buildx
     goos: linux
@@ -63,7 +63,7 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/arm64"
   - use: buildx
     goos: linux
@@ -79,7 +79,7 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,7 @@ archives:
   - id: default
     builds:
       - default
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ .Arm }}"
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-amd64'
       #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
     build_flag_templates:
       - "--pull"
@@ -55,7 +55,7 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm64'
       #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
     build_flag_templates:
       - "--pull"
@@ -71,7 +71,7 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm32v7'
       #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
     build_flag_templates:
       - "--pull"
@@ -83,11 +83,11 @@ dockers:
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}'
+    name_template: '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}'
     image_templates:
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm32v7'
   #- use: docker
   #  name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
   #  image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,4 @@
 dist: releases
-env:
-  - PACKAGE=github.com/rebuy-de/aws-nuke
 release:
   github:
     owner: rebuy-de

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,6 +97,8 @@ docker_manifests:
   #    - quay.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
 checksum:
   name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Summary }}"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,8 +40,8 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-amd64'
-      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-amd64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+      #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -55,8 +55,8 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm64'
-      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
+      #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -71,8 +71,8 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm32v7'
-      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm32v7'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
+      #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -83,17 +83,17 @@ dockers:
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}'
+    name_template: gchr.io/rebuy-de/aws-nuke:{{ .Version }}
     image_templates:
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm32v7'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
   #- use: docker
-  #  name_template: '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}'
+  #  name_template: quay.io/rebuy-de/aws-nuke:{{ .Version }}
   #  image_templates:
-  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-amd64'
-  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm64'
-  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm32v7'
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-amd64'
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
       #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
@@ -71,8 +71,8 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
-      #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -85,15 +85,15 @@ docker_manifests:
   - use: docker
     name_template: gchr.io/rebuy-de/aws-nuke:{{ .Version }}
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64'
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
+      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
   #- use: docker
   #  name_template: quay.io/rebuy-de/aws-nuke:{{ .Version }}
   #  image_templates:
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-amd64'
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm64'
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7'
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
+  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     image_templates:
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -56,7 +56,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     image_templates:
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -72,7 +72,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     image_templates:
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -88,12 +88,12 @@ docker_manifests:
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
       - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
-  - use: docker
-    name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
-    image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+  #- use: docker
+  #  name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
+  #  image_templates:
+  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,14 +24,14 @@ builds:
         goarch: arm
     ldflags:
       - -s
-      - -X '{{ .ModulePath }}/cmd.BuildVersion={{ .Version }}'
+      - -X '{{ .ModulePath }}/cmd.BuildVersion=v{{ .Version }}'
       - -X '{{ .ModulePath }}/cmd.BuildDate={{ .Date }}'
       - -X '{{ .ModulePath }}/cmd.BuildHash={{ .Commit }}'
 archives:
   - id: default
     builds:
       - default
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ .Arm }}"
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ .Arm }}"
     format_overrides:
       - goos: windows
         format: zip
@@ -41,14 +41,14 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
-      #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-amd64
+      #- quay.io/rebuy/aws-nuke:v{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.version=v{{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/amd64"
   - use: buildx
@@ -56,14 +56,14 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
-      #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-arm64
+      #- quay.io/rebuy/aws-nuke:v{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.version=v{{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/arm64"
   - use: buildx
@@ -72,29 +72,29 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
-      #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
+      #- quay.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.version=v{{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/debuy-de/aws-nuke"
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: ghcr.io/rebuy-de/aws-nuke:{{ .Version }}
+    name_template: ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}
     image_templates:
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
-      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-arm64
+      - ghcr.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
   #- use: docker
-  #  name_template: quay.io/rebuy-de/aws-nuke:{{ .Version }}
+  #  name_template: quay.io/rebuy-de/aws-nuke:v{{ .Version }}
   #  image_templates:
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
-  #    - quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+  #    - quay.io/rebuy-de/aws-nuke:v{{ .Version }}-amd64
+  #    - quay.io/rebuy-de/aws-nuke:v{{ .Version }}-arm64
+  #    - quay.io/rebuy-de/aws-nuke:v{{ .Version }}-arm32v7
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,106 @@
+dist: releases
+env:
+  - PACKAGE=github.com/rebuy-de/aws-nuke
+release:
+  github:
+    owner: rebuy-de
+    name: aws-nuke
+builds:
+  - id: default
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: arm
+    ldflags:
+      - -s
+      - -X '{{ .ModulePath }}/cmd.BuildVersion={{ .Version }}'
+      - -X '{{ .ModulePath }}/cmd.BuildDate={{ .Date }}'
+      - -X '{{ .ModulePath }}/cmd.BuildHash={{ .Commit }}'
+archives:
+  - id: default
+    builds:
+      - default
+    format_overrides:
+      - goos: windows
+        format: zip
+dockers:
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--platform=linux/amd64"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--platform=linux/arm64"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "7"
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source=https://{{ .ModulePath }}"
+      - "--platform=linux/arm/v7"
+docker_manifests:
+  - use: docker
+    name_template: '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}'
+    image_templates:
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com" "gchr.io" }}:{{ .Version }}-arm32v7'
+  - use: docker
+    name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
+    image_templates:
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+checksum:
+  name_template: "checksums.txt"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
       #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
@@ -55,7 +55,7 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
       #- quay.io/rebuy/aws-nuke:{{ .Version }}-amd64
     build_flag_templates:
       - "--pull"
@@ -71,7 +71,7 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
       #- quay.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
     build_flag_templates:
       - "--pull"
@@ -83,11 +83,11 @@ dockers:
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: gchr.io/rebuy-de/aws-nuke:{{ .Version }}
+    name_template: ghcr.io/rebuy-de/aws-nuke:{{ .Version }}
     image_templates:
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
-      - gchr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-amd64
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm64
+      - ghcr.io/rebuy-de/aws-nuke:{{ .Version }}-arm32v7
   #- use: docker
   #  name_template: quay.io/rebuy-de/aws-nuke:{{ .Version }}
   #  image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,8 +40,8 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-amd64'
-      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-amd64'
+      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-amd64'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -55,8 +55,8 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm64'
-      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm64'
+      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm64'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -71,8 +71,8 @@ dockers:
     goarm: "7"
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm32v7'
-      #- '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm32v7'
+      #- '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm32v7'
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -83,17 +83,17 @@ dockers:
       - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
-    name_template: '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}'
+    name_template: '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}'
     image_templates:
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-amd64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm64'
-      - '{{ replace .ModulePath "github.com/debuy-de" "gchr.io/debuy-de" }}:{{ .Version }}-arm32v7'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-amd64'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm64'
+      - '{{ replace .ModulePath "github.com/rebuy-de" "gchr.io/rebuy-de" }}:{{ .Version }}-arm32v7'
   #- use: docker
-  #  name_template: '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}'
+  #  name_template: '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}'
   #  image_templates:
-  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-amd64'
-  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm64'
-  #    - '{{ replace .ModulePath "github.com/debuy-de" "quay.io/debuy" }}:{{ .Version }}-arm32v7'
+  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-amd64'
+  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm64'
+  #    - '{{ replace .ModulePath "github.com/rebuy-de" "quay.io/rebuy" }}:{{ .Version }}-arm32v7'
 checksum:
   name_template: "checksums.txt"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ archives:
   - id: default
     builds:
       - default
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
         format: zip

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -4,6 +4,6 @@ ENTRYPOINT ["/usr/local/bin/aws-nuke"]
 RUN apk add --no-cache ca-certificates
 RUN adduser -D aws-nuke
 
-COPY aws-nuke /usr/local/bin/aws-nuk
+COPY aws-nuke /usr/local/bin/aws-nuke
 
 USER aws-nuke

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,9 @@
+
+FROM alpine:3.14.3
+ENTRYPOINT ["/usr/local/bin/aws-nuke"]
+RUN apk add --no-cache ca-certificates
+RUN adduser -D aws-nuke
+
+COPY aws-nuke /usr/local/bin/aws-nuk
+
+USER aws-nuke


### PR DESCRIPTION
Adding GoReleaser makes it far easier for those who want to fork and build to do so. It also provides a more consistent build experience. 