### PR TITLE
Statically Build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ release:
     - glob: ./cosign.pub
 builds:
   - id: default
+    env:
+      - CGO_ENABLED=0
     goos:
       - darwin
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
         goarch: arm
     ldflags:
       - -s
+      - -w
       - -X '{{ .ModulePath }}/cmd.BuildVersion={{ .Version }}'
       - -X '{{ .ModulePath }}/cmd.BuildDate={{ .Date }}'
       - -X '{{ .ModulePath }}/cmd.BuildHash={{ .Commit }}'

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,7 @@
 
 FROM alpine:3.14.3
 ENTRYPOINT ["/usr/local/bin/aws-nuke"]
-RUN apk add --no-cache ca-certificates libc6-compat
+RUN apk add --no-cache ca-certificates 
 RUN adduser -D aws-nuke
 
 COPY aws-nuke /usr/local/bin/aws-nuke

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,7 @@
 
 FROM alpine:3.14.3
 ENTRYPOINT ["/usr/local/bin/aws-nuke"]
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates libc6-compat
 RUN adduser -D aws-nuke
 
 COPY aws-nuke /usr/local/bin/aws-nuke


### PR DESCRIPTION
Statically build the binary so it works on all architectures by disabling CGO, not needed for this binary.