### PR TITLE
 add new cloudfront resources from upstream converted to libnuke format

### DIFF
--- a/resources/cloudfront-key-groups.go
+++ b/resources/cloudfront-key-groups.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CloudFrontKeyGroup struct {
+	svc              *cloudfront.CloudFront
+	ID               *string
+	name             *string
+	lastModifiedTime *time.Time
+}
+
+func init() {
+	register("CloudFrontKeyGroup", ListCloudFrontKeyGroups)
+}
+
+func ListCloudFrontKeyGroups(sess *session.Session) ([]Resource, error) {
+	svc := cloudfront.New(sess)
+	resources := []Resource{}
+	params := &cloudfront.ListKeyGroupsInput{}
+
+	for {
+		resp, err := svc.ListKeyGroups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range resp.KeyGroupList.Items {
+			resources = append(resources, &CloudFrontKeyGroup{
+				svc:              svc,
+				ID:               item.KeyGroup.Id,
+				name:             item.KeyGroup.KeyGroupConfig.Name,
+				lastModifiedTime: item.KeyGroup.LastModifiedTime,
+			})
+		}
+
+		if resp.KeyGroupList.NextMarker == nil {
+			break
+		}
+
+		params.Marker = resp.KeyGroupList.NextMarker
+	}
+
+	return resources, nil
+}
+
+func (f *CloudFrontKeyGroup) Remove() error {
+	resp, err := f.svc.GetKeyGroup(&cloudfront.GetKeyGroupInput{
+		Id: f.ID,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = f.svc.DeleteKeyGroup(&cloudfront.DeleteKeyGroupInput{
+		Id:      f.ID,
+		IfMatch: resp.ETag,
+	})
+
+	return err
+}
+
+func (f *CloudFrontKeyGroup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", f.ID)
+	properties.Set("Name", f.name)
+	properties.Set("LastModifiedTime", f.lastModifiedTime.Format(time.RFC3339))
+	return properties
+}

--- a/resources/cloudfront-origin-request-policy.go
+++ b/resources/cloudfront-origin-request-policy.go
@@ -1,0 +1,68 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CloudFrontOriginRequestPolicy struct {
+	svc *cloudfront.CloudFront
+	ID  *string
+}
+
+func init() {
+	register("CloudFrontOriginRequestPolicy", ListCloudFrontOriginRequestPolicies)
+}
+
+func ListCloudFrontOriginRequestPolicies(sess *session.Session) ([]Resource, error) {
+	svc := cloudfront.New(sess)
+	resources := []Resource{}
+	params := &cloudfront.ListOriginRequestPoliciesInput{}
+
+	for {
+		resp, err := svc.ListOriginRequestPolicies(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range resp.OriginRequestPolicyList.Items {
+			if *item.Type == "custom" {
+				resources = append(resources, &CloudFrontOriginRequestPolicy{
+					svc: svc,
+					ID:  item.OriginRequestPolicy.Id,
+				})
+			}
+		}
+
+		if resp.OriginRequestPolicyList.NextMarker == nil {
+			break
+		}
+
+		params.Marker = resp.OriginRequestPolicyList.NextMarker
+	}
+
+	return resources, nil
+}
+
+func (f *CloudFrontOriginRequestPolicy) Remove() error {
+	resp, err := f.svc.GetOriginRequestPolicy(&cloudfront.GetOriginRequestPolicyInput{
+		Id: f.ID,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = f.svc.DeleteOriginRequestPolicy(&cloudfront.DeleteOriginRequestPolicyInput{
+		Id:      f.ID,
+		IfMatch: resp.ETag,
+	})
+
+	return err
+}
+
+func (f *CloudFrontOriginRequestPolicy) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", f.ID)
+	return properties
+}

--- a/resources/cloudfront-origin-request-policy.go
+++ b/resources/cloudfront-origin-request-policy.go
@@ -1,9 +1,14 @@
 package resources
 
 import (
-	"github.com/aws/aws-sdk-go/aws/session"
+	"context"
+
 	"github.com/aws/aws-sdk-go/service/cloudfront"
-	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/pkg/nuke"
 )
 
 type CloudFrontOriginRequestPolicy struct {
@@ -11,13 +16,23 @@ type CloudFrontOriginRequestPolicy struct {
 	ID  *string
 }
 
+const CloudFrontOriginRequestPolicyResource = "CloudFrontOriginRequestPolicy"
+
 func init() {
-	register("CloudFrontOriginRequestPolicy", ListCloudFrontOriginRequestPolicies)
+	resource.Register(&resource.Registration{
+		Name:   CloudFrontOriginRequestPolicyResource,
+		Scope:  nuke.Account,
+		Lister: &CloudFrontOriginRequestPolicyLister{},
+	})
 }
 
-func ListCloudFrontOriginRequestPolicies(sess *session.Session) ([]Resource, error) {
-	svc := cloudfront.New(sess)
-	resources := []Resource{}
+type CloudFrontOriginRequestPolicyLister struct{}
+
+func (l *CloudFrontOriginRequestPolicyLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+
+	svc := cloudfront.New(opts.Session)
+	resources := make([]resource.Resource, 0)
 	params := &cloudfront.ListOriginRequestPoliciesInput{}
 
 	for {
@@ -45,7 +60,7 @@ func ListCloudFrontOriginRequestPolicies(sess *session.Session) ([]Resource, err
 	return resources, nil
 }
 
-func (f *CloudFrontOriginRequestPolicy) Remove() error {
+func (f *CloudFrontOriginRequestPolicy) Remove(_ context.Context) error {
 	resp, err := f.svc.GetOriginRequestPolicy(&cloudfront.GetOriginRequestPolicyInput{
 		Id: f.ID,
 	})

--- a/resources/cloudfront-public-keys.go
+++ b/resources/cloudfront-public-keys.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CloudFrontPublicKey struct {
+	svc         *cloudfront.CloudFront
+	ID          *string
+	name        *string
+	createdTime *time.Time
+}
+
+func init() {
+	register("CloudFrontPublicKey", ListCloudFrontPublicKeys)
+}
+
+func ListCloudFrontPublicKeys(sess *session.Session) ([]Resource, error) {
+	svc := cloudfront.New(sess)
+	resources := []Resource{}
+	params := &cloudfront.ListPublicKeysInput{}
+
+	for {
+		resp, err := svc.ListPublicKeys(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range resp.PublicKeyList.Items {
+			resources = append(resources, &CloudFrontPublicKey{
+				svc:         svc,
+				ID:          item.Id,
+				name:        item.Name,
+				createdTime: item.CreatedTime,
+			})
+		}
+
+		if resp.PublicKeyList.NextMarker == nil {
+			break
+		}
+
+		params.Marker = resp.PublicKeyList.NextMarker
+	}
+
+	return resources, nil
+}
+
+func (f *CloudFrontPublicKey) Remove() error {
+	resp, err := f.svc.GetPublicKey(&cloudfront.GetPublicKeyInput{
+		Id: f.ID,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = f.svc.DeletePublicKey(&cloudfront.DeletePublicKeyInput{
+		Id:      f.ID,
+		IfMatch: resp.ETag,
+	})
+
+	return err
+}
+
+func (f *CloudFrontPublicKey) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", f.ID)
+	properties.Set("Name", f.name)
+	properties.Set("CreatedTime", f.createdTime.Format(time.RFC3339))
+	return properties
+}


### PR DESCRIPTION
this adds the following resources and converts them to the libnuke format

- cloudfront-key-groups
- cloudfront-origin-request-policy
- cloudfront-public-keys