### PR TITLE
 add new elasticache resources from upstream converted to libnuke format

### DIFF
--- a/resources/elasticache-subnetgroups.go
+++ b/resources/elasticache-subnetgroups.go
@@ -2,6 +2,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -48,6 +50,13 @@ func (l *ElasticacheSubnetGroupLister) List(_ context.Context, o interface{}) ([
 type ElasticacheSubnetGroup struct {
 	svc  *elasticache.ElastiCache
 	name *string
+}
+
+func (i *ElasticacheSubnetGroup) Filter() error {
+	if strings.HasPrefix(*i.name, "default") {
+		return fmt.Errorf("cannot delete default subnet group")
+	}
+	return nil
 }
 
 func (i *ElasticacheSubnetGroup) Remove(_ context.Context) error {

--- a/resources/elasticache-usergroups.go
+++ b/resources/elasticache-usergroups.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type ElasticacheUserGroup struct {
+	svc     *elasticache.ElastiCache
+	groupId *string
+}
+
+func init() {
+	register("ElasticacheUserGroup", ListElasticacheUserGroups)
+}
+
+func ListElasticacheUserGroups(sess *session.Session) ([]Resource, error) {
+	svc := elasticache.New(sess)
+	resources := []Resource{}
+	var nextToken *string
+
+	for {
+		params := &elasticache.DescribeUserGroupsInput{
+			MaxRecords: aws.Int64(100),
+			Marker:     nextToken,
+		}
+		resp, err := svc.DescribeUserGroups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, userGroup := range resp.UserGroups {
+			resources = append(resources, &ElasticacheUserGroup{
+				svc:     svc,
+				groupId: userGroup.UserGroupId,
+			})
+		}
+
+		// Check if there are more results
+		if resp.Marker == nil {
+			break // No more results, exit the loop
+		}
+
+		// Set the nextToken for the next iteration
+		nextToken = resp.Marker
+	}
+
+	return resources, nil
+}
+
+func (i *ElasticacheUserGroup) Remove() error {
+	params := &elasticache.DeleteUserGroupInput{
+		UserGroupId: i.groupId,
+	}
+
+	_, err := i.svc.DeleteUserGroup(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *ElasticacheUserGroup) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", i.groupId)
+	return properties
+}
+
+func (i *ElasticacheUserGroup) String() string {
+	return *i.groupId
+}

--- a/resources/elasticache-usergroups.go
+++ b/resources/elasticache-usergroups.go
@@ -1,10 +1,15 @@
 package resources
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elasticache"
-	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/pkg/nuke"
 )
 
 type ElasticacheUserGroup struct {
@@ -12,13 +17,23 @@ type ElasticacheUserGroup struct {
 	groupId *string
 }
 
+const ElasticacheUserGroupResource = "ElasticacheUserGroup"
+
 func init() {
-	register("ElasticacheUserGroup", ListElasticacheUserGroups)
+	resource.Register(&resource.Registration{
+		Name:   ElasticacheUserGroupResource,
+		Scope:  nuke.Account,
+		Lister: &ElasticacheUserGroupLister{},
+	})
 }
 
-func ListElasticacheUserGroups(sess *session.Session) ([]Resource, error) {
-	svc := elasticache.New(sess)
-	resources := []Resource{}
+type ElasticacheUserGroupLister struct{}
+
+func (l *ElasticacheUserGroupLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+
+	svc := elasticache.New(opts.Session)
+	resources := make([]resource.Resource, 0)
 	var nextToken *string
 
 	for {
@@ -50,7 +65,7 @@ func ListElasticacheUserGroups(sess *session.Session) ([]Resource, error) {
 	return resources, nil
 }
 
-func (i *ElasticacheUserGroup) Remove() error {
+func (i *ElasticacheUserGroup) Remove(_ context.Context) error {
 	params := &elasticache.DeleteUserGroupInput{
 		UserGroupId: i.groupId,
 	}

--- a/resources/elasticache-users.go
+++ b/resources/elasticache-users.go
@@ -1,0 +1,87 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type ElasticacheUser struct {
+	svc      *elasticache.ElastiCache
+	userId   *string
+	userName *string
+}
+
+func init() {
+	register("ElasticacheUser", ListElasticacheUsers)
+}
+
+func ListElasticacheUsers(sess *session.Session) ([]Resource, error) {
+	svc := elasticache.New(sess)
+	resources := []Resource{}
+	var nextToken *string
+
+	for {
+		params := &elasticache.DescribeUsersInput{
+			MaxRecords: aws.Int64(100),
+			Marker:     nextToken,
+		}
+		resp, err := svc.DescribeUsers(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, user := range resp.Users {
+			resources = append(resources, &ElasticacheUser{
+				svc:      svc,
+				userId:   user.UserId,
+				userName: user.UserName,
+			})
+		}
+
+		// Check if there are more results
+		if resp.Marker == nil {
+			break // No more results, exit the loop
+		}
+
+		// Set the nextToken for the next iteration
+		nextToken = resp.Marker
+	}
+
+	return resources, nil
+}
+
+func (i *ElasticacheUser) Filter() error {
+	if strings.HasPrefix(*i.userName, "default") {
+		return fmt.Errorf("cannot delete default user")
+	}
+	return nil
+}
+
+func (i *ElasticacheUser) Remove() error {
+	params := &elasticache.DeleteUserInput{
+		UserId: i.userId,
+	}
+
+	_, err := i.svc.DeleteUser(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *ElasticacheUser) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", i.userId)
+	properties.Set("UserName", i.userName)
+	return properties
+}
+
+func (i *ElasticacheUser) String() string {
+	return *i.userId
+}

--- a/resources/elasticache-users.go
+++ b/resources/elasticache-users.go
@@ -1,13 +1,17 @@
 package resources
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elasticache"
-	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/pkg/nuke"
 )
 
 type ElasticacheUser struct {
@@ -16,13 +20,23 @@ type ElasticacheUser struct {
 	userName *string
 }
 
+const ElasticacheUserResource = "ElasticacheUser"
+
 func init() {
-	register("ElasticacheUser", ListElasticacheUsers)
+	resource.Register(&resource.Registration{
+		Name:   ElasticacheUserResource,
+		Scope:  nuke.Account,
+		Lister: &ElasticacheUserLister{},
+	})
 }
 
-func ListElasticacheUsers(sess *session.Session) ([]Resource, error) {
-	svc := elasticache.New(sess)
-	resources := []Resource{}
+type ElasticacheUserLister struct{}
+
+func (l *ElasticacheUserLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+
+	svc := elasticache.New(opts.Session)
+	resources := make([]resource.Resource, 0)
 	var nextToken *string
 
 	for {
@@ -62,7 +76,7 @@ func (i *ElasticacheUser) Filter() error {
 	return nil
 }
 
-func (i *ElasticacheUser) Remove() error {
+func (i *ElasticacheUser) Remove(_ context.Context) error {
 	params := &elasticache.DeleteUserInput{
 		UserId: i.userId,
 	}


### PR DESCRIPTION
This adds the following resources from the upstream project and converted to the libnuke format. It also pulls in a change to the filter for the elasticache-subnetgroups

- elasticache-users
- elasticache-usergroups