### PR TITLE
feat: allow bypass of aws alias checks

### DIFF
--- a/docs/cli-experimental.md
+++ b/docs/cli-experimental.md
@@ -1,10 +1,10 @@
-# Feature Flags
+# Experimental Features
 
 ## Overview
 
-These are the feature flags that are currently available in aws-nuke. They are all disabled by default. These are 
-switches that changes the actual behavior of the tool itself. Changing the behavior of a resource is done via resource
-settings.
+These are the experimental features hidden behind feature flags that are currently available in aws-nuke. They are all
+disabled by default. These are switches that changes the actual behavior of the tool itself. Changing the behavior of
+a resource is done via resource settings.
 
 !!! note
     The original tool had configuration options called `feature-flags` which were used to enable/disable certain

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -1,0 +1,11 @@
+# Options
+
+This is not a comprehensive list of options, but rather a list of features that I think are worth highlighting.
+
+## Skip Alias Checks
+
+`--no-alias-check` will skip the check for the AWS account alias. This is useful if you are running in an account that does not have an alias.
+
+## Skip Prompts
+
+`--no-prompt` will skip the prompt to verify you want to run the command. This is useful if you are running in a CI/CD environment.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -35,18 +35,19 @@ USAGE:
    aws-nuke run [command options] [arguments...]
 
 OPTIONS:
-   --config value                                                                                                                                                         path to config file (default: "config.yaml")
-   --force                                                                                                                                                                disable prompting for verification to run (default: false)
-   --force-sleep value                                                                                                                                                    seconds to sleep (default: 10)
-   --quiet                                                                                                                                                                hide filtered messages (default: false)
-   --no-dry-run                                                                                                                                                           actually run the removal of the resources after discovery (default: false)
-   --only-resource value, --target value, --include value, --include-resource value [ --only-resource value, --target value, --include value, --include-resource value ]  only run against these resource types
-   --exclude-resource value, --exclude value [ --exclude-resource value, --exclude value ]                                                                                exclude these resource types
-   --cloud-control value [ --cloud-control value ]                                                                                                                        use these resource types with the Cloud Control API instead of the default
-   --feature-flag value [ --feature-flag value ]                                                                                                                          enable experimental behaviors that may not be fully tested or supported
-   --log-level value, -l value                                                                                                                                            Log Level (default: "info") [$LOGLEVEL]
-   --log-caller                                                                                                                                                           log the caller (aka line number and file) (default: false)
-   --log-disable-color                                                                                                                                                    disable log coloring (default: false)
-   --log-full-timestamp                                                                                                                                                   force log output to always show full timestamp (default: false)
-   --help, -h                                                                                                                                                             show help
+   --config value                                                       path to config file (default: "config.yaml")
+   --include value, --target value [ --include value, --target value ]  only run against these resource types
+   --exclude value [ --exclude value ]                                  exclude these resource types
+   --cloud-control value [ --cloud-control value ]                      use these resource types with the Cloud Control API instead of the default
+   --quiet                                                              hide filtered messages (default: false)
+   --no-dry-run                                                         actually run the removal of the resources after discovery (default: false)
+   --no-alias-check                                                     disable aws account alias check - requires entry in config as well (default: false)
+   --no-prompt, --force                                                 disable prompting for verification to run (default: false)
+   --prompt-delay value, --force-sleep value                            seconds to delay after prompt before running (minimum: 3 seconds) (default: 10)
+   --feature-flag value [ --feature-flag value ]                        enable experimental behaviors that may not be fully tested or supported
+   --log-level value, -l value                                          Log Level (default: "info") [$LOGLEVEL]
+   --log-caller                                                         log the caller (aka line number and file) (default: false)
+   --log-disable-color                                                  disable log coloring (default: false)
+   --log-full-timestamp                                                 force log output to always show full timestamp (default: false)
+   --help, -h                                                           show help  
 ```

--- a/docs/features/bypass-alias-check.md
+++ b/docs/features/bypass-alias-check.md
@@ -1,0 +1,28 @@
+# Bypass AWS Alias Check
+
+While we take security and precautions serious with a tool that can have devastating effects, we understand that some
+users may want to skip the alias check. This is not recommended, but we understand that some users may want to do this.
+
+This feature allows you to skip the alias check but requires additional configuration to enable.
+
+## How it Works
+
+There are two components to this feature:
+
+1. The `--no-alias-check` flag (also available as `NO_ALIAS_CHECK` environment variable)
+2. The `bypass-alias-check-accounts` configuration in the `config.yml` file
+
+The account ID must be in the `bypass-alias-check-accounts` configuration for the `--no-alias-check` flag to work.
+
+## Example Configuration
+
+```yaml
+bypass-alias-check-accounts:
+  - 123456789012
+```
+
+## Example Usage
+
+```console
+aws-nuke run --config=example-config.yaml --no-alias-check
+```

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,0 +1,7 @@
+# Standards
+
+## CLI Standards
+
+- Use `--no-` prefix for boolean flags
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,9 +70,12 @@ nav:
     - Install: installation.md
     - Authentication: auth.md
     - Quick Start: quick-start.md
+  - Features:
+      - Bypass Alias Check: features/bypass-alias-check.md
   - CLI:
     - Usage: cli-usage.md
-    - Feature Flags: cli-feature-flags.md
+    - Options: cli-options.md
+    - Experimental: cli-experimental.md
   - Config:
     - Overview: config.md
     - Filtering: config-filtering.md
@@ -81,6 +84,7 @@ nav:
     - Migration Guide: config-migration.md
   - Development:
     - Overview: development.md
+    - Stanards: standards.md
     - Resources: resources.md
     - Releases: releases.md
     - Testing: testing.md

--- a/pkg/commands/nuke/command.go
+++ b/pkg/commands/nuke/command.go
@@ -105,7 +105,7 @@ func execute(c *cli.Context) error {
 
 	// Register our custom validate handler that validates the account and AWS nuke unique alias checks
 	n.RegisterValidateHandler(func() error {
-		return parsedConfig.ValidateAccount(account.ID(), account.Aliases())
+		return parsedConfig.ValidateAccount(account.ID(), account.Aliases(), c.Bool("no-alias-check"))
 	})
 
 	// Register our custom prompt handler that shows the account information
@@ -172,14 +172,18 @@ func init() {
 			Usage: "path to config file",
 			Value: "config.yaml",
 		},
-		&cli.BoolFlag{
-			Name:  "force",
-			Usage: "disable prompting for verification to run",
+		&cli.StringSliceFlag{
+			Name:    "include",
+			Usage:   "only run against these resource types",
+			Aliases: []string{"target"},
 		},
-		&cli.IntFlag{
-			Name:  "force-sleep",
-			Usage: "seconds to sleep",
-			Value: 10,
+		&cli.StringSliceFlag{
+			Name:  "exclude",
+			Usage: "exclude these resource types",
+		},
+		&cli.StringSliceFlag{
+			Name:  "cloud-control",
+			Usage: "use these resource types with the Cloud Control API instead of the default",
 		},
 		&cli.BoolFlag{
 			Name:  "quiet",
@@ -189,19 +193,20 @@ func init() {
 			Name:  "no-dry-run",
 			Usage: "actually run the removal of the resources after discovery",
 		},
-		&cli.StringSliceFlag{
-			Name:    "only-resource",
-			Usage:   "only run against these resource types",
-			Aliases: []string{"target", "include", "include-resource"},
+		&cli.BoolFlag{
+			Name:  "no-alias-check",
+			Usage: "disable aws account alias check - requires entry in config as well",
 		},
-		&cli.StringSliceFlag{
-			Name:    "exclude-resource",
-			Usage:   "exclude these resource types",
-			Aliases: []string{"exclude"},
+		&cli.BoolFlag{
+			Name:    "no-prompt",
+			Usage:   "disable prompting for verification to run",
+			Aliases: []string{"force"},
 		},
-		&cli.StringSliceFlag{
-			Name:  "cloud-control",
-			Usage: "use these resource types with the Cloud Control API instead of the default",
+		&cli.IntFlag{
+			Name:    "prompt-delay",
+			Usage:   "seconds to delay after prompt before running (minimum: 3 seconds)",
+			Value:   10,
+			Aliases: []string{"force-sleep"},
 		},
 		&cli.StringSliceFlag{
 			Name:  "feature-flag",

--- a/pkg/config/testdata/bypass-alias.yaml
+++ b/pkg/config/testdata/bypass-alias.yaml
@@ -1,0 +1,20 @@
+---
+regions:
+  - "us-east-1"
+
+blocklist:
+  - 1234567890
+
+bypass-alias-check-accounts:
+  - 123654654
+
+accounts:
+  123654654:
+    resource-types:
+      targets:
+        - S3Bucket
+    filters:
+      IAMRole:
+        - "uber.admin"
+      IAMRolePolicyAttachment:
+        - "uber.admin -> AdministratorAccess"

--- a/pkg/config/testdata/deprecated-feature-flags.yaml
+++ b/pkg/config/testdata/deprecated-feature-flags.yaml
@@ -1,6 +1,9 @@
 feature-flags:
   disable-ec2-instance-stop-protection: true
+  force-delete-lightsail-addons: true
   disable-deletion-protection:
     RDSInstance: true
     EC2Instance: true
     CloudformationStack: true
+    ELBv2: true
+    QLDBLedger: true

--- a/pkg/config/testdata/incomplete.yaml
+++ b/pkg/config/testdata/incomplete.yaml
@@ -1,0 +1,24 @@
+---
+regions:
+  - "eu-west-1"
+  - stratoscale
+
+accounts:
+  555133742:
+    presets:
+      - "terraform"
+    resource-types:
+      targets:
+        - S3Bucket
+    filters:
+      IAMRole:
+        - "uber.admin"
+      IAMRolePolicyAttachment:
+        - "uber.admin -> AdministratorAccess"
+
+presets:
+  terraform:
+    filters:
+      S3Bucket:
+        - type: glob
+          value: "my-statebucket-*"

--- a/pkg/config/testdata/invalid.yaml
+++ b/pkg/config/testdata/invalid.yaml
@@ -1,0 +1,4 @@
+this is 
+not a 
+valid
+yaml file


### PR DESCRIPTION
This allows the bypass of the AWS alias check code.

See the full documentation on how to bypass, but it's essentially a two step process, one of which only has to be done once.

You must list the account in the configuration under `bypass-alias-check-accounts` and then present the CLI flag (or it's equivalent environment variable)

Resolves #62 