### PR TITLE
docs: add cli examples, including for --force usage

### DIFF
--- a/docs/cli-examples.md
+++ b/docs/cli-examples.md
@@ -1,0 +1,28 @@
+# Examples
+
+## Basic usage
+
+```bash
+aws-nuke --config config.yml
+```
+
+## Using a profile
+
+!!! note
+    This assumes you have configured your AWS credentials file with a profile named `my-profile`.
+
+```bash
+aws-nuke --config config.yml --profile my-profile
+```
+
+## Using the force flags
+
+!!! danger
+    Running without prompts can be dangerous. Make sure you understand what you are doing before using these flags.
+
+The following is an example of how you automate the command to run without any prompts of the user. This is useful
+for running in a CI/CD pipeline.
+
+```bash
+aws-nuke --config config.yml --force --force-delay 5
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,8 @@ nav:
     - Usage: cli-usage.md
     - Options: cli-options.md
     - Experimental: cli-experimental.md
+    - Feature Flags: cli-feature-flags.md
+    - Examples: cli-examples.md
   - Config:
     - Overview: config.md
     - Filtering: config-filtering.md
@@ -84,7 +86,7 @@ nav:
     - Migration Guide: config-migration.md
   - Development:
     - Overview: development.md
-    - Stanards: standards.md
+    - Standards: standards.md
     - Resources: resources.md
     - Releases: releases.md
     - Testing: testing.md


### PR DESCRIPTION
Upstream users have requested CLI usage examples. This introduces 3, including one specifically for force 

https://github.com/rebuy-de/aws-nuke/issues/668