### PR TITLE
fix: quick fix for default run sleep

### DIFF
--- a/pkg/commands/nuke/command.go
+++ b/pkg/commands/nuke/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -104,6 +105,7 @@ func execute(c *cli.Context) error {
 	// Instantiate libnuke
 	n := libnuke.New(params, filters, parsedConfig.Settings)
 
+	n.SetRunSleep(5 * time.Second)
 	n.RegisterVersion(common.AppVersion.Summary)
 
 	// Register our custom validate handler that validates the account and AWS nuke unique alias checks


### PR DESCRIPTION
Been fixed in the upstream libnuke lib but need to upgrade to that, for now this is quick fix to get a default run loop sleep back in place. It was instance, now after looping through resources it'll sleep for 5 before looping again. This matters less with dozens or hundreds of resources but if you are deleting a singular resource type, this can cause a lot of extra calls to the AWS APIs for no reason.