### PR TITLE
fix: bug with external id and session name, missing -c option and docs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,15 +1,35 @@
 # Authentication
 
-There are multiple ways to authenticate to AWS for *aws-nuke*.
+The authentication for aws-nuke is a bit custom but still done through the AWS SDK. In a future version, we will 
+likely switch to using the AWS SDK directly to handle authentication.
 
-## Using CLI Flags
+## CLI Flags
+
+The following flags are available for authentication:
+
+- `--access-key-id` - The AWS access key ID
+- `--secret-access-key` - The AWS secret access key
+- `--session-token` - The AWS session token
+- `--profile` - The AWS profile to use
+- `--region` - The AWS region to use
+- `--assume-role` - The ARN of the role to assume
+- `--assume-role-session-name` - The session name to use when assuming a role
+- `--assume-role-external-id` - The external ID to use when assuming a role
+
+### Static Credentials (CLI)
 
 To use *static credentials* the command line flags `--access-key-id` and `--secret-access-key`
-are required. The flag `--session-token` is only required for temporary sessions.
+are required. The flag `--session-token` is only required for temporary sessions provided to you by the AWS STS service.
+
+**Note:** this is mutually exclusive with `--profile`.
+
+### Static Credentials (Profiles)
 
 `--profile` is also available if you are using the [AWS Config](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 
-### AWS Config
+**Note:** this is mutually exclusive with `--access-key-id` and `--secret-access-key`.
+
+#### AWS Config
 
 You can also authenticate using the [AWS Config](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 file. This can also have static credentials in them, but you can also use profiles. These files are generally located
@@ -20,6 +40,13 @@ credentials in the [shared credential file](https://docs.aws.amazon.com/cli/late
 
 ## Environment Variables
 
-To use *static credentials* via environment variables, export `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and
-optionally if using a temporary session `AWS_SESSION_TOKEN`.
+The following environment variables are available for authentication:
 
+- `AWS_ACCESS_KEY_ID` - The AWS access key ID
+- `AWS_SECRET_ACCESS_KEY` - The AWS secret access key
+- `AWS_SESSION_TOKEN` - The AWS session token
+- `AWS_PROFILE` - The AWS profile to use
+- `AWS_REGION` - The AWS region to use
+- `AWS_ASSUME_ROLE` - The ARN of the role to assume
+- `AWS_ASSUME_ROLE_SESSION_NAME` - The session name to use when assuming a role
+- `AWS_ASSUME_ROLE_EXTERNAL_ID` - The external ID to use when assuming a role

--- a/pkg/awsutil/session.go
+++ b/pkg/awsutil/session.go
@@ -119,8 +119,13 @@ func (c *Credentials) rootSession() (*session.Session, error) {
 		// if given a role to assume, overwrite the session credentials with assume role credentials
 		if c.AssumeRoleArn != "" {
 			sess.Config.Credentials = stscreds.NewCredentials(sess, c.AssumeRoleArn, func(p *stscreds.AssumeRoleProvider) {
-				p.RoleSessionName = c.RoleSessionName
-				p.ExternalID = aws.String(c.ExternalId)
+				if c.RoleSessionName == "" {
+					p.RoleSessionName = c.RoleSessionName
+				}
+
+				if c.ExternalId == "" {
+					p.ExternalID = aws.String(c.ExternalId)
+				}
 			})
 		}
 

--- a/pkg/commands/nuke/command.go
+++ b/pkg/commands/nuke/command.go
@@ -174,9 +174,10 @@ func execute(c *cli.Context) error {
 func init() {
 	flags := []cli.Flag{
 		&cli.PathFlag{
-			Name:  "config",
-			Usage: "path to config file",
-			Value: "config.yaml",
+			Name:    "config",
+			Aliases: []string{"c"},
+			Usage:   "path to config file",
+			Value:   "config.yaml",
 		},
 		&cli.StringSliceFlag{
 			Name:    "include",

--- a/pkg/commands/nuke/command.go
+++ b/pkg/commands/nuke/command.go
@@ -223,34 +223,42 @@ func init() {
 		&cli.StringFlag{
 			Name:    "default-region",
 			EnvVars: []string{"AWS_DEFAULT_REGION"},
+			Usage:   "the default aws region to use when setting up the aws auth session",
 		},
 		&cli.StringFlag{
 			Name:    "access-key-id",
 			EnvVars: []string{"AWS_ACCESS_KEY_ID"},
+			Usage:   "the aws access key id to use when setting up the aws auth session",
 		},
 		&cli.StringFlag{
 			Name:    "secret-access-key",
 			EnvVars: []string{"AWS_SECRET_ACCESS_KEY"},
+			Usage:   "the aws secret access key to use when setting up the aws auth session",
 		},
 		&cli.StringFlag{
 			Name:    "session-token",
 			EnvVars: []string{"AWS_SESSION_TOKEN"},
+			Usage:   "the aws session token to use when setting up the aws auth session, typically used for temporary credentials",
 		},
 		&cli.StringFlag{
 			Name:    "profile",
 			EnvVars: []string{"AWS_PROFILE"},
+			Usage:   "the aws profile to use when setting up the aws auth session, typically used for shared credentials files",
 		},
 		&cli.StringFlag{
 			Name:    "assume-role-arn",
 			EnvVars: []string{"AWS_ASSUME_ROLE_ARN"},
+			Usage:   "the role arn to assume using the credentials provided in the profile or statically set",
 		},
 		&cli.StringFlag{
 			Name:    "assume-role-session-name",
 			EnvVars: []string{"AWS_ASSUME_ROLE_SESSION_NAME"},
+			Usage:   "the session name to provide for the assumed role",
 		},
 		&cli.StringFlag{
 			Name:    "assume-role-external-id",
 			EnvVars: []string{"AWS_ASSUME_ROLE_EXTERNAL_ID"},
+			Usage:   "the external id to provide for the assumed role",
 		},
 	}
 


### PR DESCRIPTION
## Overview
Updates the aws authentication documentation, adds the `-c` option back for `--config` and fixes a bug where session and role name were not being treated as optional.

## References
- Resolves #78 
- Resolves #79 