### PR TITLE
fix: log error as warning vs throwing error with property not supported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.6
 
 require (
 	github.com/aws/aws-sdk-go v1.50.4
-	github.com/ekristen/libnuke v0.10.0
+	github.com/ekristen/libnuke v0.10.1
 	github.com/fatih/color v1.16.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/ekristen/libnuke v0.9.1 h1:AoX1cggVTanP671Xuh6kJRv0HEp26NLqqPTzwYbz9I
 github.com/ekristen/libnuke v0.9.1/go.mod h1:WhYx7LDAkvkXwwfhWCASRn7fbifF8kfyhNsUj5zCCVs=
 github.com/ekristen/libnuke v0.10.0 h1:MBtly8gdZ8EBU/RPE1gI1aDpJlqWKKGxURcW7f8HVxY=
 github.com/ekristen/libnuke v0.10.0/go.mod h1:WhYx7LDAkvkXwwfhWCASRn7fbifF8kfyhNsUj5zCCVs=
+github.com/ekristen/libnuke v0.10.1 h1:+BRdDPuFR/5a8eJu1gpShXYbYs9tJ2kemM83EsbPp2g=
+github.com/ekristen/libnuke v0.10.1/go.mod h1:WhYx7LDAkvkXwwfhWCASRn7fbifF8kfyhNsUj5zCCVs=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=


### PR DESCRIPTION
The original aws-nuke logged the error with a custom property not being supported, this updates to libuke@0.10.1 that fixes this bug.

Resolves #81 