### PR TITLE
chore: fix migrate tool default imports

### DIFF
--- a/tools/migrate-resource/main.go
+++ b/tools/migrate-resource/main.go
@@ -29,8 +29,9 @@ var funcTemplate = `func (l *{{.ResourceType}}Lister) List(_ context.Context, o 
 var imports = `import (
 	"context"
 
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
-"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/types"
 
 	"github.com/ekristen/aws-nuke/pkg/nuke"
 `


### PR DESCRIPTION
Update the migrate tool to have the correct imports.