### PR TITLE
docs: add missing build command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,6 +30,6 @@ To compile **aws-nuke** from source you need a working [Golang](https://golang.o
 **aws-nuke** uses go modules and so the clone path should not matter. Then simply change directory into the clone and run:
 
 ```bash
-goreleaser --clean --snapshot --single-target
+goreleaser build --clean --snapshot --single-target
 ```
 


### PR DESCRIPTION
Running the build command as currently stated in the docs results in the following error (on my machine):

```bash
(main)> goreleaser --clean --snapshot --single-target
  ⨯ command failed                                   error=unknown flag: --single-target
```

Adding the `build` command before `--clean` results in the intended behavior.