### PR TITLE
feat: rename command file to nuke and add q alias for --quiet

### DIFF
--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -224,8 +224,9 @@ func init() { //nolint:funlen
 			Usage: "use these resource types with the Cloud Control API instead of the default",
 		},
 		&cli.BoolFlag{
-			Name:  "quiet",
-			Usage: "hide filtered messages",
+			Name:    "quiet",
+			Aliases: []string{"q"},
+			Usage:   "hide filtered messages",
 		},
 		&cli.BoolFlag{
 			Name:  "no-dry-run",


### PR DESCRIPTION
- Renames the file for the `nuke` command to `nuke.go` in line with the name of the other command files
- Adds the `-q` alias for the `--quiet` switch on the `nuke` command, as this was present in the original `aws-nuke` and is also a pretty universal alias