### PR TITLE
feat: add cloudfront cache policy resource

### DIFF
--- a/resources/cloudfront-cache-policy.go
+++ b/resources/cloudfront-cache-policy.go
@@ -1,0 +1,68 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type CloudFrontCachePolicy struct {
+	svc *cloudfront.CloudFront
+	ID  *string
+}
+
+func init() {
+	register("CloudFrontCachePolicy", ListCloudFrontCachePolicy)
+}
+
+func ListCloudFrontCachePolicy(sess *session.Session) ([]Resource, error) {
+	svc := cloudfront.New(sess)
+	resources := []Resource{}
+	params := &cloudfront.ListCachePoliciesInput{}
+
+	for {
+		resp, err := svc.ListCachePolicies(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range resp.CachePolicyList.Items {
+			if *item.Type == "custom" {
+				resources = append(resources, &CloudFrontCachePolicy{
+					svc: svc,
+					ID:  item.CachePolicy.Id,
+				})
+			}
+		}
+
+		if resp.CachePolicyList.NextMarker == nil {
+			break
+		}
+
+		params.Marker = resp.CachePolicyList.NextMarker
+	}
+
+	return resources, nil
+}
+
+func (f *CloudFrontCachePolicy) Remove() error {
+	resp, err := f.svc.GetCachePolicy(&cloudfront.GetCachePolicyInput{
+		Id: f.ID,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = f.svc.DeleteCachePolicy(&cloudfront.DeleteCachePolicyInput{
+		Id:      f.ID,
+		IfMatch: resp.ETag,
+	})
+
+	return err
+}
+
+func (f *CloudFrontCachePolicy) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", f.ID)
+	return properties
+}

--- a/resources/cloudfront-cache-policy.go
+++ b/resources/cloudfront-cache-policy.go
@@ -43,7 +43,7 @@ func (l *CloudFrontCachePolicyLister) List(_ context.Context, o interface{}) ([]
 		}
 
 		for _, item := range resp.CachePolicyList.Items {
-			if *item.Type == "custom" {
+			if *item.Type == "custom" { //nolint:goconst
 				resources = append(resources, &CloudFrontCachePolicy{
 					svc: svc,
 					ID:  item.CachePolicy.Id,


### PR DESCRIPTION
## Overview

This adds the cloudfront cache policy by way of [cherry picked commit](https://github.com/MikeSchouw/aws-nuke/commit/dd2be49755ece7ac993a0c1fe7d1c6ad68d721ad) from @MikeSchouw and their upstream branch based on this PR https://github.com/rebuy-de/aws-nuke/pull/1152

Rebased the original commit to turn the commit into semantic commit message format, but preserve Mike's contributions as much as possible. Converted to the libnuke resource format and add a nolint statement for golangci-lint to ignore.

Resolves #135 

## Upstream References
- https://github.com/rebuy-de/aws-nuke/issues/1151
- https://github.com/rebuy-de/aws-nuke/pull/1152


