### PR TITLE
fix(awsutil): properly determine partition for all supported regions

### DIFF
--- a/pkg/commands/account/account.go
+++ b/pkg/commands/account/account.go
@@ -39,18 +39,19 @@ func execute(c *cli.Context) error {
 	// Set the default region for the AWS SDK to use.
 	if defaultRegion != "" {
 		awsutil.DefaultRegionID = defaultRegion
-		switch defaultRegion {
-		case endpoints.UsEast1RegionID, endpoints.UsEast2RegionID, endpoints.UsWest1RegionID, endpoints.UsWest2RegionID:
-			awsutil.DefaultAWSPartitionID = endpoints.AwsPartitionID
-		case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
-			awsutil.DefaultAWSPartitionID = endpoints.AwsUsGovPartitionID
-		default:
+
+		partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), defaultRegion)
+		if !ok {
 			if parsedConfig.CustomEndpoints.GetRegion(defaultRegion) == nil {
-				err = fmt.Errorf("the custom region '%s' must be specified in the configuration 'endpoints'", defaultRegion)
-				logrus.Error(err.Error())
+				err = fmt.Errorf(
+					"the custom region '%s' must be specified in the configuration 'endpoints'"+
+						" to determine its partition", defaultRegion)
+				logrus.WithError(err).Error("unable to resolve partition for region: %s", defaultRegion)
 				return err
 			}
 		}
+
+		awsutil.DefaultAWSPartitionID = partition.ID()
 	}
 
 	// Create the AWS Account object. This will be used to get the account ID and aliases for the account.

--- a/pkg/commands/account/account.go
+++ b/pkg/commands/account/account.go
@@ -46,7 +46,7 @@ func execute(c *cli.Context) error {
 				err = fmt.Errorf(
 					"the custom region '%s' must be specified in the configuration 'endpoints'"+
 						" to determine its partition", defaultRegion)
-				logrus.WithError(err).Error("unable to resolve partition for region: %s", defaultRegion)
+				logrus.WithError(err).Errorf("unable to resolve partition for region: %s", defaultRegion)
 				return err
 			}
 		}

--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -86,8 +86,10 @@ func execute(c *cli.Context) error { //nolint:funlen,gocyclo
 		partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), defaultRegion)
 		if !ok {
 			if parsedConfig.CustomEndpoints.GetRegion(defaultRegion) == nil {
-				err = fmt.Errorf("the custom region '%s' must be specified in the configuration 'endpoints'", defaultRegion)
-				logrus.WithError(err).Error("unable to resolve partition for region: %s", defaultRegion)
+				err = fmt.Errorf(
+					"the custom region '%s' must be specified in the configuration 'endpoints'"+
+						" to determine its partition", defaultRegion)
+				logrus.WithError(err).Errorf("unable to resolve partition for region: %s", defaultRegion)
 				return err
 			}
 		}

--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -82,18 +82,17 @@ func execute(c *cli.Context) error { //nolint:funlen,gocyclo
 	// Set the default region for the AWS SDK to use.
 	if defaultRegion != "" {
 		awsutil.DefaultRegionID = defaultRegion
-		switch defaultRegion {
-		case endpoints.UsEast1RegionID, endpoints.UsEast2RegionID, endpoints.UsWest1RegionID, endpoints.UsWest2RegionID:
-			awsutil.DefaultAWSPartitionID = endpoints.AwsPartitionID
-		case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
-			awsutil.DefaultAWSPartitionID = endpoints.AwsUsGovPartitionID
-		default:
+
+		partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), defaultRegion)
+		if !ok {
 			if parsedConfig.CustomEndpoints.GetRegion(defaultRegion) == nil {
 				err = fmt.Errorf("the custom region '%s' must be specified in the configuration 'endpoints'", defaultRegion)
-				logrus.Error(err.Error())
+				logrus.WithError(err).Error("unable to resolve partition for region: %s", defaultRegion)
 				return err
 			}
 		}
+
+		awsutil.DefaultAWSPartitionID = partition.ID()
 	}
 
 	// Create the AWS Account object. This will be used to get the account ID and aliases for the account.


### PR DESCRIPTION
# Overview

Refactors code to allow for all regions to be supported for the `AWS_DEFAULT_REGION` environment variable by doing a lookup to determine it's proper partition. It also happens to simplify the code as well.

Resolves #142