### PR TITLE
fix: statically compile when doing direct docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,19 @@ RUN adduser -D aws-nuke
 FROM ghcr.io/acorn-io/images-mirror/golang:1.21 AS build
 COPY / /src
 WORKDIR /src
+ENV CGO_ENABLED=0
 RUN \
   --mount=type=cache,target=/go/pkg \
   --mount=type=cache,target=/root/.cache/go-build \
-  go build -o bin/aws-nuke main.go
+  go build -ldflags '-s -w -extldflags="-static"' -o bin/aws-nuke main.go
 
-FROM base AS goreleaser
+FROM base AS gorelease
 ENTRYPOINT ["/usr/local/bin/aws-nuke"]
 COPY aws-nuke /usr/local/bin/aws-nuke
 USER aws-nuke
 
 FROM base
 ENTRYPOINT ["/usr/local/bin/aws-nuke"]
-COPY --from=build /src/bin/aws-nuke /usr/local/bin/aws-nuke
+COPY --from=build --chmod=755 /src/bin/aws-nuke /usr/local/bin/aws-nuke
+RUN chmod +x /usr/local/bin/aws-nuke
 USER aws-nuke


### PR DESCRIPTION
The preferred method of building is to use goreleaser but this method is in place for quick and easy builds for testing purposes, unfortunately it didn't match the goreleaser configuration, this resolves that.

This turns on static compilation for the binary when being built directly with docker instead of goreleaser.

Resolve #144