### PR TITLE
feat(sagemaker-spaces): add support for Sagemaker Spaces

### DIFF
--- a/resources/sagemaker-apps.go
+++ b/resources/sagemaker-apps.go
@@ -50,6 +50,7 @@ func (l *SageMakerAppLister) List(_ context.Context, o interface{}) ([]resource.
 				appName:         app.AppName,
 				appType:         app.AppType,
 				userProfileName: app.UserProfileName,
+				spaceName:       app.SpaceName,
 				status:          app.Status,
 			})
 		}
@@ -70,6 +71,7 @@ type SageMakerApp struct {
 	appName         *string
 	appType         *string
 	userProfileName *string
+	spaceName       *string
 	status          *string
 }
 
@@ -79,6 +81,7 @@ func (f *SageMakerApp) Remove(_ context.Context) error {
 		AppName:         f.appName,
 		AppType:         f.appType,
 		UserProfileName: f.userProfileName,
+		SpaceName:       f.spaceName,
 	})
 
 	return err
@@ -94,7 +97,8 @@ func (f *SageMakerApp) Properties() types.Properties {
 		Set("DomainID", f.domainID).
 		Set("AppName", f.appName).
 		Set("AppType", f.appType).
-		Set("UserProfileName", f.userProfileName)
+		Set("UserProfileName", f.userProfileName).
+		Set("SpaceName", f.spaceName)
 	return properties
 }
 

--- a/resources/sagemaker-spaces.go
+++ b/resources/sagemaker-spaces.go
@@ -1,0 +1,97 @@
+package resources
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/pkg/nuke"
+)
+
+const SageMakerSpaceResource = "SageMakerSpace"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:   SageMakerSpaceResource,
+		Scope:  nuke.Account,
+		Lister: &SageMakerSpaceLister{},
+	})
+}
+
+type SageMakerSpaceLister struct{}
+
+func (l *SageMakerSpaceLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+
+	svc := sagemaker.New(opts.Session)
+	resources := make([]resource.Resource, 0)
+
+	params := &sagemaker.ListSpacesInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListSpaces(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, space := range resp.Spaces {
+			resources = append(resources, &SageMakerSpace{
+				svc:              svc,
+				domainID:         space.DomainId,
+				spaceDisplayName: space.SpaceDisplayName,
+				spaceName:        space.SpaceName,
+				status:           space.Status,
+				lastModifiedTime: space.LastModifiedTime,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+type SageMakerSpace struct {
+	svc              *sagemaker.SageMaker
+	domainID         *string
+	spaceDisplayName *string
+	spaceName        *string
+	status           *string
+	lastModifiedTime *time.Time
+}
+
+func (f *SageMakerSpace) Remove(_ context.Context) error {
+	_, err := f.svc.DeleteSpace(&sagemaker.DeleteSpaceInput{
+		DomainId:  f.domainID,
+		SpaceName: f.spaceName,
+	})
+
+	return err
+}
+
+func (f *SageMakerSpace) String() string {
+	return *f.spaceName
+}
+
+func (f *SageMakerSpace) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.
+		Set("DomainID", f.domainID).
+		Set("SpaceDisplayName", f.spaceDisplayName).
+		Set("SpaceName", f.spaceName).
+		Set("Status", f.status).
+		Set("LastModifiedTime", f.lastModifiedTime)
+	return properties
+}


### PR DESCRIPTION
Closes #157 

This PR is a port of https://github.com/rebuy-de/aws-nuke/pull/1197

**Output with feature activated**

```
> aws-nuke - 3.0.0-dev - dirty
Do you really want to nuke the account with the ID 000000000000 and the alias 'test-account'?
Do you want to continue? Enter account alias to continue.
> test-account

eu-west-1 - SageMakerApp - default - [AppName: "default", AppType: "JupyterServer", DomainID: "d-fafofydwvicv", SpaceName: "test"] - would remove
eu-west-1 - SageMakerSpace - test - [DomainID: "d-fafofydwvicv", LastModifiedTime: "2024-05-03 10:31:30.218 +0000 UTC", SpaceName: "test", Status: "InService"] - would remove
eu-west-1 - SageMakerDomain - d-fafofydwvicv - [CreationTime: "2024-05-03T10:25:08Z", DomainID: "d-fafofydwvicv"] - would remove
eu-west-1 - SageMakerUserProfiles - default-1714732293655 - [DomainID: "d-fafofydwvicv", UserProfileName: "default-1714732293655"] - would remove
Scan complete: 4 total, 4 nukeable, 0 filtered.

Do you really want to nuke the account with the ID 000000000000 and the alias 'test-account'?
Do you want to continue? Enter account alias to continue.
> test-account

eu-west-1 - SageMakerApp - default - [AppName: "default", AppType: "JupyterServer", DomainID: "d-fafofydwvicv", SpaceName: "test"] - triggered remove
eu-west-1 - SageMakerSpace - test - [DomainID: "d-fafofydwvicv", LastModifiedTime: "2024-05-03 10:31:30.218 +0000 UTC", SpaceName: "test", Status: "InService"] - failed
eu-west-1 - SageMakerDomain - d-fafofydwvicv - [CreationTime: "2024-05-03T10:25:08Z", DomainID: "d-fafofydwvicv"] - failed
eu-west-1 - SageMakerUserProfiles - default-1714732293655 - [DomainID: "d-fafofydwvicv", UserProfileName: "default-1714732293655"] - triggered remove

Removal requested: 2 waiting, 2 failed, 0 skipped, 0 finished

eu-west-1 - SageMakerApp - default - [AppName: "default", AppType: "JupyterServer", DomainID: "d-fafofydwvicv", SpaceName: "test"] - waiting
eu-west-1 - SageMakerSpace - test - [DomainID: "d-fafofydwvicv", LastModifiedTime: "2024-05-03 10:31:30.218 +0000 UTC", SpaceName: "test", Status: "InService"] - triggered remove
eu-west-1 - SageMakerDomain - d-fafofydwvicv - [CreationTime: "2024-05-03T10:25:08Z", DomainID: "d-fafofydwvicv"] - failed
eu-west-1 - SageMakerUserProfiles - default-1714732293655 - [DomainID: "d-fafofydwvicv", UserProfileName: "default-1714732293655"] - waiting

Removal requested: 3 waiting, 1 failed, 0 skipped, 0 finished

eu-west-1 - SageMakerApp - default - [AppName: "default", AppType: "JupyterServer", DomainID: "d-fafofydwvicv", SpaceName: "test"] - removed
eu-west-1 - SageMakerSpace - test - [DomainID: "d-fafofydwvicv", LastModifiedTime: "2024-05-03 10:31:30.218 +0000 UTC", SpaceName: "test", Status: "InService"] - waiting
eu-west-1 - SageMakerDomain - d-fafofydwvicv - [CreationTime: "2024-05-03T10:25:08Z", DomainID: "d-fafofydwvicv"] - triggered remove
eu-west-1 - SageMakerUserProfiles - default-1714732293655 - [DomainID: "d-fafofydwvicv", UserProfileName: "default-1714732293655"] - removed

Removal requested: 2 waiting, 0 failed, 0 skipped, 2 finished

eu-west-1 - SageMakerSpace - test - [DomainID: "d-fafofydwvicv", LastModifiedTime: "2024-05-03 10:31:30.218 +0000 UTC", SpaceName: "test", Status: "InService"] - removed
eu-west-1 - SageMakerDomain - d-fafofydwvicv - [CreationTime: "2024-05-03T10:25:08Z", DomainID: "d-fafofydwvicv"] - waiting

Removal requested: 1 waiting, 0 failed, 0 skipped, 3 finished

eu-west-1 - SageMakerDomain - d-fafofydwvicv - [CreationTime: "2024-05-03T10:25:08Z", DomainID: "d-fafofydwvicv"] - waiting

eu-west-1 - SageMakerDomain - d-fafofydwvicv - [CreationTime: "2024-05-03T10:25:08Z", DomainID: "d-fafofydwvicv"] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 4 finished

Nuke complete: 0 failed, 0 skipped, 4 finished.
```