### PR TITLE
feat: support config conformance pack removal

### DIFF
--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -72,6 +73,13 @@ type CloudFormationStack struct {
 	stack             *cloudformation.Stack
 	maxDeleteAttempts int
 	settings          *settings.Setting
+}
+
+func (cfs *CloudFormationStack) Filter() error {
+	if *cfs.stack.Description == "DO NOT MODIFY THIS STACK! This stack is managed by Config Conformance Packs." {
+		return fmt.Errorf("stack is managed by Config Conformance Packs")
+	}
+	return nil
 }
 
 func (cfs *CloudFormationStack) Settings(setting *settings.Setting) {

--- a/resources/configservice-conformance-pack.go
+++ b/resources/configservice-conformance-pack.go
@@ -1,0 +1,82 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/configservice"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/pkg/nuke"
+)
+
+const ConfigServiceConformancePackResource = "ConfigServiceConformancePack"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:   ConfigServiceConformancePackResource,
+		Scope:  nuke.Account,
+		Lister: &ConfigServiceConformancePackLister{},
+	})
+}
+
+type ConfigServiceConformancePackLister struct{}
+
+func (l *ConfigServiceConformancePackLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := configservice.New(opts.Session)
+	var resources []resource.Resource
+
+	var nextToken *string
+
+	for {
+		res, err := svc.DescribeConformancePacks(&configservice.DescribeConformancePacksInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, p := range res.ConformancePackDetails {
+			resources = append(resources, &ConfigServiceConformancePack{
+				svc:  svc,
+				id:   p.ConformancePackId,
+				name: p.ConformancePackName,
+			})
+		}
+
+		if res.NextToken == nil {
+			break
+		}
+
+		nextToken = res.NextToken
+	}
+
+	return resources, nil
+}
+
+type ConfigServiceConformancePack struct {
+	svc  *configservice.ConfigService
+	id   *string
+	name *string
+}
+
+func (r *ConfigServiceConformancePack) Remove(_ context.Context) error {
+	_, err := r.svc.DeleteConformancePack(&configservice.DeleteConformancePackInput{
+		ConformancePackName: r.name,
+	})
+	return err
+}
+
+func (r *ConfigServiceConformancePack) Properties() types.Properties {
+	props := types.NewProperties()
+	props.Set("ID", r.id)
+	props.Set("Name", r.name)
+	return props
+}
+
+func (r *ConfigServiceConformancePack) String() string {
+	return *r.id
+}


### PR DESCRIPTION
This adds support for removing config conformance packs via the config service. It also filters out cloudformation stacks that are managed by the config conformance packs because they cannot be removed. The conformance pack has to be removed, which in turn removes the stack.