### PR TITLE
fix(cloudformation-stack): protect against nil pointer

### DIFF
--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gotidy/ptr"
 	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -76,7 +77,7 @@ type CloudFormationStack struct {
 }
 
 func (cfs *CloudFormationStack) Filter() error {
-	if *cfs.stack.Description == "DO NOT MODIFY THIS STACK! This stack is managed by Config Conformance Packs." {
+	if ptr.ToString(cfs.stack.Description) == "DO NOT MODIFY THIS STACK! This stack is managed by Config Conformance Packs." {
 		return fmt.Errorf("stack is managed by Config Conformance Packs")
 	}
 	return nil


### PR DESCRIPTION
A recent change to filter out AWS managed cloudformation stacks that cannot be removed successfully was added. However the description field can sometimes be a nil pointer and it wasn't protected against that. This fixes that bug.

Resolves #183