### PR TITLE
feat(ec2-image): include disabled and deprecated images

### DIFF
--- a/resources/ec2-image.go
+++ b/resources/ec2-image.go
@@ -2,12 +2,16 @@ package resources
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/gotidy/ptr"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/settings"
 	"github.com/ekristen/libnuke/pkg/types"
 
 	"github.com/ekristen/aws-nuke/pkg/nuke"
@@ -15,17 +19,27 @@ import (
 
 const EC2ImageResource = "EC2Image"
 
+const IncludeDeprecatedSetting = "IncludeDeprecated"
+const IncludeDisabledSetting = "IncludeDisabled"
+const DisableDeregistrationProtectionSetting = "DisableDeregistrationProtection"
+
 func init() {
 	registry.Register(&registry.Registration{
 		Name:   EC2ImageResource,
 		Scope:  nuke.Account,
 		Lister: &EC2ImageLister{},
+		Settings: []string{
+			DisableDeregistrationProtectionSetting,
+			IncludeDeprecatedSetting,
+			IncludeDisabledSetting,
+		},
 	})
 }
 
 type EC2ImageLister struct{}
 
 func (l *EC2ImageLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	resources := make([]resource.Resource, 0)
 	opts := o.(*nuke.ListerOpts)
 
 	svc := ec2.New(opts.Session)
@@ -33,24 +47,25 @@ func (l *EC2ImageLister) List(_ context.Context, o interface{}) ([]resource.Reso
 		Owners: []*string{
 			aws.String("self"),
 		},
-		IncludeDeprecated: aws.Bool(true),
-		IncludeDisabled:   aws.Bool(true),
+		IncludeDeprecated: ptr.Bool(true),
+		IncludeDisabled:   ptr.Bool(true),
 	}
 	resp, err := svc.DescribeImages(params)
 	if err != nil {
 		return nil, err
 	}
 
-	resources := make([]resource.Resource, 0)
 	for _, out := range resp.Images {
 		resources = append(resources, &EC2Image{
-			svc:            svc,
-			creationDate:   *out.CreationDate,
-			id:             *out.ImageId,
-			name:           *out.Name,
-			tags:           out.Tags,
-			state:          out.State,
-			deprecatedTime: out.DeprecationTime,
+			svc:                      svc,
+			id:                       out.ImageId,
+			name:                     out.Name,
+			tags:                     out.Tags,
+			state:                    out.State,
+			creationDate:             out.CreationDate,
+			deprecated:               ptr.Bool(out.DeprecationTime != nil),
+			deprecatedTime:           out.DeprecationTime,
+			deregistrationProtection: out.DeregistrationProtection,
 		})
 	}
 
@@ -58,21 +73,63 @@ func (l *EC2ImageLister) List(_ context.Context, o interface{}) ([]resource.Reso
 }
 
 type EC2Image struct {
-	svc            *ec2.EC2
-	creationDate   string
-	id             string
-	name           string
-	tags           []*ec2.Tag
-	state          *string
-	deprecated     *bool
-	deprecatedTime *string
+	svc      *ec2.EC2
+	settings *settings.Setting
+
+	id                       *string
+	name                     *string
+	tags                     []*ec2.Tag
+	state                    *string
+	deprecated               *bool
+	deprecatedTime           *string
+	creationDate             *string
+	deregistrationProtection *string
+}
+
+func (e *EC2Image) Filter() error {
+	if *e.state == "pending" {
+		return fmt.Errorf("ineligible state for removal")
+	}
+
+	if *e.deregistrationProtection != "disabled" {
+		if e.settings.Get(DisableDeregistrationProtectionSetting) == nil ||
+			(e.settings.Get(DisableDeregistrationProtectionSetting) != nil &&
+				!e.settings.Get(DisableDeregistrationProtectionSetting).(bool)) {
+			return fmt.Errorf("deregistration protection is enabled")
+		}
+	}
+
+	if !e.settings.Get(IncludeDeprecatedSetting).(bool) && e.deprecated != nil && *e.deprecated {
+		return fmt.Errorf("excluded by %s setting being false", IncludeDeprecatedSetting)
+	}
+
+	if !e.settings.Get(IncludeDisabledSetting).(bool) && e.state != nil && *e.state == "disabled" {
+		return fmt.Errorf("excluded by %s setting being false", IncludeDisabledSetting)
+	}
+
+	return nil
 }
 
 func (e *EC2Image) Remove(_ context.Context) error {
+	if err := e.removeDeregistrationProtection(); err != nil {
+		return err
+	}
+
 	_, err := e.svc.DeregisterImage(&ec2.DeregisterImageInput{
-		ImageId: &e.id,
+		ImageId: e.id,
 	})
+
 	return err
+}
+
+func (e *EC2Image) removeDeregistrationProtection() error {
+	res, _ := e.svc.DisableImageDeregistrationProtectionRequest(&ec2.DisableImageDeregistrationProtectionInput{
+		ImageId: e.id,
+	})
+	if res.Error != nil {
+		return res.Error
+	}
+	return nil
 }
 
 func (e *EC2Image) Properties() types.Properties {
@@ -83,6 +140,7 @@ func (e *EC2Image) Properties() types.Properties {
 	properties.Set("State", e.state)
 	properties.Set("Deprecated", e.deprecated)
 	properties.Set("DeprecatedTime", e.deprecatedTime)
+	properties.Set("DeregistrationProtection", e.deregistrationProtection)
 
 	for _, tagValue := range e.tags {
 		properties.SetTag(tagValue.Key, tagValue.Value)
@@ -91,5 +149,9 @@ func (e *EC2Image) Properties() types.Properties {
 }
 
 func (e *EC2Image) String() string {
-	return e.id
+	return *e.id
+}
+
+func (e *EC2Image) Settings(settings *settings.Setting) {
+	e.settings = settings
 }


### PR DESCRIPTION
## Overview

This improves the EC2Image resource by introducing 3 new settings, by default these settings are false because they would change the behavior of the EC2Image discovery.

In Version 4, these settings will be enabled by default.

## New Settings

- IncludeDisabled
- IncludeDeprecated
- DisableDeregistrationProtection

## About Disabling Deregistration Protection

There are 2 types of protection, one with a 24 hour cool-down, and 1 without a cool-down. If the image is protected by the option without a cooldown, the image will be removed immediately given that the `DisableDeregistrationProtection` setting is true. 

If the image is protected with the 24 hour cool-down and `DisableDeregistrationProtection` is true, then aws-nuke will disable the deregistration protection and then filter the resource out due to it not being eligible for removal. You will then have to re-run aws-nuke after 24 hours to remove the remaining images. Using CLI argument `--include EC2Image` will target the specific resource type.
