### PR TITLE
fix: nil pointer error with settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.6
 
 require (
 	github.com/aws/aws-sdk-go v1.53.19
-	github.com/ekristen/libnuke v0.15.1
+	github.com/ekristen/libnuke v0.17.0
 	github.com/fatih/color v1.17.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.6
 
 require (
 	github.com/aws/aws-sdk-go v1.53.19
-	github.com/ekristen/libnuke v0.17.0
+	github.com/ekristen/libnuke v0.17.1
 	github.com/fatih/color v1.17.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/ekristen/libnuke v0.15.0 h1:YiQo8E32cZucz1UI14OPikSRl1UoyIp02rntrVeX3
 github.com/ekristen/libnuke v0.15.0/go.mod h1:riI1tjCf6r+et/9oUBd1vQeFmn2Sn6UeFUR0nWkMeYw=
 github.com/ekristen/libnuke v0.15.1 h1:qOfGxnFYuCGaFW4g+J6QHvphhkHoeb0i5Z7VuaIOGSQ=
 github.com/ekristen/libnuke v0.15.1/go.mod h1:riI1tjCf6r+et/9oUBd1vQeFmn2Sn6UeFUR0nWkMeYw=
+github.com/ekristen/libnuke v0.17.0 h1:DrTHsRh7eHBIbCKwrzpTzAdngDUAnnq61J/1I3+kDTM=
+github.com/ekristen/libnuke v0.17.0/go.mod h1:riI1tjCf6r+et/9oUBd1vQeFmn2Sn6UeFUR0nWkMeYw=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/ekristen/libnuke v0.15.1 h1:qOfGxnFYuCGaFW4g+J6QHvphhkHoeb0i5Z7VuaIOG
 github.com/ekristen/libnuke v0.15.1/go.mod h1:riI1tjCf6r+et/9oUBd1vQeFmn2Sn6UeFUR0nWkMeYw=
 github.com/ekristen/libnuke v0.17.0 h1:DrTHsRh7eHBIbCKwrzpTzAdngDUAnnq61J/1I3+kDTM=
 github.com/ekristen/libnuke v0.17.0/go.mod h1:riI1tjCf6r+et/9oUBd1vQeFmn2Sn6UeFUR0nWkMeYw=
+github.com/ekristen/libnuke v0.17.1 h1:bEroAfJ18eEKq+1B6n1QSJi9NvwIu9RFUxwOrjwn1xI=
+github.com/ekristen/libnuke v0.17.1/go.mod h1:riI1tjCf6r+et/9oUBd1vQeFmn2Sn6UeFUR0nWkMeYw=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -106,7 +106,7 @@ func (cfs *CloudFormationStack) removeWithAttempts(attempt int) error {
 		if ok && awsErr.Code() == "ValidationError" &&
 			awsErr.Message() == "Stack ["+*cfs.stack.StackName+"] cannot be deleted while TerminationProtection is enabled" {
 			// check if the setting for the resource is set to allow deletion protection to be disabled
-			if cfs.settings.Get("DisableDeletionProtection").(bool) {
+			if cfs.settings.GetBool("DisableDeletionProtection") {
 				logrus.Infof("CloudFormationStack stackName=%s attempt=%d maxAttempts=%d updating termination protection",
 					*cfs.stack.StackName, attempt, cfs.maxDeleteAttempts)
 				_, err = cfs.svc.UpdateTerminationProtection(&cloudformation.UpdateTerminationProtectionInput{

--- a/resources/ec2-image.go
+++ b/resources/ec2-image.go
@@ -104,10 +104,9 @@ func (e *EC2Image) Filter() error {
 			strings.ReplaceAll(*e.deregistrationProtection, "disabled after ", ""))
 	}
 
-	if ptr.ToString(e.deregistrationProtection) != ec2.ImageStateDisabled {
-		if !e.settings.GetBool(DisableDeregistrationProtectionSetting) || !e.settings.GetBool(DisableDeregistrationProtectionSetting) {
-			return fmt.Errorf("deregistration protection is enabled")
-		}
+	if ptr.ToString(e.deregistrationProtection) != ec2.ImageStateDisabled &&
+		!e.settings.GetBool(DisableDeregistrationProtectionSetting) {
+		return fmt.Errorf("deregistration protection is enabled")
 	}
 
 	// TODO(v4): enable by default

--- a/resources/ec2-image.go
+++ b/resources/ec2-image.go
@@ -95,7 +95,7 @@ type EC2Image struct {
 }
 
 func (e *EC2Image) Filter() error {
-	if *e.state == "pending" {
+	if ptr.ToString(e.state) == "pending" {
 		return fmt.Errorf("ineligible state for removal")
 	}
 
@@ -104,19 +104,19 @@ func (e *EC2Image) Filter() error {
 			strings.ReplaceAll(*e.deregistrationProtection, "disabled after ", ""))
 	}
 
-	if *e.deregistrationProtection != ec2.ImageStateDisabled {
-		if e.settings.Get(DisableDeregistrationProtectionSetting) == nil ||
-			(e.settings.Get(DisableDeregistrationProtectionSetting) != nil &&
-				!e.settings.Get(DisableDeregistrationProtectionSetting).(bool)) {
+	if ptr.ToString(e.deregistrationProtection) != ec2.ImageStateDisabled {
+		if !e.settings.GetBool(DisableDeregistrationProtectionSetting) || !e.settings.GetBool(DisableDeregistrationProtectionSetting) {
 			return fmt.Errorf("deregistration protection is enabled")
 		}
 	}
 
-	if !e.settings.Get(IncludeDeprecatedSetting).(bool) && e.deprecated != nil && *e.deprecated {
+	// TODO(v4): enable by default
+	if !e.settings.GetBool(IncludeDeprecatedSetting) && ptr.ToBool(e.deprecated) {
 		return fmt.Errorf("excluded by %s setting being false", IncludeDeprecatedSetting)
 	}
 
-	if !e.settings.Get(IncludeDisabledSetting).(bool) && e.state != nil && *e.state == ec2.ImageStateDisabled {
+	// TODO(v4): enable by default
+	if !e.settings.GetBool(IncludeDisabledSetting) && ptr.ToString(e.state) == ec2.ImageStateDisabled {
 		return fmt.Errorf("excluded by %s setting being false", IncludeDisabledSetting)
 	}
 
@@ -144,7 +144,7 @@ func (e *EC2Image) removeDeregistrationProtection() error {
 		return nil
 	}
 
-	if !e.settings.Get(DisableDeregistrationProtectionSetting).(bool) {
+	if !e.settings.GetBool(DisableDeregistrationProtectionSetting) {
 		return nil
 	}
 

--- a/resources/ec2-instance.go
+++ b/resources/ec2-instance.go
@@ -102,7 +102,7 @@ func (i *EC2Instance) Remove(_ context.Context) error {
 		if ok && awsErr.Code() == awsutil.ErrCodeOperationNotPermitted &&
 			awsErr.Message() == "The instance '"+*i.instance.InstanceId+"' may not be "+
 				"terminated. Modify its 'disableApiTermination' instance attribute and "+
-				"try again." && i.settings.Get("DisableDeletionProtection").(bool) {
+				"try again." && i.settings.GetBool("DisableDeletionProtection") {
 			termErr := i.DisableTerminationProtection()
 			if termErr != nil {
 				return termErr
@@ -119,7 +119,7 @@ func (i *EC2Instance) Remove(_ context.Context) error {
 		if ok && awsErr.Code() == "OperationNotPermitted" &&
 			awsErr.Message() == "The instance '"+*i.instance.InstanceId+"' may not be "+
 				"terminated. Modify its 'disableApiStop' instance attribute and try "+
-				"again." && i.settings.Get("DisableStopProtection").(bool) {
+				"again." && i.settings.GetBool("DisableStopProtection") {
 			stopErr := i.DisableStopProtection()
 			if stopErr != nil {
 				return stopErr

--- a/resources/elbv2-alb.go
+++ b/resources/elbv2-alb.go
@@ -97,7 +97,7 @@ func (e *ELBv2LoadBalancer) Remove(_ context.Context) error {
 	}
 
 	if _, err := e.svc.DeleteLoadBalancer(params); err != nil {
-		if e.settings.Get("DisableDeletionProtection").(bool) {
+		if e.settings.GetBool("DisableDeletionProtection") {
 			var awsErr awserr.Error
 			ok := errors.As(err, &awsErr)
 			if ok && awsErr.Code() == "OperationNotPermitted" &&

--- a/resources/lightsail-instances.go
+++ b/resources/lightsail-instances.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/gotidy/ptr"
+
 	"github.com/aws/aws-sdk-go/service/lightsail"
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -73,7 +74,7 @@ func (f *LightsailInstance) Settings(setting *libsettings.Setting) {
 func (f *LightsailInstance) Remove(_ context.Context) error {
 	_, err := f.svc.DeleteInstance(&lightsail.DeleteInstanceInput{
 		InstanceName:      f.instanceName,
-		ForceDeleteAddOns: aws.Bool(f.settings.Get("ForceDeleteAddOns").(bool)),
+		ForceDeleteAddOns: ptr.Bool(f.settings.GetBool("ForceDeleteAddOns")),
 	})
 
 	return err

--- a/resources/qldb-ledger.go
+++ b/resources/qldb-ledger.go
@@ -74,7 +74,7 @@ func (l *QLDBLedger) Settings(setting *libsettings.Setting) {
 }
 
 func (l *QLDBLedger) Remove(_ context.Context) error {
-	if aws.BoolValue(l.ledger.DeletionProtection) && l.settings.Get("DisableDeletionProtection").(bool) {
+	if aws.BoolValue(l.ledger.DeletionProtection) && l.settings.GetBool("DisableDeletionProtection") {
 		modifyParams := &qldb.UpdateLedgerInput{
 			DeletionProtection: aws.Bool(false),
 			Name:               l.ledger.Name,

--- a/resources/quicksight-subscriptions.go
+++ b/resources/quicksight-subscriptions.go
@@ -99,7 +99,7 @@ func (l *QuickSightSubscriptionLister) List(_ context.Context, o interface{}) ([
 }
 
 func (r *QuickSightSubscription) Remove(_ context.Context) error {
-	if r.settings != nil && r.settings.Get("DisableTerminationProtection").(bool) {
+	if r.settings != nil && r.settings.GetBool("DisableTerminationProtection") {
 		err := r.DisableTerminationProtection()
 		if err != nil {
 			return err

--- a/resources/rds-instances.go
+++ b/resources/rds-instances.go
@@ -74,7 +74,7 @@ func (i *RDSInstance) Settings(settings *libsettings.Setting) {
 }
 
 func (i *RDSInstance) Remove(_ context.Context) error {
-	if aws.BoolValue(i.instance.DeletionProtection) && i.settings.Get("DisableDeletionProtection").(bool) {
+	if aws.BoolValue(i.instance.DeletionProtection) && i.settings.GetBool("DisableDeletionProtection") {
 		modifyParams := &rds.ModifyDBInstanceInput{
 			DBInstanceIdentifier: i.instance.DBInstanceIdentifier,
 			DeletionProtection:   aws.Bool(false),


### PR DESCRIPTION
This addresses an issue where if a setting isn't set, it can cause an nil pointer the way the setting pkg was written. A quick fix and release of https://github.com/ekristen/libnuke/releases/tag/v0.17.1 to add type returning functions avoids the nil pointer issue. 

The rest of this PR is updating the setting calls to use the new `GetBool` vs `Get` to remove the possibility of nil pointer, this will specifically address the nil pointer that occurred in issue #199 with respect to EC2Image

Resolves #199 