### PR TITLE
fix: set config logger

### DIFF
--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -73,6 +73,7 @@ func execute(c *cli.Context) error { //nolint:funlen,gocyclo
 	parsedConfig, err := config.New(libconfig.Options{
 		Path:         c.Path("config"),
 		Deprecations: registry.GetDeprecatedResourceTypeMapping(),
+		Log:          logrus.WithField("component", "config"),
 	})
 	if err != nil {
 		logrus.Errorf("Failed to parse config file %s", c.Path("config"))


### PR DESCRIPTION
Config logger ensures that logs during config loading get printed.
https://github.com/ekristen/aws-nuke/pull/198 added logger to `Nuke`. This adds logger early when loading the config to `Config`.

This is related to the scenario mentioned in https://github.com/ekristen/libnuke/issues/61#issuecomment-2181633826.

Before:

```console
$ ./aws-nuke run -c nuke-cfg.yaml
> aws-nuke - 3.0.0-dev - dirty
Do you really want to nuke the account with the ID XXXXX and the alias 'xxxxx'?
Do you want to continue? Enter account alias to continue.
```

After:

```console
$ ./aws-nuke run -c nuke-cfg.yaml
WARN[0000] deprecated configuration key 'account-blacklist' - please use 'blocklist' instead  component=config
WARN[0000] deprecated resource type 'EKSNodegroups' - converting to 'EKSNodegroup'  component=config
> aws-nuke - 3.0.0-dev - dirty
Do you really want to nuke the account with the ID XXXXX and the alias 'xxxxx'?
Do you want to continue? Enter account alias to continue.
```
