### PR TITLE
fix: elasticache resources using cluster id vs arn for tag lookup

### DIFF
--- a/pkg/testsuite/logrus.go
+++ b/pkg/testsuite/logrus.go
@@ -1,0 +1,39 @@
+package testsuite
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+type GlobalHook struct {
+	T  *testing.T
+	TF func(t *testing.T, e *logrus.Entry)
+}
+
+func (h *GlobalHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *GlobalHook) Fire(e *logrus.Entry) error {
+	if h.TF != nil {
+		h.TF(h.T, e)
+	}
+
+	return nil
+}
+
+func (h *GlobalHook) Cleanup() {
+	logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
+}
+
+// NewGlobalHook creates a new GlobalHook for logrus testing
+func NewGlobalHook(t *testing.T, tf func(t *testing.T, e *logrus.Entry)) *GlobalHook {
+	gh := &GlobalHook{
+		T:  t,
+		TF: tf,
+	}
+	logrus.SetReportCaller(true)
+	logrus.AddHook(gh)
+	return gh
+}

--- a/resources/elasticache-memcacheclusters.go
+++ b/resources/elasticache-memcacheclusters.go
@@ -54,7 +54,7 @@ func (l *ElasticacheCacheClusterLister) List(_ context.Context, o interface{}) (
 	var resources []resource.Resource
 	for _, cacheCluster := range resp.CacheClusters {
 		tags, err := svc.ListTagsForResource(&elasticache.ListTagsForResourceInput{
-			ResourceName: cacheCluster.CacheClusterId,
+			ResourceName: cacheCluster.ARN,
 		})
 		if err != nil {
 			logrus.WithError(err).Error("unable to retrieve tags")

--- a/resources/elasticache-subnetgroups.go
+++ b/resources/elasticache-subnetgroups.go
@@ -51,7 +51,7 @@ func (l *ElasticacheSubnetGroupLister) List(_ context.Context, o interface{}) ([
 	var resources []resource.Resource
 	for _, subnetGroup := range resp.CacheSubnetGroups {
 		tags, err := svc.ListTagsForResource(&elasticache.ListTagsForResourceInput{
-			ResourceName: subnetGroup.CacheSubnetGroupName,
+			ResourceName: subnetGroup.ARN,
 		})
 		if err != nil {
 			logrus.WithError(err).Error("unable to retrieve tags")

--- a/resources/elasticache-subnetgroups_mock_test.go
+++ b/resources/elasticache-subnetgroups_mock_test.go
@@ -49,13 +49,14 @@ func Test_Mock_ElastiCache_SubnetGroup_List_NoTags(t *testing.T) {
 	mockElastiCache.EXPECT().DescribeCacheSubnetGroups(gomock.Any()).Return(&elasticache.DescribeCacheSubnetGroupsOutput{
 		CacheSubnetGroups: []*elasticache.CacheSubnetGroup{
 			{
+				ARN:                  aws.String("arn:aws:elasticache:us-west-2:123456789012:subnet-group:foobar"),
 				CacheSubnetGroupName: aws.String("foobar"),
 			},
 		},
 	}, nil)
 
 	mockElastiCache.EXPECT().ListTagsForResource(&elasticache.ListTagsForResourceInput{
-		ResourceName: aws.String("foobar"),
+		ResourceName: aws.String("arn:aws:elasticache:us-west-2:123456789012:subnet-group:foobar"),
 	}).Return(&elasticache.TagListMessage{}, nil)
 
 	resources, err := subnetGroupsLister.List(context.TODO(), &nuke.ListerOpts{})
@@ -82,13 +83,14 @@ func Test_Mock_ElastiCache_SubnetGroup_List_WithTags(t *testing.T) {
 	mockElastiCache.EXPECT().DescribeCacheSubnetGroups(gomock.Any()).Return(&elasticache.DescribeCacheSubnetGroupsOutput{
 		CacheSubnetGroups: []*elasticache.CacheSubnetGroup{
 			{
+				ARN:                  aws.String("arn:aws:elasticache:us-west-2:123456789012:subnet-group:foobar"),
 				CacheSubnetGroupName: aws.String("foobar"),
 			},
 		},
 	}, nil)
 
 	mockElastiCache.EXPECT().ListTagsForResource(&elasticache.ListTagsForResourceInput{
-		ResourceName: aws.String("foobar"),
+		ResourceName: aws.String("arn:aws:elasticache:us-west-2:123456789012:subnet-group:foobar"),
 	}).Return(&elasticache.TagListMessage{
 		TagList: []*elasticache.Tag{
 			{


### PR DESCRIPTION
Fixes a bug where the cluster id was incorrectly being used in place of the arn to lookup tag data for the resources.

Resolves #208 