### PR TITLE
fix(rds-snapshot): protect against nil pointer

### DIFF
--- a/resources/rds-snapshots.go
+++ b/resources/rds-snapshots.go
@@ -99,8 +99,11 @@ func (i *RDSSnapshot) Properties() types.Properties {
 		Set("Identifier", i.snapshot.DBSnapshotIdentifier).
 		Set("SnapshotType", i.snapshot.SnapshotType).
 		Set("Status", i.snapshot.Status).
-		Set("AvailabilityZone", i.snapshot.AvailabilityZone).
-		Set("CreatedTime", i.snapshot.SnapshotCreateTime.Format(time.RFC3339))
+		Set("AvailabilityZone", i.snapshot.AvailabilityZone)
+
+	if i.snapshot != nil && i.snapshot.SnapshotCreateTime != nil {
+		properties.Set("CreatedTime", i.snapshot.SnapshotCreateTime.Format(time.RFC3339))
+	}
 
 	for _, tag := range i.tags {
 		properties.SetTag(tag.Key, tag.Value)


### PR DESCRIPTION
Unsure the circumstances but it appears that the `SnapshotCreateTime` can sometimes be `nil` therefore we need a guard for it.

Resolves #221 