### PR TITLE
feat: s3 bucket - bypass governance retention

### DIFF
--- a/pkg/awsmod/batch.go
+++ b/pkg/awsmod/batch.go
@@ -220,9 +220,9 @@ type BatchDelete struct {
 //	}); err != nil {
 //		return err
 //	}
-func NewBatchDeleteWithClient(client s3iface.S3API, options ...func(*BatchDelete)) *BatchDelete {
+func NewBatchDeleteWithClient(s3client s3iface.S3API, options ...func(*BatchDelete)) *BatchDelete {
 	svc := &BatchDelete{
-		Client:    client,
+		Client:    s3client,
 		BatchSize: DefaultBatchSize,
 	}
 
@@ -255,8 +255,8 @@ func NewBatchDeleteWithClient(client s3iface.S3API, options ...func(*BatchDelete
 //		return err
 //	}
 func NewBatchDelete(c client.ConfigProvider, options ...func(*BatchDelete)) *BatchDelete {
-	client := s3.New(c)
-	return NewBatchDeleteWithClient(client, options...)
+	s3client := s3.New(c)
+	return NewBatchDeleteWithClient(s3client, options...)
 }
 
 // BatchDeleteObject is a wrapper object for calling the batch delete operation.

--- a/pkg/awsmod/batch.go
+++ b/pkg/awsmod/batch.go
@@ -1,0 +1,445 @@
+package awsmod
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+const (
+	// DefaultBatchSize is the batch size we initialize when constructing a batch delete client.
+	// This value is used when calling DeleteObjects. This represents how many objects to delete
+	// per DeleteObjects call.
+	DefaultBatchSize = 100
+)
+
+// BatchError will contain the key and bucket of the object that failed to
+// either upload or download.
+type BatchError struct {
+	Errors  Errors
+	code    string
+	message string
+}
+
+// Errors is a typed alias for a slice of errors to satisfy the error
+// interface.
+type Errors []Error
+
+func (errs Errors) Error() string {
+	buf := bytes.NewBuffer(nil)
+	for i, err := range errs {
+		buf.WriteString(err.Error())
+		if i+1 < len(errs) {
+			buf.WriteString("\n")
+		}
+	}
+	return buf.String()
+}
+
+// Error will contain the original error, bucket, and key of the operation that failed
+// during batch operations.
+type Error struct {
+	OrigErr error
+	Bucket  *string
+	Key     *string
+}
+
+func newError(err error, bucket, key *string) Error {
+	return Error{
+		err,
+		bucket,
+		key,
+	}
+}
+
+func (err *Error) Error() string {
+	origErr := ""
+	if err.OrigErr != nil {
+		origErr = ":\n" + err.OrigErr.Error()
+	}
+	return fmt.Sprintf("failed to perform batch operation on %q to %q%s",
+		aws.StringValue(err.Key),
+		aws.StringValue(err.Bucket),
+		origErr,
+	)
+}
+
+// NewBatchError will return a BatchError that satisfies the awserr.Error interface.
+func NewBatchError(code, message string, err []Error) awserr.Error {
+	return &BatchError{
+		Errors:  err,
+		code:    code,
+		message: message,
+	}
+}
+
+// Code will return the code associated with the batch error.
+func (err *BatchError) Code() string {
+	return err.code
+}
+
+// Message will return the message associated with the batch error.
+func (err *BatchError) Message() string {
+	return err.message
+}
+
+func (err *BatchError) Error() string {
+	return awserr.SprintError(err.Code(), err.Message(), "", err.Errors)
+}
+
+// OrigErr will return the original error. Which, in this case, will always be nil
+// for batched operations.
+func (err *BatchError) OrigErr() error {
+	return err.Errors
+}
+
+// BatchDeleteIterator is an interface that uses the scanner pattern to
+// iterate through what needs to be deleted.
+type BatchDeleteIterator interface {
+	Next() bool
+	Err() error
+	DeleteObject() BatchDeleteObject
+}
+
+// DeleteListIterator is an alternative iterator for the BatchDelete client. This will
+// iterate through a list of objects and delete the objects.
+//
+// Example:
+//
+//	iter := &s3manager.DeleteListIterator{
+//		Client: svc,
+//		Input: &s3.ListObjectsInput{
+//			Bucket:  aws.String("bucket"),
+//			MaxKeys: aws.Int64(5),
+//		},
+//		Paginator: request.Pagination{
+//			NewRequest: func() (*request.Request, error) {
+//				var inCpy *ListObjectsInput
+//				if input != nil {
+//					tmp := *input
+//					inCpy = &tmp
+//				}
+//				req, _ := c.ListObjectsRequest(inCpy)
+//				return req, nil
+//			},
+//		},
+//	}
+//
+//	batcher := s3manager.NewBatchDeleteWithClient(svc)
+//	if err := batcher.Delete(aws.BackgroundContext(), iter); err != nil {
+//		return err
+//	}
+type DeleteListIterator struct {
+	Bucket    *string
+	Paginator request.Pagination
+	objects   []*s3.Object
+}
+
+// NewDeleteListIterator will return a new DeleteListIterator.
+func NewDeleteListIterator(svc s3iface.S3API, input *s3.ListObjectsInput, opts ...func(*DeleteListIterator)) BatchDeleteIterator {
+	iter := &DeleteListIterator{
+		Bucket: input.Bucket,
+		Paginator: request.Pagination{
+			NewRequest: func() (*request.Request, error) {
+				var inCpy *s3.ListObjectsInput
+				if input != nil {
+					tmp := *input
+					inCpy = &tmp
+				}
+				req, _ := svc.ListObjectsRequest(inCpy)
+				return req, nil
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(iter)
+	}
+	return iter
+}
+
+// Next will use the S3API client to iterate through a list of objects.
+func (iter *DeleteListIterator) Next() bool {
+	if len(iter.objects) > 0 {
+		iter.objects = iter.objects[1:]
+	}
+
+	if len(iter.objects) == 0 && iter.Paginator.Next() {
+		iter.objects = iter.Paginator.Page().(*s3.ListObjectsOutput).Contents
+	}
+
+	return len(iter.objects) > 0
+}
+
+// Err will return the last known error from Next.
+func (iter *DeleteListIterator) Err() error {
+	return iter.Paginator.Err()
+}
+
+// DeleteObject will return the current object to be deleted.
+func (iter *DeleteListIterator) DeleteObject() BatchDeleteObject {
+	return BatchDeleteObject{
+		Object: &s3.DeleteObjectInput{
+			Bucket: iter.Bucket,
+			Key:    iter.objects[0].Key,
+		},
+	}
+}
+
+// BatchDelete will use the s3 package's service client to perform a batch
+// delete.
+type BatchDelete struct {
+	Client    s3iface.S3API
+	BatchSize int
+}
+
+// NewBatchDeleteWithClient will return a new delete client that can delete a batched amount of
+// objects.
+//
+// Example:
+//
+//	batcher := s3manager.NewBatchDeleteWithClient(client, size)
+//
+//	objects := []BatchDeleteObject{
+//		{
+//			Object:	&s3.DeleteObjectInput {
+//				Key: aws.String("key"),
+//				Bucket: aws.String("bucket"),
+//			},
+//		},
+//	}
+//
+//	if err := batcher.Delete(aws.BackgroundContext(), &s3manager.DeleteObjectsIterator{
+//		Objects: objects,
+//	}); err != nil {
+//		return err
+//	}
+func NewBatchDeleteWithClient(client s3iface.S3API, options ...func(*BatchDelete)) *BatchDelete {
+	svc := &BatchDelete{
+		Client:    client,
+		BatchSize: DefaultBatchSize,
+	}
+
+	for _, opt := range options {
+		opt(svc)
+	}
+
+	return svc
+}
+
+// NewBatchDelete will return a new delete client that can delete a batched amount of
+// objects.
+//
+// Example:
+//
+//	batcher := s3manager.NewBatchDelete(sess, size)
+//
+//	objects := []BatchDeleteObject{
+//		{
+//			Object:	&s3.DeleteObjectInput {
+//				Key: aws.String("key"),
+//				Bucket: aws.String("bucket"),
+//			},
+//		},
+//	}
+//
+//	if err := batcher.Delete(aws.BackgroundContext(), &s3manager.DeleteObjectsIterator{
+//		Objects: objects,
+//	}); err != nil {
+//		return err
+//	}
+func NewBatchDelete(c client.ConfigProvider, options ...func(*BatchDelete)) *BatchDelete {
+	client := s3.New(c)
+	return NewBatchDeleteWithClient(client, options...)
+}
+
+// BatchDeleteObject is a wrapper object for calling the batch delete operation.
+type BatchDeleteObject struct {
+	Object *s3.DeleteObjectInput
+	// After will run after each iteration during the batch process. This function will
+	// be executed whether the request was successful.
+	After func() error
+}
+
+// DeleteObjectsIterator is an interface that uses the scanner pattern to iterate
+// through a series of objects to be deleted.
+type DeleteObjectsIterator struct {
+	Objects []BatchDeleteObject
+	index   int
+	inc     bool
+}
+
+// Next will increment the default iterators index and ensure that there
+// is another object to iterator to.
+func (iter *DeleteObjectsIterator) Next() bool {
+	if iter.inc {
+		iter.index++
+	} else {
+		iter.inc = true
+	}
+	return iter.index < len(iter.Objects)
+}
+
+// Err will return an error. Since this is just used to satisfy the BatchDeleteIterator interface
+// this will only return nil.
+func (iter *DeleteObjectsIterator) Err() error {
+	return nil
+}
+
+// DeleteObject will return the BatchDeleteObject at the current batched index.
+func (iter *DeleteObjectsIterator) DeleteObject() BatchDeleteObject {
+	object := iter.Objects[iter.index]
+	return object
+}
+
+// Delete will use the iterator to queue up objects that need to be deleted.
+// Once the batch size is met, this will call the deleteBatch function.
+func (d *BatchDelete) Delete(ctx aws.Context, iter BatchDeleteIterator, opts ...func(input *s3.DeleteObjectsInput)) error {
+	var errs []Error
+	var objects []BatchDeleteObject
+	var input *s3.DeleteObjectsInput
+
+	for iter.Next() {
+		o := iter.DeleteObject()
+
+		if input == nil {
+			input = initDeleteObjectsInput(o.Object)
+		}
+
+		for _, opt := range opts {
+			opt(input)
+		}
+
+		parity := hasParity(input, o)
+		if parity {
+			input.Delete.Objects = append(input.Delete.Objects, &s3.ObjectIdentifier{
+				Key:       o.Object.Key,
+				VersionId: o.Object.VersionId,
+			})
+			objects = append(objects, o)
+		}
+
+		if len(input.Delete.Objects) == d.BatchSize || !parity {
+			if err := deleteBatch(ctx, d, input, objects); err != nil {
+				errs = append(errs, err...)
+			}
+
+			objects = objects[:0]
+			input = nil
+
+			if !parity {
+				objects = append(objects, o)
+				input = initDeleteObjectsInput(o.Object)
+
+				for _, opt := range opts {
+					opt(input)
+				}
+
+				input.Delete.Objects = append(input.Delete.Objects, &s3.ObjectIdentifier{
+					Key:       o.Object.Key,
+					VersionId: o.Object.VersionId,
+				})
+			}
+		}
+	}
+
+	// iter.Next() could return false (above) plus populate iter.Err()
+	if iter.Err() != nil {
+		errs = append(errs, newError(iter.Err(), nil, nil))
+	}
+
+	if input != nil && len(input.Delete.Objects) > 0 {
+		if err := deleteBatch(ctx, d, input, objects); err != nil {
+			errs = append(errs, err...)
+		}
+	}
+
+	if len(errs) > 0 {
+		return NewBatchError("BatchedDeleteIncomplete", "some objects have failed to be deleted.", errs)
+	}
+	return nil
+}
+
+func initDeleteObjectsInput(o *s3.DeleteObjectInput) *s3.DeleteObjectsInput {
+	return &s3.DeleteObjectsInput{
+		Bucket:       o.Bucket,
+		MFA:          o.MFA,
+		RequestPayer: o.RequestPayer,
+		Delete:       &s3.Delete{},
+	}
+}
+
+const (
+	// ErrDeleteBatchFailCode represents an error code which will be returned
+	// only when DeleteObjects.Errors has an error that does not contain a code.
+	ErrDeleteBatchFailCode       = "DeleteBatchError"
+	errDefaultDeleteBatchMessage = "failed to delete"
+)
+
+// deleteBatch will delete a batch of items in the objects parameters.
+func deleteBatch(ctx aws.Context, d *BatchDelete, input *s3.DeleteObjectsInput, objects []BatchDeleteObject) []Error {
+	var errs []Error
+
+	if result, err := d.Client.DeleteObjectsWithContext(ctx, input); err != nil {
+		for i := 0; i < len(input.Delete.Objects); i++ {
+			errs = append(errs, newError(err, input.Bucket, input.Delete.Objects[i].Key))
+		}
+	} else if len(result.Errors) > 0 {
+		for i := 0; i < len(result.Errors); i++ {
+			code := ErrDeleteBatchFailCode
+			msg := errDefaultDeleteBatchMessage
+			if result.Errors[i].Message != nil {
+				msg = *result.Errors[i].Message
+			}
+			if result.Errors[i].Code != nil {
+				code = *result.Errors[i].Code
+			}
+
+			errs = append(errs, newError(awserr.New(code, msg, err), input.Bucket, result.Errors[i].Key))
+		}
+	}
+	for _, object := range objects {
+		if object.After == nil {
+			continue
+		}
+		if err := object.After(); err != nil {
+			errs = append(errs, newError(err, object.Object.Bucket, object.Object.Key))
+		}
+	}
+
+	return errs
+}
+
+func hasParity(o1 *s3.DeleteObjectsInput, o2 BatchDeleteObject) bool {
+	if o1.Bucket != nil && o2.Object.Bucket != nil {
+		if *o1.Bucket != *o2.Object.Bucket {
+			return false
+		}
+	} else if o1.Bucket != o2.Object.Bucket {
+		return false
+	}
+
+	if o1.MFA != nil && o2.Object.MFA != nil {
+		if *o1.MFA != *o2.Object.MFA {
+			return false
+		}
+	} else if o1.MFA != o2.Object.MFA {
+		return false
+	}
+
+	if o1.RequestPayer != nil && o2.Object.RequestPayer != nil {
+		if *o1.RequestPayer != *o2.Object.RequestPayer {
+			return false
+		}
+	} else if o1.RequestPayer != o2.Object.RequestPayer {
+		return false
+	}
+
+	return true
+}

--- a/resources/iam-user_test.go
+++ b/resources/iam-user_test.go
@@ -35,7 +35,7 @@ func Test_IAMUser_Remove(t *testing.T) {
 
 	iamUser := IAMUser{
 		svc:  svc,
-		name: "test-user",
+		name: aws.String("test-user"),
 		tags: createInput.Tags,
 	}
 

--- a/resources/s3-bucket.go
+++ b/resources/s3-bucket.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ekristen/aws-nuke/v3/pkg/awsmod"
-	libsettings "github.com/ekristen/libnuke/pkg/settings"
 	"time"
 
 	"github.com/gotidy/ptr"
@@ -17,10 +15,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
+	libsettings "github.com/ekristen/libnuke/pkg/settings"
 	"github.com/ekristen/libnuke/pkg/types"
 
+	"github.com/ekristen/aws-nuke/v3/pkg/awsmod"
 	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 

--- a/resources/s3-bucket_test.go
+++ b/resources/s3-bucket_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	libsettings "github.com/ekristen/libnuke/pkg/settings"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/awsmod"
+)
+
+type TestS3BucketObjectLockSuite struct {
+	suite.Suite
+	bucket string
+	svc    *s3.S3
+}
+
+func (suite *TestS3BucketObjectLockSuite) SetupSuite() {
+	var err error
+
+	suite.bucket = fmt.Sprintf("aws-nuke-testing-bucket-%d", time.Now().UnixNano())
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-west-2")},
+	)
+	if err != nil {
+		suite.T().Fatalf("failed to create session, %v", err)
+	}
+
+	// Create S3 service client
+	suite.svc = s3.New(sess)
+
+	// Create the bucket
+	_, err = suite.svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(suite.bucket),
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to create bucket, %v", err)
+	}
+
+	// enable versioning
+	_, err = suite.svc.PutBucketVersioning(&s3.PutBucketVersioningInput{
+		Bucket: aws.String(suite.bucket),
+		VersioningConfiguration: &s3.VersioningConfiguration{
+			Status: aws.String("Enabled"),
+		},
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to enable versioning, %v", err)
+	}
+
+	// Set the object lock configuration to governance mode
+	_, err = suite.svc.PutObjectLockConfiguration(&s3.PutObjectLockConfigurationInput{
+		Bucket: aws.String(suite.bucket),
+		ObjectLockConfiguration: &s3.ObjectLockConfiguration{
+			ObjectLockEnabled: aws.String("Enabled"),
+			Rule: &s3.ObjectLockRule{
+				DefaultRetention: &s3.DefaultRetention{
+					Mode: aws.String("GOVERNANCE"),
+					Days: aws.Int64(1),
+				},
+			},
+		},
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to set object lock configuration, %v", err)
+	}
+
+	// Create an object in the bucket
+	_, err = suite.svc.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(suite.bucket),
+		Key:    aws.String("test-object"),
+		Body:   aws.ReadSeekCloser(strings.NewReader("test content")),
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to create object, %v", err)
+	}
+}
+
+func (suite *TestS3BucketObjectLockSuite) TearDownSuite() {
+	iterator := newS3DeleteVersionListIterator(suite.svc, &s3.ListObjectVersionsInput{
+		Bucket: &suite.bucket,
+	}, true)
+	if err := awsmod.NewBatchDeleteWithClient(suite.svc).Delete(context.TODO(), iterator, bypassGovernanceRetention); err != nil {
+		if !strings.Contains(err.Error(), "NoSuchBucket") {
+			suite.T().Fatalf("failed to delete objects, %v", err)
+		}
+	}
+
+	iterator2 := newS3ObjectDeleteListIterator(suite.svc, &s3.ListObjectsInput{
+		Bucket: &suite.bucket,
+	}, true)
+	if err := awsmod.NewBatchDeleteWithClient(suite.svc).Delete(context.TODO(), iterator2, bypassGovernanceRetention); err != nil {
+		if !strings.Contains(err.Error(), "NoSuchBucket") {
+			suite.T().Fatalf("failed to delete objects, %v", err)
+		}
+	}
+
+	_, err := suite.svc.DeleteBucket(&s3.DeleteBucketInput{
+		Bucket: aws.String(suite.bucket),
+	})
+	if err != nil {
+		if !strings.Contains(err.Error(), "NoSuchBucket") {
+			suite.T().Fatalf("failed to delete bucket, %v", err)
+		}
+	}
+}
+
+func (suite *TestS3BucketObjectLockSuite) TestS3BucketObjectLock() {
+	// Verify the object lock configuration
+	result, err := suite.svc.GetObjectLockConfiguration(&s3.GetObjectLockConfigurationInput{
+		Bucket: aws.String(suite.bucket),
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to get object lock configuration, %v", err)
+	}
+
+	assert.Equal(suite.T(), "Enabled", *result.ObjectLockConfiguration.ObjectLockEnabled)
+	assert.Equal(suite.T(), "GOVERNANCE", *result.ObjectLockConfiguration.Rule.DefaultRetention.Mode)
+	assert.Equal(suite.T(), int64(1), *result.ObjectLockConfiguration.Rule.DefaultRetention.Days)
+}
+
+func (suite *TestS3BucketObjectLockSuite) TestS3BucketRemove() {
+	// Create the S3Bucket object
+	bucket := &S3Bucket{
+		svc:      suite.svc,
+		name:     suite.bucket,
+		settings: &libsettings.Setting{},
+	}
+
+	err := bucket.Remove(context.TODO())
+	assert.Error(suite.T(), err)
+}
+
+func (suite *TestS3BucketObjectLockSuite) TestS3BucketRemoveWithBypass() {
+	// Create the S3Bucket object
+	bucket := &S3Bucket{
+		svc:  suite.svc,
+		name: suite.bucket,
+		settings: &libsettings.Setting{
+			"BypassGovernanceRetention": true,
+		},
+	}
+
+	err := bucket.Remove(context.TODO())
+	assert.Nil(suite.T(), err)
+}
+
+func TestS3BucketObjectLock(t *testing.T) {
+	suite.Run(t, new(TestS3BucketObjectLockSuite))
+}


### PR DESCRIPTION
This adds the ability to bypass the governance retention on s3 objects in a bucket and still clean the bucket up.

This adds a new setting to the `S3Bucket` called `BypassGovernanceRetention`, when set to true, the recursive delete of a bucket will set `BypassGovernanceRentention` to true when calling to S3, thus allowing the bypass of any governance enforcement.

**Note:** if you are using COMPLIANCE mode this will not work. aws-nuke will also currently fail if any objects are in compliance mode.