### PR TITLE
feat(configservice-configrule): remove remediation config

### DIFF
--- a/resources/configservice-configrule.go
+++ b/resources/configservice-configrule.go
@@ -3,10 +3,12 @@ package resources
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/configservice"
+
 	"github.com/gotidy/ptr"
 	"github.com/sirupsen/logrus"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/configservice"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"

--- a/resources/configservice-configrule.go
+++ b/resources/configservice-configrule.go
@@ -83,38 +83,38 @@ type ConfigServiceConfigRule struct {
 	CreatedBy            *string
 }
 
-func (f *ConfigServiceConfigRule) Filter() error {
-	if aws.StringValue(f.CreatedBy) == "securityhub.amazonaws.com" {
+func (r *ConfigServiceConfigRule) Filter() error {
+	if aws.StringValue(r.CreatedBy) == "securityhub.amazonaws.com" {
 		return fmt.Errorf("cannot remove rule owned by securityhub.amazonaws.com")
 	}
 
-	if aws.StringValue(f.CreatedBy) == "config-conforms.amazonaws.com" {
+	if aws.StringValue(r.CreatedBy) == "config-conforms.amazonaws.com" {
 		return fmt.Errorf("cannot remove rule owned by config-conforms.amazonaws.com")
 	}
 
 	return nil
 }
 
-func (f *ConfigServiceConfigRule) Remove(_ context.Context) error {
-	if ptr.ToBool(f.HasRemediationConfig) {
-		if _, err := f.svc.DeleteRemediationConfiguration(&configservice.DeleteRemediationConfigurationInput{
-			ConfigRuleName: f.Name,
+func (r *ConfigServiceConfigRule) Remove(_ context.Context) error {
+	if ptr.ToBool(r.HasRemediationConfig) {
+		if _, err := r.svc.DeleteRemediationConfiguration(&configservice.DeleteRemediationConfigurationInput{
+			ConfigRuleName: r.Name,
 		}); err != nil {
 			return err
 		}
 	}
 
-	_, err := f.svc.DeleteConfigRule(&configservice.DeleteConfigRuleInput{
-		ConfigRuleName: f.Name,
+	_, err := r.svc.DeleteConfigRule(&configservice.DeleteConfigRuleInput{
+		ConfigRuleName: r.Name,
 	})
 
 	return err
 }
 
-func (f *ConfigServiceConfigRule) String() string {
-	return *f.Name
+func (r *ConfigServiceConfigRule) String() string {
+	return *r.Name
 }
 
-func (f *ConfigServiceConfigRule) Properties() types.Properties {
-	return types.NewPropertiesFromStruct(f)
+func (r *ConfigServiceConfigRule) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
 }

--- a/resources/configservice-configrules.go
+++ b/resources/configservice-configrules.go
@@ -3,9 +3,10 @@ package resources
 import (
 	"context"
 	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -41,11 +42,27 @@ func (l *ConfigServiceConfigRuleLister) List(_ context.Context, o interface{}) (
 		}
 
 		for _, configRule := range output.ConfigRules {
-			resources = append(resources, &ConfigServiceConfigRule{
-				svc:            svc,
-				configRuleName: configRule.ConfigRuleName,
-				createdBy:      configRule.CreatedBy,
+			remConfig, err := svc.DescribeRemediationConfigurations(&configservice.DescribeRemediationConfigurationsInput{
+				ConfigRuleNames: []*string{configRule.ConfigRuleName},
 			})
+			if err != nil {
+				logrus.
+					WithField("name", configRule.ConfigRuleName).
+					WithError(err).
+					Warn("unable to describe remediation configurations")
+			}
+
+			newResource := &ConfigServiceConfigRule{
+				svc:       svc,
+				Name:      configRule.ConfigRuleName,
+				CreatedBy: configRule.CreatedBy,
+			}
+
+			if remConfig != nil && len(remConfig.RemediationConfigurations) > 0 {
+				newResource.HasRemediationConfig = ptr.Bool(true)
+			}
+
+			resources = append(resources, newResource)
 		}
 
 		if output.NextToken == nil {
@@ -59,17 +76,19 @@ func (l *ConfigServiceConfigRuleLister) List(_ context.Context, o interface{}) (
 }
 
 type ConfigServiceConfigRule struct {
-	svc            *configservice.ConfigService
-	configRuleName *string
-	createdBy      *string
+	svc                  *configservice.ConfigService
+	Name                 *string
+	Scope                *string
+	HasRemediationConfig *bool
+	CreatedBy            *string
 }
 
 func (f *ConfigServiceConfigRule) Filter() error {
-	if aws.StringValue(f.createdBy) == "securityhub.amazonaws.com" {
+	if aws.StringValue(f.CreatedBy) == "securityhub.amazonaws.com" {
 		return fmt.Errorf("cannot remove rule owned by securityhub.amazonaws.com")
 	}
 
-	if aws.StringValue(f.createdBy) == "config-conforms.amazonaws.com" {
+	if aws.StringValue(f.CreatedBy) == "config-conforms.amazonaws.com" {
 		return fmt.Errorf("cannot remove rule owned by config-conforms.amazonaws.com")
 	}
 
@@ -77,19 +96,25 @@ func (f *ConfigServiceConfigRule) Filter() error {
 }
 
 func (f *ConfigServiceConfigRule) Remove(_ context.Context) error {
+	if ptr.ToBool(f.HasRemediationConfig) {
+		if _, err := f.svc.DeleteRemediationConfiguration(&configservice.DeleteRemediationConfigurationInput{
+			ConfigRuleName: f.Name,
+		}); err != nil {
+			return err
+		}
+	}
+
 	_, err := f.svc.DeleteConfigRule(&configservice.DeleteConfigRuleInput{
-		ConfigRuleName: f.configRuleName,
+		ConfigRuleName: f.Name,
 	})
 
 	return err
 }
 
 func (f *ConfigServiceConfigRule) String() string {
-	return *f.configRuleName
+	return *f.Name
 }
 
 func (f *ConfigServiceConfigRule) Properties() types.Properties {
-	props := types.NewProperties()
-	props.Set("CreatedBy", f.createdBy)
-	return props
+	return types.NewPropertiesFromStruct(f)
 }


### PR DESCRIPTION
If you attempt to delete a config rule that has a remediation config it will fail, this fixes it so that if a remediation config is present it deletes that first.