### PR TITLE
fix(iam-virtual-mfa-device): handle unassigned mfa devices

### DIFF
--- a/resources/iam-virtual-mfa-device_mock_test.go
+++ b/resources/iam-virtual-mfa-device_mock_test.go
@@ -8,10 +8,102 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
+
+func Test_Mock_IAMVirtualMFADevice_List(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIAM := mock_iamiface.NewMockIAMAPI(ctrl)
+
+	mockIAM.EXPECT().ListVirtualMFADevices(gomock.Any()).Return(&iam.ListVirtualMFADevicesOutput{
+		VirtualMFADevices: []*iam.VirtualMFADevice{
+			{
+				SerialNumber: ptr.String("serial:device1"),
+				User: &iam.User{
+					UserName: ptr.String("user1"),
+					Arn:      ptr.String("arn:aws:iam::123456789012:user/user1"),
+				},
+			},
+			{
+				SerialNumber: ptr.String("arn:aws:iam::077097111583:mfa/Authenticator"),
+				User: &iam.User{
+					UserName: ptr.String("user1"),
+					UserId:   ptr.String("0000000000000"),
+					Arn:      ptr.String("arn:aws:iam::123456789012:user/user1"),
+				},
+			},
+			{
+				SerialNumber: ptr.String("serial:device2"),
+				User:         nil,
+			},
+		},
+	}, nil)
+
+	lister := &IAMVirtualMFADeviceLister{
+		mockSvc: mockIAM,
+	}
+
+	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
+		Region: &nuke.Region{
+			Name: "us-east-2",
+		},
+		Session: session.Must(session.NewSession()),
+	})
+	a.Nil(err)
+	a.Len(resources, 3)
+}
+
+func Test_IAMVirtualMFADevice_Properties(t *testing.T) {
+	a := assert.New(t)
+
+	iamVirtualMFADevice := IAMVirtualMFADevice{
+		user: &iam.User{
+			UserName: ptr.String("foobar"),
+			Arn:      ptr.String("arn:aws:iam::123456789012:user/foobar"),
+		},
+		SerialNumber: ptr.String("serial:foobar"),
+		Assigned:     ptr.Bool(true),
+	}
+
+	properties := iamVirtualMFADevice.Properties()
+	a.Equal("serial:foobar", properties.Get("SerialNumber"))
+	a.Equal("true", properties.Get("Assigned"))
+	a.Equal("serial:foobar", iamVirtualMFADevice.String())
+}
+
+func Test_IAMVirtualMFADevice_Filter(t *testing.T) {
+	a := assert.New(t)
+
+	rootMFADevice := &IAMVirtualMFADevice{
+		user: &iam.User{
+			UserId: ptr.String("0000000000000"),
+			Arn:    ptr.String("arn:aws:iam::0000000000000:root"),
+		},
+		SerialNumber: ptr.String("arn:aws:iam::0000000000000:mfa/root-account-mfa-device"),
+	}
+
+	err := rootMFADevice.Filter()
+	a.NotNil(err)
+	a.EqualError(err, "cannot delete root mfa device")
+
+	nonRootMFADevice := &IAMVirtualMFADevice{
+		user: &iam.User{
+			UserId: ptr.String("123456789012"),
+			Arn:    ptr.String("arn:aws:iam::123456789012:user/user1"),
+		},
+		SerialNumber: ptr.String("arn:aws:iam::123456789012:mfa/user1"),
+	}
+
+	err = nonRootMFADevice.Filter()
+	a.Nil(err)
+}
 
 func Test_Mock_IAMVirtualMFADevice_Remove(t *testing.T) {
 	a := assert.New(t)
@@ -21,18 +113,21 @@ func Test_Mock_IAMVirtualMFADevice_Remove(t *testing.T) {
 	mockIAM := mock_iamiface.NewMockIAMAPI(ctrl)
 
 	iamVirtualMFADevice := IAMVirtualMFADevice{
-		svc:          mockIAM,
-		userName:     ptr.String("user:foobar"),
-		serialNumber: ptr.String("serial:foobar"),
+		svc: mockIAM,
+		user: &iam.User{
+			UserName: ptr.String("foobar"),
+			Arn:      ptr.String("arn:aws:iam::123456789012:user/foobar"),
+		},
+		SerialNumber: ptr.String("serial:foobar"),
 	}
 
 	mockIAM.EXPECT().DeactivateMFADevice(gomock.Eq(&iam.DeactivateMFADeviceInput{
-		UserName:     iamVirtualMFADevice.userName,
-		SerialNumber: iamVirtualMFADevice.serialNumber,
+		UserName:     iamVirtualMFADevice.user.UserName,
+		SerialNumber: iamVirtualMFADevice.SerialNumber,
 	})).Return(&iam.DeactivateMFADeviceOutput{}, nil)
 
 	mockIAM.EXPECT().DeleteVirtualMFADevice(gomock.Eq(&iam.DeleteVirtualMFADeviceInput{
-		SerialNumber: iamVirtualMFADevice.serialNumber,
+		SerialNumber: iamVirtualMFADevice.SerialNumber,
 	})).Return(&iam.DeleteVirtualMFADeviceOutput{}, nil)
 
 	err := iamVirtualMFADevice.Remove(context.TODO())


### PR DESCRIPTION
It's possible to have MFA devices that are not assigned to a user, this fixes it so that those devices can be deleted