### PR TITLE
feat(experimental): filter groups

### DIFF
--- a/docs/cli-experimental.md
+++ b/docs/cli-experimental.md
@@ -20,6 +20,8 @@ aws-nuke run --feature-flag "wait-on-dependencies"
 
 ## Available Feature Flags
 
+- `filter-groups` - This feature flag will cause aws-nuke to filter based on a grouping method which allows for AND'ing
+  filters together.
 - `wait-on-dependencies` - This feature flag will cause aws-nuke to wait for all resource type dependencies to be 
   deleted before deleting the next resource type.
 
@@ -33,3 +35,20 @@ The problem is that if you delete the IAM Role first, it will fail because it ha
 
 This feature flag will cause aws-nuke to wait for all resources of a given type to be deleted before deleting the next
 resource type. This will reduce the number of errors and unnecessary API calls.
+
+### filter-groups
+
+This feature flag will cause aws-nuke to filter resources based on a group method. This is useful when filters need
+to be AND'd together. For example, if you want to delete all resources that are tagged with `env:dev` and `namespace:test`
+you can use the following filter group:
+
+```yaml
+filters:
+  ResourceType:
+    - property: tag:env
+      value: dev
+      group: group1
+    - property: tag:namespace
+      value: test
+      group: group2
+```

--- a/docs/config-filtering.md
+++ b/docs/config-filtering.md
@@ -21,6 +21,33 @@ against some resources and not others.
 Global works by taking all filters defined under `__global__` and prepends to any filters found for a resource type. If
 a resource does NOT have any filters defined, the `__global__` ones will still be used.
 
+## Filter Groups
+
+!!! important
+    Filter groups are an experimental feature and are disabled by default. To enable filter groups, use the
+    `--feature-flag filter-groups` flag.
+
+Filter groups are used to group filters together. This is useful when filters need to be AND'd together. For example,
+if you want to delete all resources that are tagged with `env:dev` and `namespace:test` you can use the following filter
+group:
+
+```yaml
+filters:
+  ResourceType:
+    - property: tag:env
+      value: dev
+      group: group1
+    - property: tag:namespace
+      value: test
+      group: group2
+```
+
+In this example, the `group1` and `group2` filters are AND'd together. This means that a resource must match both filters
+to be excluded from deletion.
+
+Only a single filter in a group is required to match. This means that if a resource matches any filter in a group it will
+count as a match for the group.
+
 ### Example
 
 In this example, we are ignoring all resources that have the tag `aws-nuke` set to `ignore`. Additionally filtering

--- a/docs/features/filter-groups.md
+++ b/docs/features/filter-groups.md
@@ -1,0 +1,11 @@
+# Filter Groups
+
+!!! important
+    This feature is experimental and is disabled by default. To enable it, use the `--feature-flag "filter-groups"` CLI argument.
+
+Filter groups allow you to filter resources based on a grouping method which allows for AND'ing filters together. By
+default, all filters belong to the same group, but you can specify a group name to group filters together. 
+
+All filters within a group are OR'd together, and all groups are AND'd together. 
+
+[Full Documentation](../config-filtering.md#filter-groups)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.6
 
 require (
 	github.com/aws/aws-sdk-go v1.54.20
-	github.com/ekristen/libnuke v0.19.2
+	github.com/ekristen/libnuke v0.20.0
 	github.com/fatih/color v1.17.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/ekristen/libnuke v0.19.1 h1:n52PMccQjs4MsaYPtulavxmKyHFq4xz3KCy6mpjoX
 github.com/ekristen/libnuke v0.19.1/go.mod h1:riI1tjCf6r+et/9oUBd1vQeFmn2Sn6UeFUR0nWkMeYw=
 github.com/ekristen/libnuke v0.19.2 h1:dlmqeHBHaQN+gv6Cg7+DwehpayocAABTYzSaTmaP6Pk=
 github.com/ekristen/libnuke v0.19.2/go.mod h1:DIN5VmrH6AUwaXc25RHcH/V+JKALdl16CN9iJvFtbK4=
+github.com/ekristen/libnuke v0.20.0 h1:GV6ebfPt3ac+5ygto3hdIH5PN9ppXPAAJo7C00ngOCI=
+github.com/ekristen/libnuke v0.20.0/go.mod h1:DIN5VmrH6AUwaXc25RHcH/V+JKALdl16CN9iJvFtbK4=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Overview: features/overview.md
       - Bypass Alias Check: features/bypass-alias-check.md
       - Global Filters: features/global-filters.md
+      - Filter Groups: features/filter-groups.md
       - Enabled Regions: features/enabled-regions.md
       - Signed Binaries: features/signed-binaries.md
   - CLI:

--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -68,6 +68,10 @@ func execute(c *cli.Context) error { //nolint:funlen,gocyclo
 		if slices.Contains(c.StringSlice("feature-flag"), "wait-on-dependencies") {
 			params.WaitOnDependencies = true
 		}
+
+		if slices.Contains(c.StringSlice("feature-flag"), "filter-groups") {
+			params.UseFilterGroups = true
+		}
 	}
 
 	// Parse the user supplied configuration file to pass in part to configure the nuke process.


### PR DESCRIPTION
## Overview

By default all filters are part of group `default`, this allows you to set `group: <value>` for any filter. 

Filters within the same group are `OR`, meaning if any are true, then the resource is filtered.

If more than 1 filter group is present, they are `AND`ed together and both groups must be true for the filter to match.

## Example Output

This is the filter definition

```yaml
    filters:
      IAMUser:
        - value: "testing"
          type: contains
          group: group1
        - property: tag:test
          value: "alpha"
          group: group2
```

**WITHOUT** filter groups, both resources get filtered because they match 1 or more filters.

```console
global - IAMUser - testing - [CreateDate: "2024-10-15T22:42:39Z", Name: "testing", Path: "/", UserID: "AIDAZI2LHXQ5T2ABOSX2H"] - filtered by config
global - IAMUser - testing12345 - [CreateDate: "2024-10-15T22:42:52Z", Name: "testing12345", Path: "/", UserID: "AIDAZI2LHXQ5YFP5X4QVZ", tag:test: "alpha"] - filtered by config
Scan complete: 2 total, 0 nukeable, 2 filtered.
```

**WITH** filter groups enabled via `--feature-flag filter-groups`, only a single resource gets filtered because it has to match **BOTH** because there are two groups defined.

```console
global - IAMUser - testing - [CreateDate: "2024-10-15T22:42:39Z", Name: "testing", Path: "/", UserID: "AIDAZI2LHXQ5T2ABOSX2H"] - would remove
global - IAMUser - testing12345 - [CreateDate: "2024-10-15T22:42:52Z", Name: "testing12345", Path: "/", UserID: "AIDAZI2LHXQ5YFP5X4QVZ", tag:test: "alpha"] - filtered by config
Scan complete: 2 total, 1 nukeable, 1 filtered.
```

## References

- Resolves #378