### PR TITLE
fix(ec2-vpc-endpoint-connection): filter rejected state

### DIFF
--- a/pkg/awsutil/consts.go
+++ b/pkg/awsutil/consts.go
@@ -8,3 +8,6 @@ const StateDeleted = "deleted"
 
 // StateDeleting is a generic constant for the word deleting for state
 const StateDeleting = "deleting"
+
+// StateRejected is a generic constant for the word rejected for state
+const StateRejected = "rejected"


### PR DESCRIPTION
This fixes a bug where ec2 vpc endpoint connections can remain in the describe API in the rejected state. The rejected state is a form of deletion, therefore we need to filter it once it hits this state.

Upstream issue is https://github.com/rebuy-de/aws-nuke/issues/1258

Resolves https://github.com/ekristen/aws-nuke/issues/272