### PR TITLE
feat(config): custom alias keyword blocklist and disable default keywords

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,8 @@ The configuration is the user supplied configuration that is used to drive the n
 The configuration is broken down into the following sections:
 
 - [blocklist](#blocklist)
-- [blocklist-alias-keywords](#blocklist-alias-keywords)
+- [blocklist-terms](#blocklist-terms)
+- [no-blocklist-terms-default](#no-blocklist-terms-default)
 - [regions](#regions)
 - [accounts](#accounts)
     - [presets](#presets)
@@ -32,10 +33,12 @@ The configuration is broken down into the following sections:
 blocklist:
   - 1234567890
     
-blocklist-alias-keywords:
+blocklist-terms:
   - "prod"
   - "production"
   - "live"
+
+no-blocklist-terms-default: false # default value
 
 regions:
   - global
@@ -75,17 +78,36 @@ blocklist:
   - 1234567890
 ```
 
-## Blocklist Alias Keywords
+## Blocklist Terms
 
-`blocklist-alias-keywords` is a list of keywords that the tool will use to block accounts based on their aliases. If 
-an account alias contains any of the keywords in the list, then the account will be blocked. However if the bypass alias
-check flag is set, then this feature has no affect.
+`blocklist-terms` is a list of terms that the tool will use to block accounts based on their aliases. If an account
+alias contains any of the terms in the list, then the account will be blocked. However, if the bypass alias check flag
+is set, then this feature has no affect.
 
 ```yaml
-blocklist-alias-keywords:
+blocklist-terms:
   - "prod"
   - "production"
   - "live"
+```
+
+## No Blocklist Terms Default
+
+`no-blocklist-terms-default` is a boolean value that determines the default behavior of the blocklist. If set to true,
+then the blocklist will be empty by default. If set to false, then the blocklist will be populated by default.
+
+### Usage
+
+**Default Value:** `false`
+
+```yaml
+no-blocklist-terms-default: true
+```
+
+### Default Terms
+
+```yaml
+- prod
 ```
 
 ## Regions

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,6 +7,7 @@ The configuration is the user supplied configuration that is used to drive the n
 The configuration is broken down into the following sections:
 
 - [blocklist](#blocklist)
+- [blocklist-alias-keywords](#blocklist-alias-keywords)
 - [regions](#regions)
 - [accounts](#accounts)
     - [presets](#presets)
@@ -30,6 +31,11 @@ The configuration is broken down into the following sections:
 ```yaml
 blocklist:
   - 1234567890
+    
+blocklist-alias-keywords:
+  - "prod"
+  - "production"
+  - "live"
 
 regions:
   - global
@@ -61,14 +67,38 @@ settings:
 
 ## Blocklist
 
-The blocklist is simply a list of Accounts that the tool cannot run against. This is to protect the user from accidentally
+The `blocklist` is simply a list of Accounts that the tool cannot run against. This is to protect the user from accidentally
 running the tool against the wrong account. The blocklist must always be populated with at least one entry.
+
+```yaml
+blocklist:
+  - 1234567890
+```
+
+## Blocklist Alias Keywords
+
+`blocklist-alias-keywords` is a list of keywords that the tool will use to block accounts based on their aliases. If 
+an account alias contains any of the keywords in the list, then the account will be blocked. However if the bypass alias
+check flag is set, then this feature has no affect.
+
+```yaml
+blocklist-alias-keywords:
+  - "prod"
+  - "production"
+  - "live"
+```
 
 ## Regions
 
-The regions is a list of AWS regions that the tool will run against. The tool will run against all regions specified in the
+The `regions` is a list of AWS regions that the tool will run against. The tool will run against all regions specified in the
 configuration. If no regions are listed, then the tool will **NOT** run against any region. Regions must be explicitly
 provided.
+
+```yaml
+regions:
+  - global
+  - us-east-1
+```
 
 ### All Enabled Regions
 
@@ -79,6 +109,11 @@ special region `global` which is for specific global resources.
 !!! important
     The use of `all` will ignore all other regions specified in the configuration. It will only run against regions
     that are enabled in the account.
+
+```yaml
+regions:
+  - all
+```
 
 ## Accounts
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,9 +43,13 @@ type Config struct {
 	// Config is the underlying libnuke configuration.
 	*config.Config `yaml:",inline"`
 
-	// BlocklistAliasKeywords is a list of keywords that are blocklisted from being used in an alias.
+	// BlocklistTerms is a list of keywords that are blocklisted from being used in an alias.
 	// If any of these keywords are found in an alias, the nuke will abort.
-	BlocklistAliasKeywords []string `yaml:"blocklist-alias-keywords"`
+	BlocklistTerms []string `yaml:"blocklist-terms"`
+
+	// NoBlocklistTermsDefault is a setting that can be used to disable the default terms from being added to the
+	// blocklist.
+	NoBlocklistTermsDefault bool `yaml:"no-blocklist-terms-default"`
 
 	// BypassAliasCheckAccounts is a list of account IDs that will be allowed to bypass the alias check.
 	// This is useful for accounts that don't have an alias for a number of reasons, it must be used with a cli
@@ -75,7 +79,9 @@ func (c *Config) Load(path string) error {
 		return err
 	}
 
-	c.BlocklistAliasKeywords = append(c.BlocklistAliasKeywords, "prod")
+	if !c.NoBlocklistTermsDefault {
+		c.BlocklistTerms = append(c.BlocklistTerms, "prod")
+	}
 
 	return nil
 }
@@ -115,7 +121,7 @@ func (c *Config) ValidateAccount(accountID string, aliases []string, skipAliasCh
 	}
 
 	for _, alias := range aliases {
-		for _, keyword := range c.BlocklistAliasKeywords {
+		for _, keyword := range c.BlocklistTerms {
 			if strings.Contains(strings.ToLower(alias), keyword) {
 				return fmt.Errorf("you are trying to nuke an account with the alias '%s', "+
 					"but it contains the blocklisted keyword '%s'. Aborting", alias, keyword)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -69,12 +69,12 @@ func TestConfig_LoadExample(t *testing.T) {
 						},
 					},
 					ResourceTypes: libconfig.ResourceTypes{
-						Targets: types.Collection{"S3Bucket"},
+						Includes: types.Collection{"S3Bucket"},
 					},
 				},
 			},
 			ResourceTypes: libconfig.ResourceTypes{
-				Targets:  types.Collection{"DynamoDBTable", "S3Bucket", "S3Object"},
+				Includes: types.Collection{"DynamoDBTable", "S3Bucket", "S3Object"},
 				Excludes: types.Collection{"IAMRole"},
 			},
 			Presets: map[string]libconfig.Preset{
@@ -111,7 +111,69 @@ func TestConfig_LoadExample(t *testing.T) {
 				},
 			},
 		},
-		BlocklistAliasKeywords: []string{"prod"},
+		BlocklistTerms: []string{"prod"},
+	}
+
+	assert.Equal(t, expect, *config)
+}
+
+func TestConfig_NoBlocklistTermsProd(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	entry := logrus.WithField("test", true)
+
+	config, err := New(libconfig.Options{
+		Path: "testdata/no-blocklist-term-prod.yaml",
+		Log:  entry,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := Config{
+		Config: &libconfig.Config{
+			Blocklist: []string{"012345678901"},
+			Regions:   []string{"global", "us-east-1"},
+			Accounts: map[string]*libconfig.Account{
+				"555133742": {
+					Presets: []string{"terraform"},
+					Filters: filter.Filters{
+						"IAMRole": {
+							filter.NewExactFilter("uber.admin"),
+						},
+						"IAMRolePolicyAttachment": {
+							filter.NewExactFilter("uber.admin -> AdministratorAccess"),
+						},
+					},
+					ResourceTypes: libconfig.ResourceTypes{
+						Includes: types.Collection{"S3Bucket"},
+					},
+				},
+			},
+			ResourceTypes: libconfig.ResourceTypes{
+				Includes: types.Collection{"DynamoDBTable", "S3Bucket", "S3Object"},
+				Excludes: types.Collection{"IAMRole"},
+			},
+			Presets: map[string]libconfig.Preset{
+				"terraform": {
+					Filters: filter.Filters{
+						"S3Bucket": {
+							filter.Filter{
+								Type:   filter.Glob,
+								Value:  "my-statebucket-*",
+								Values: []string{},
+							},
+						},
+					},
+				},
+			},
+			Settings:     &settings.Settings{},
+			Deprecations: make(map[string]string),
+			Log:          entry,
+		},
+		CustomEndpoints:         CustomEndpoints{},
+		BlocklistTerms:          []string{"alpha"},
+		NoBlocklistTermsDefault: true,
 	}
 
 	assert.Equal(t, expect, *config)
@@ -387,7 +449,7 @@ func TestConfig_ValidateAccount_Blocklist(t *testing.T) {
 
 	// Add an account to the blocklist
 	config.Blocklist = append(config.Blocklist, "1234567890")
-	config.BlocklistAliasKeywords = append(config.BlocklistAliasKeywords, "alpha-tango")
+	config.BlocklistTerms = append(config.BlocklistTerms, "alpha-tango")
 
 	// Test cases
 	cases := []struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -111,6 +111,7 @@ func TestConfig_LoadExample(t *testing.T) {
 				},
 			},
 		},
+		BlocklistAliasKeywords: []string{"prod"},
 	}
 
 	assert.Equal(t, expect, *config)

--- a/pkg/config/testdata/no-blocklist-term-prod.yaml
+++ b/pkg/config/testdata/no-blocklist-term-prod.yaml
@@ -1,20 +1,15 @@
 ---
 regions:
-  - "eu-west-1"
-  - stratoscale
+  - global
+  - us-east-1
 
 blocklist:
-  - 1234567890
+  - 012345678901
 
-endpoints:
-  - region: stratoscale
-    tls_insecure_skip_verify: true
-    services:
-      - service: ec2
-        url: https://stratoscale.cloud.internal/api/v2/aws/ec2
-      - service: s3
-        url: https://stratoscale.cloud.internal:1060
-        tls_insecure_skip_verify: true
+blocklist-terms:
+  - alpha
+
+no-blocklist-terms-default: true
 
 resource-types:
   includes:


### PR DESCRIPTION
## Overview

- This adds support for expanding the list of terms that will be used to block aliases.
- This also adds support for **REMOVING** the default blocklist terms like `prod` from the alias checks.

**Note:** if you use the Bypass Alias Check, this feature has no affect, as all alias checking is disabled. 
