### PR TITLE
feat: expand lister opts to include account id and logger

### DIFF
--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gotidy/ptr"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
@@ -184,7 +185,12 @@ func execute(c *cli.Context) error { //nolint:funlen,gocyclo
 
 		// Step 2 - Create the scannerActual object
 		scannerActual := scanner.New(regionName, resourceTypes, &nuke.ListerOpts{
-			Region: region,
+			Region:    region,
+			AccountID: ptr.String(account.ID()),
+			Logger: logrus.WithFields(logrus.Fields{
+				"component": "scanner",
+				"region":    regionName,
+			}),
 		})
 
 		// Step 3 - Register a mutate function that will be called to modify the lister options for each resource type

--- a/pkg/nuke/resource.go
+++ b/pkg/nuke/resource.go
@@ -1,6 +1,8 @@
 package nuke
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -13,8 +15,10 @@ const Account registry.Scope = "account"
 // so that each implementing tool can define their own options for the lister. Each resource then asserts the type on
 // the interface{} to get the options it needs.
 type ListerOpts struct {
-	Region  *Region
-	Session *session.Session
+	Region    *Region
+	Session   *session.Session
+	AccountID *string
+	Logger    *logrus.Entry
 }
 
 // MutateOpts is a function that will be called for each resource type to mutate the options for the scanner based on
@@ -29,5 +33,12 @@ var MutateOpts = func(opts interface{}, resourceType string) interface{} {
 	}
 
 	o.Session = session
+
+	if o.Logger != nil {
+		o.Logger = o.Logger.WithField("resource", resourceType)
+	} else {
+		o.Logger = logrus.WithField("resource", resourceType)
+	}
+
 	return o
 }

--- a/resources/athena-work-group.go
+++ b/resources/athena-work-group.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/aws/aws-sdk-go/service/sts"
-
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/types"
@@ -37,18 +35,9 @@ func (l *AthenaWorkGroupLister) List(_ context.Context, o interface{}) ([]resour
 	svc := athena.New(opts.Session)
 	resources := make([]resource.Resource, 0)
 
-	// Lookup current account ID
-	stsSvc := sts.New(opts.Session)
-	callerID, err := stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-	if err != nil {
-		return nil, err
-	}
-	accountID := callerID.Account
-	region := svc.Config.Region
-
 	// List WorkGroup
 	var workgroupNames []*string
-	err = svc.ListWorkGroupsPages(
+	err := svc.ListWorkGroupsPages(
 		&athena.ListWorkGroupsInput{},
 		func(page *athena.ListWorkGroupsOutput, lastPage bool) bool {
 			for _, workgroup := range page.WorkGroups {
@@ -70,7 +59,7 @@ func (l *AthenaWorkGroupLister) List(_ context.Context, o interface{}) ([]resour
 			// so we need to construct one ourselves
 			arn: aws.String(fmt.Sprintf(
 				"arn:aws:athena:%s:%s:workgroup/%s",
-				*region, *accountID, *name,
+				opts.Region.Name, *opts.AccountID, *name,
 			)),
 		})
 	}

--- a/resources/autoscaling-launch-configurations_mock_test.go
+++ b/resources/autoscaling-launch-configurations_mock_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_autoscalingiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_AutoScalingLaunchConfiguration_List(t *testing.T) {
@@ -42,12 +40,7 @@ func Test_Mock_AutoScalingLaunchConfiguration_List(t *testing.T) {
 		mockSvc: mockSvc,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 
 	a.Nil(err)
 	a.Len(resources, 1)

--- a/resources/autoscaling-lifecycle-hooks_mock_test.go
+++ b/resources/autoscaling-lifecycle-hooks_mock_test.go
@@ -8,11 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_autoscalingiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_AutoScalingLifeCycleHook_List(t *testing.T) {
@@ -47,12 +45,7 @@ func Test_Mock_AutoScalingLifeCycleHook_List(t *testing.T) {
 		mockSvc: mockSvc,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession(&aws.Config{})),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 
 	a.NoError(err)
 	a.Len(resources, 1)

--- a/resources/dynamodb-backup_mock_test.go
+++ b/resources/dynamodb-backup_mock_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_dynamodbiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_DynamoDBBackup_List(t *testing.T) {
@@ -41,12 +39,7 @@ func Test_Mock_DynamoDBBackup_List(t *testing.T) {
 		mockSvc: mockSvc,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 }

--- a/resources/dynamodb-table_mock_test.go
+++ b/resources/dynamodb-table_mock_test.go
@@ -9,13 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 
 	libsettings "github.com/ekristen/libnuke/pkg/settings"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_dynamodbiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_DynamoDBTable_List(t *testing.T) {
@@ -54,12 +52,7 @@ func Test_Mock_DynamoDBTable_List(t *testing.T) {
 		mockSvc: mockSvc,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.NoError(err)
 	a.Len(resources, 1)
 }

--- a/resources/ecs-clusters_mock_test.go
+++ b/resources/ecs-clusters_mock_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_ecsiface"
-
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_ECSCluster_List(t *testing.T) {
@@ -51,7 +49,7 @@ func Test_Mock_ECSCluster_List(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := ecsClusterLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := ecsClusterLister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 

--- a/resources/ecs-task_mock_test.go
+++ b/resources/ecs-task_mock_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_ecsiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_ECSTask_List(t *testing.T) {
@@ -55,7 +54,7 @@ func Test_Mock_ECSTask_List(t *testing.T) {
 		mockSvc: mockECS,
 	}
 
-	resources, err := ecsTaskLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := ecsTaskLister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 }

--- a/resources/elasticache-cachecluster_mock_test.go
+++ b/resources/elasticache-cachecluster_mock_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_elasticacheiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 	"github.com/ekristen/aws-nuke/v3/pkg/testsuite"
 )
 
@@ -97,7 +96,7 @@ func Test_Mock_ElastiCache_CacheCluster_List_NoTags(t *testing.T) {
 		ResourceName: ptr.String("arn:aws:elasticache:us-west-2:123456789012:serverless:foobar"),
 	}).Return(&elasticache.TagListMessage{}, nil)
 
-	resources, err := cacheClusterLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := cacheClusterLister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 2)
 
@@ -150,7 +149,7 @@ func Test_Mock_ElastiCache_CacheCluster_List_WithTags(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := cacheClusterLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := cacheClusterLister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 2)
 
@@ -215,7 +214,7 @@ func Test_Mock_ElastiCache_CacheCluster_List_TagsInvalidARN(t *testing.T) {
 		ResourceName: ptr.String("foobar:invalid:arn"),
 	}).Return(nil, awserr.New(elasticache.ErrCodeInvalidARNFault, elasticache.ErrCodeInvalidARNFault, nil))
 
-	resources, err := cacheClusterLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := cacheClusterLister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 2)
 

--- a/resources/elasticache-subnetgroups_mock_test.go
+++ b/resources/elasticache-subnetgroups_mock_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_elasticacheiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_ElastiCache_SubnetGroup_Remove(t *testing.T) {
@@ -59,7 +58,7 @@ func Test_Mock_ElastiCache_SubnetGroup_List_NoTags(t *testing.T) {
 		ResourceName: aws.String("arn:aws:elasticache:us-west-2:123456789012:subnet-group:foobar"),
 	}).Return(&elasticache.TagListMessage{}, nil)
 
-	resources, err := subnetGroupsLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := subnetGroupsLister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 
@@ -104,7 +103,7 @@ func Test_Mock_ElastiCache_SubnetGroup_List_WithTags(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := subnetGroupsLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := subnetGroupsLister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 
 	a.Len(resources, 1)

--- a/resources/glue-securityconfiguration_mock_test.go
+++ b/resources/glue-securityconfiguration_mock_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/glue"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_glueiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_GlueSecurityConfiguration_Remove(t *testing.T) {
@@ -53,7 +52,7 @@ func Test_Mock_GlueSecurityConfiguration_List(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := resource.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := resource.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 	a.Equal("foobar", *resources[0].(*GlueSecurityConfiguration).name)
@@ -90,7 +89,7 @@ func Test_Mock_GlueSecurityConfiguration_ListNext(t *testing.T) {
 		NextToken: &[]string{""}[0], // empty string to break the loop or nil
 	}, nil)
 
-	resources, err := resource.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := resource.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 2)
 	a.Equal("foobar1", *resources[0].(*GlueSecurityConfiguration).name)

--- a/resources/iam-instance-profile-role_mock_test.go
+++ b/resources/iam-instance-profile-role_mock_test.go
@@ -10,11 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_IAMInstanceProfileRole_List(t *testing.T) {
@@ -59,12 +57,7 @@ func Test_Mock_IAMInstanceProfileRole_List(t *testing.T) {
 		mockSvc: mockIAM,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 }

--- a/resources/iam-instance-profile_mock_test.go
+++ b/resources/iam-instance-profile_mock_test.go
@@ -10,11 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_IAMInstanceProfile_List(t *testing.T) {
@@ -69,12 +67,7 @@ func Test_Mock_IAMInstanceProfile_List(t *testing.T) {
 		mockSvc: mockIAM,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 
 	a.Nil(err)
 	a.Len(resources, 1)

--- a/resources/iam-login-profile_mock_test.go
+++ b/resources/iam-login-profile_mock_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_IAMLoginProfile_List(t *testing.T) {
@@ -48,12 +46,7 @@ func Test_Mock_IAMLoginProfile_List(t *testing.T) {
 		mockSvc: mockIAM,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 }

--- a/resources/iam-role_mock_test.go
+++ b/resources/iam-role_mock_test.go
@@ -10,13 +10,11 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	libsettings "github.com/ekristen/libnuke/pkg/settings"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_IAMRole_List(t *testing.T) {
@@ -55,12 +53,7 @@ func Test_Mock_IAMRole_List(t *testing.T) {
 		mockSvc: mockIAM,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 

--- a/resources/iam-user-mfa-device_mock_test.go
+++ b/resources/iam-user-mfa-device_mock_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_IAMUserMFADevice_List(t *testing.T) {
@@ -50,12 +48,7 @@ func Test_Mock_IAMUserMFADevice_List(t *testing.T) {
 		mockSvc: mockIAM,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.NoError(err)
 	a.Len(resources, 1)
 }

--- a/resources/iam-user_mock_test.go
+++ b/resources/iam-user_mock_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_IAMUser_List(t *testing.T) {
@@ -46,12 +44,7 @@ func Test_Mock_IAMUser_List(t *testing.T) {
 		mockSvc: mockIAM,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.NoError(err)
 	a.Len(resources, 1)
 }

--- a/resources/iam-virtual-mfa-device_mock_test.go
+++ b/resources/iam-virtual-mfa-device_mock_test.go
@@ -8,11 +8,9 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_IAMVirtualMFADevice_List(t *testing.T) {
@@ -50,12 +48,7 @@ func Test_Mock_IAMVirtualMFADevice_List(t *testing.T) {
 		mockSvc: mockIAM,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 3)
 }

--- a/resources/kms-alias_mock_test.go
+++ b/resources/kms-alias_mock_test.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_kmsiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_KMSAlias_List(t *testing.T) {
@@ -40,12 +38,7 @@ func Test_Mock_KMSAlias_List(t *testing.T) {
 		mockSvc: mockKMS,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.NoError(err)
 	a.Len(resources, 2)
 }
@@ -65,12 +58,7 @@ func Test_Mock_KMSAlias_List_Error(t *testing.T) {
 		mockSvc: mockKMS,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Error(err)
 	a.Nil(resources)
 	a.EqualError(err, "BadRequest: 400 Bad Request")

--- a/resources/kms-key_mock_test.go
+++ b/resources/kms-key_mock_test.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_kmsiface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_KMSKey_List(t *testing.T) {
@@ -62,12 +60,7 @@ func Test_Mock_KMSKey_List(t *testing.T) {
 		mockSvc: mockKMS,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.NoError(err)
 	a.Len(resources, 1)
 }
@@ -134,12 +127,7 @@ func Test_Mock_KMSKey_List_WithAccessDenied(t *testing.T) {
 		mockSvc: mockKMS,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.NoError(err)
 	a.Len(resources, 1)
 }

--- a/resources/opsworks-userprofiles.go
+++ b/resources/opsworks-userprofiles.go
@@ -33,7 +33,6 @@ func (l *OpsWorksUserProfileLister) List(_ context.Context, o interface{}) ([]re
 	resources := make([]resource.Resource, 0)
 
 	// TODO: pass in account information via ListerOpts to avoid additional calls.
-
 	identityOutput, err := sts.New(opts.Session).GetCallerIdentity(nil)
 	if err != nil {
 		return nil, err

--- a/resources/quicksight-subscriptions_mock_test.go
+++ b/resources/quicksight-subscriptions_mock_test.go
@@ -21,7 +21,7 @@ func Test_Mock_QuicksightSubscription_List_ValidSubscription(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 	quickSightAccountInfo := quicksight.AccountInfo{
 		AccountName:               aws.String("AccountName"),
 		NotificationEmail:         aws.String("notification@email.com"),
@@ -31,7 +31,7 @@ func Test_Mock_QuicksightSubscription_List_ValidSubscription(t *testing.T) {
 	mockQuickSightAPI := mock_quicksightiface.NewMockQuickSightAPI(ctrl)
 
 	mockQuickSightAPI.EXPECT().DescribeAccountSubscription(&quicksight.DescribeAccountSubscriptionInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(&quicksight.DescribeAccountSubscriptionOutput{
 		AccountInfo: &quickSightAccountInfo,
 	}, nil)
@@ -56,7 +56,7 @@ func Test_Mock_QuicksightSubscription_List_SubscriptionNotFound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 	quickSightSubscriptionNotFoundError := &quicksight.ResourceNotFoundException{
 		Message_: aws.String("Resource not found"),
 	}
@@ -64,7 +64,7 @@ func Test_Mock_QuicksightSubscription_List_SubscriptionNotFound(t *testing.T) {
 	mockQuickSightAPI := mock_quicksightiface.NewMockQuickSightAPI(ctrl)
 
 	mockQuickSightAPI.EXPECT().DescribeAccountSubscription(&quicksight.DescribeAccountSubscriptionInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(nil, quickSightSubscriptionNotFoundError)
 
 	quicksightSubscriptionListener := QuickSightSubscriptionLister{
@@ -81,12 +81,12 @@ func Test_Mock_QuicksightSubscription_List_ErrorOnQuicksight(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 
 	mockQuickSightAPI := mock_quicksightiface.NewMockQuickSightAPI(ctrl)
 
 	mockQuickSightAPI.EXPECT().DescribeAccountSubscription(&quicksight.DescribeAccountSubscriptionInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(nil, errors.New("MOCK_ERROR"))
 
 	quicksightSubscriptionListener := QuickSightSubscriptionLister{
@@ -103,7 +103,7 @@ func Test_Mock_QuicksightSubscription_Remove_No_Settings(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 	subscriptionName := aws.String("Name")
 	subscriptionDefaultNamespace := aws.String("Default")
 	subscriptionNotificationEmail := aws.String("notification@email.com")
@@ -113,7 +113,7 @@ func Test_Mock_QuicksightSubscription_Remove_No_Settings(t *testing.T) {
 	mockQuickSightAPI := mock_quicksightiface.NewMockQuickSightAPI(ctrl)
 
 	mockQuickSightAPI.EXPECT().DescribeAccountSettings(&quicksight.DescribeAccountSettingsInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(&quicksight.DescribeAccountSettingsOutput{
 		AccountSettings: &quicksight.AccountSettings{
 			DefaultNamespace:             subscriptionDefaultNamespace,
@@ -123,19 +123,19 @@ func Test_Mock_QuicksightSubscription_Remove_No_Settings(t *testing.T) {
 	}, nil).Times(0)
 
 	mockQuickSightAPI.EXPECT().UpdateAccountSettings(&quicksight.UpdateAccountSettingsInput{
-		AwsAccountId:                 &accountID,
+		AwsAccountId:                 accountID,
 		DefaultNamespace:             subscriptionDefaultNamespace,
 		NotificationEmail:            subscriptionNotificationEmail,
 		TerminationProtectionEnabled: aws.Bool(false),
 	}).Return(&quicksight.UpdateAccountSettingsOutput{}, nil).Times(0)
 
 	mockQuickSightAPI.EXPECT().DeleteAccountSubscription(&quicksight.DeleteAccountSubscriptionInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(&quicksight.DeleteAccountSubscriptionOutput{}, nil).Times(1)
 
 	quicksightSubscription := QuickSightSubscription{
 		svc:               mockQuickSightAPI,
-		accountID:         &accountID,
+		accountID:         accountID,
 		name:              subscriptionName,
 		notificationEmail: subscriptionNotificationEmail,
 		edition:           subscriptionEdition,
@@ -152,7 +152,7 @@ func Test_Mock_QuicksightSubscription_Remove_TerminationSetting_Is_False(t *test
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 	subscriptionName := aws.String("Name")
 	subscriptionDefaultNamespace := aws.String("Default")
 	subscriptionNotificationEmail := aws.String("notification@email.com")
@@ -164,7 +164,7 @@ func Test_Mock_QuicksightSubscription_Remove_TerminationSetting_Is_False(t *test
 	mockQuickSightAPI := mock_quicksightiface.NewMockQuickSightAPI(ctrl)
 
 	mockQuickSightAPI.EXPECT().DescribeAccountSettings(&quicksight.DescribeAccountSettingsInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(&quicksight.DescribeAccountSettingsOutput{
 		AccountSettings: &quicksight.AccountSettings{
 			DefaultNamespace:             subscriptionDefaultNamespace,
@@ -174,19 +174,19 @@ func Test_Mock_QuicksightSubscription_Remove_TerminationSetting_Is_False(t *test
 	}, nil).Times(0)
 
 	mockQuickSightAPI.EXPECT().UpdateAccountSettings(&quicksight.UpdateAccountSettingsInput{
-		AwsAccountId:                 &accountID,
+		AwsAccountId:                 accountID,
 		DefaultNamespace:             subscriptionDefaultNamespace,
 		NotificationEmail:            subscriptionNotificationEmail,
 		TerminationProtectionEnabled: aws.Bool(false),
 	}).Return(&quicksight.UpdateAccountSettingsOutput{}, nil).Times(0)
 
 	mockQuickSightAPI.EXPECT().DeleteAccountSubscription(&quicksight.DeleteAccountSubscriptionInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(&quicksight.DeleteAccountSubscriptionOutput{}, nil).Times(1)
 
 	quicksightSubscription := QuickSightSubscription{
 		svc:               mockQuickSightAPI,
-		accountID:         &accountID,
+		accountID:         accountID,
 		name:              subscriptionName,
 		notificationEmail: subscriptionNotificationEmail,
 		edition:           subscriptionEdition,
@@ -204,7 +204,7 @@ func Test_Mock_QuicksightSubscription_Remove_TerminationSetting_Is_True(t *testi
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 	subscriptionName := aws.String("Name")
 	subscriptionDefaultNamespace := aws.String("Default")
 	subscriptionNotificationEmail := aws.String("notification@email.com")
@@ -216,7 +216,7 @@ func Test_Mock_QuicksightSubscription_Remove_TerminationSetting_Is_True(t *testi
 	mockQuickSightAPI := mock_quicksightiface.NewMockQuickSightAPI(ctrl)
 
 	mockQuickSightAPI.EXPECT().DescribeAccountSettings(&quicksight.DescribeAccountSettingsInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(&quicksight.DescribeAccountSettingsOutput{
 		AccountSettings: &quicksight.AccountSettings{
 			DefaultNamespace:             subscriptionDefaultNamespace,
@@ -226,19 +226,19 @@ func Test_Mock_QuicksightSubscription_Remove_TerminationSetting_Is_True(t *testi
 	}, nil).Times(1)
 
 	mockQuickSightAPI.EXPECT().UpdateAccountSettings(&quicksight.UpdateAccountSettingsInput{
-		AwsAccountId:                 &accountID,
+		AwsAccountId:                 accountID,
 		DefaultNamespace:             subscriptionDefaultNamespace,
 		NotificationEmail:            subscriptionNotificationEmail,
 		TerminationProtectionEnabled: aws.Bool(false),
 	}).Return(&quicksight.UpdateAccountSettingsOutput{}, nil).Times(1)
 
 	mockQuickSightAPI.EXPECT().DeleteAccountSubscription(&quicksight.DeleteAccountSubscriptionInput{
-		AwsAccountId: &accountID,
+		AwsAccountId: accountID,
 	}).Return(&quicksight.DeleteAccountSubscriptionOutput{}, nil).Times(1)
 
 	quicksightSubscription := QuickSightSubscription{
 		svc:               mockQuickSightAPI,
-		accountID:         &accountID,
+		accountID:         accountID,
 		name:              subscriptionName,
 		notificationEmail: subscriptionNotificationEmail,
 		edition:           subscriptionEdition,
@@ -254,14 +254,14 @@ func Test_Mock_QuicksightSubscription_Remove_TerminationSetting_Is_True(t *testi
 func Test_Mock_QuicksightSubscription_Filter(t *testing.T) {
 	assertions := assert.New(t)
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 	subscriptionName := aws.String("Name")
 	subscriptionNotificationEmail := aws.String("notification@email.com")
 	subscriptionEdition := aws.String("Edition")
 	subscriptionStatus := aws.String("ACCOUNT_CREATED")
 
 	quicksightSubscription := QuickSightSubscription{
-		accountID:         &accountID,
+		accountID:         accountID,
 		name:              subscriptionName,
 		notificationEmail: subscriptionNotificationEmail,
 		edition:           subscriptionEdition,
@@ -276,14 +276,14 @@ func Test_Mock_QuicksightSubscription_Filter(t *testing.T) {
 func Test_Mock_QuicksightSubscription_Filter_Status(t *testing.T) {
 	assertions := assert.New(t)
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 	subscriptionName := aws.String("Name")
 	subscriptionNotificationEmail := aws.String("notification@email.com")
 	subscriptionEdition := aws.String("Edition")
 	subscriptionStatus := aws.String("UNSUBSCRIBED")
 
 	quicksightSubscription := QuickSightSubscription{
-		accountID:         &accountID,
+		accountID:         accountID,
 		name:              subscriptionName,
 		notificationEmail: subscriptionNotificationEmail,
 		edition:           subscriptionEdition,
@@ -298,14 +298,14 @@ func Test_Mock_QuicksightSubscription_Filter_Status(t *testing.T) {
 func Test_Mock_QuicksightSubscription_Filter_Name(t *testing.T) {
 	assertions := assert.New(t)
 
-	accountID := "012345678901"
+	accountID := testListerOpts.AccountID
 	subscriptionName := aws.String("NOT_AVAILABLE")
 	subscriptionNotificationEmail := aws.String("notification@email.com")
 	subscriptionEdition := aws.String("Edition")
 	subscriptionStatus := aws.String("ACCOUNT_CREATED")
 
 	quicksightSubscription := QuickSightSubscription{
-		accountID:         &accountID,
+		accountID:         accountID,
 		name:              subscriptionName,
 		notificationEmail: subscriptionNotificationEmail,
 		edition:           subscriptionEdition,

--- a/resources/quicksight-subscriptions_mock_test.go
+++ b/resources/quicksight-subscriptions_mock_test.go
@@ -44,7 +44,7 @@ func Test_Mock_QuicksightSubscription_List_ValidSubscription(t *testing.T) {
 	assertions.Nil(err)
 
 	resource := resources[0].(*QuickSightSubscription)
-	assertions.Equal(*resource.accountID, accountID)
+	assertions.Equal(resource.accountID, accountID)
 	assertions.Equal(resource.edition, quickSightAccountInfo.Edition)
 	assertions.Equal(resource.name, quickSightAccountInfo.AccountName)
 	assertions.Equal(resource.notificationEmail, quickSightAccountInfo.NotificationEmail)

--- a/resources/quicksight_mock_test.go
+++ b/resources/quicksight_mock_test.go
@@ -1,0 +1,5 @@
+//go:generate ../mocks/generate_mocks.sh quicksight quicksightiface
+
+package resources
+
+// Note: this file is empty on purpose

--- a/resources/route53-resolver-rule_mock_test.go
+++ b/resources/route53-resolver-rule_mock_test.go
@@ -10,13 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 
 	"github.com/ekristen/libnuke/pkg/resource"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_route53resolveriface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_Route53ResolverRule_List(t *testing.T) {
@@ -67,12 +65,7 @@ func Test_Mock_Route53ResolverRule_List(t *testing.T) {
 		mockSvc: mockRoute53Resolver,
 	}
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession()),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 3)
 

--- a/resources/sagemaker-domain_test.go
+++ b/resources/sagemaker-domain_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ekristen/libnuke/pkg/resource"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_sagemakeriface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 // TestSageMakerDomain_List is a unit test function to test the list of SageMakerDomain via mocked interface
@@ -62,7 +61,7 @@ func TestSageMakerDomain_List(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := sagemakerDomainLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := sagemakerDomainLister.List(context.TODO(), testListerOpts)
 	a.NoError(err)
 	a.Len(resources, 1)
 	a.Equal([]resource.Resource{&sagemakerDomain}, resources)

--- a/resources/sagemaker-userprofiles_mock_test.go
+++ b/resources/sagemaker-userprofiles_mock_test.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/sagemaker"
 
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
-
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_sagemakeriface"
 )
 
@@ -57,7 +55,7 @@ func Test_Mock_SageMakerUserProfiles_List(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := resource.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := resource.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 

--- a/resources/secretsmanager-secret_mock_test.go
+++ b/resources/secretsmanager-secret_mock_test.go
@@ -8,12 +8,9 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_secretsmanageriface"
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_SecretsManager_List(t *testing.T) {
@@ -47,12 +44,7 @@ func Test_Mock_SecretsManager_List(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := lister.List(context.TODO(), &nuke.ListerOpts{
-		Region: &nuke.Region{
-			Name: "us-east-2",
-		},
-		Session: session.Must(session.NewSession(&aws.Config{})),
-	})
+	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 2)
 

--- a/resources/servicediscovery-namespaces_mock_test.go
+++ b/resources/servicediscovery-namespaces_mock_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_servicediscoveryiface"
-
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_ServiceDiscoveryNamespace_List(t *testing.T) {
@@ -47,7 +45,7 @@ func Test_Mock_ServiceDiscoveryNamespace_List(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := resource.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := resource.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 }
@@ -76,7 +74,7 @@ func Test_Mock_ServiceDiscoveryNamespace_List_NoTags(t *testing.T) {
 		ResourceARN: ptr.String("arn:aws:servicediscovery:us-west-2:123456789012:namespace/id"),
 	})).Return(&servicediscovery.ListTagsForResourceOutput{}, nil)
 
-	resources, err := resource.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := resource.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 }
@@ -105,7 +103,7 @@ func Test_Mock_ServiceDiscoveryNamespace_List_TagError(t *testing.T) {
 		ResourceARN: ptr.String("arn:aws:servicediscovery:us-west-2:123456789012:namespace/id"),
 	})).Return(&servicediscovery.ListTagsForResourceOutput{}, fmt.Errorf("error"))
 
-	resources, err := resource.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := resource.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 

--- a/resources/sqs-queues_mock_test.go
+++ b/resources/sqs-queues_mock_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_sqsiface"
-
-	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 func Test_Mock_SQSQueues_List(t *testing.T) {
@@ -38,7 +36,7 @@ func Test_Mock_SQSQueues_List(t *testing.T) {
 		},
 	}, nil)
 
-	resources, err := sqsQueueLister.List(context.TODO(), &nuke.ListerOpts{})
+	resources, err := sqsQueueLister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
 	a.Len(resources, 1)
 

--- a/resources/testsuite_test.go
+++ b/resources/testsuite_test.go
@@ -1,0 +1,17 @@
+package resources
+
+import (
+	"github.com/gotidy/ptr"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+var testListerOpts = &nuke.ListerOpts{
+	Region: &nuke.Region{
+		Name: "us-east-2",
+	},
+	Session:   session.Must(session.NewSession()),
+	AccountID: ptr.String("012345678901"),
+}


### PR DESCRIPTION
This is primarily a performance enhancement PR. It now passes a logger and account ID from the start via the ListerOpts to all Lister functions so that we can reduce all the extra sts API calls that were being performed.