### PR TITLE
feat: various fixes and features - october

### DIFF
--- a/docs/config-contrib.md
+++ b/docs/config-contrib.md
@@ -40,6 +40,9 @@ presets:
       CloudWatchEventsRule:
         - type: "contains"
           value: "aws-controltower"
+        - property: "Name"
+          type: glob
+          value: "AWSControlTower*"
       EC2VPCEndpoint:
         - type: "contains"
           value: "aws-controltower"
@@ -57,6 +60,8 @@ presets:
       CloudWatchEventsTarget:
         - type: "contains"
           value: "aws-controltower"
+        - type: "glob"
+          value: "Rule: AWSControlTower*"
       SNSSubscription:
         - type: "contains"
           value: "aws-controltower"
@@ -97,4 +102,6 @@ presets:
       IAMRolePolicy:
         - type: "contains"
           value: "aws-controltower"
+        - type: glob
+          value: "AWSReservedSSO_*"
 ```

--- a/docs/config-contrib.md
+++ b/docs/config-contrib.md
@@ -1,0 +1,100 @@
+# Config Contributions
+
+## Community Presets
+
+These are a collection of presets from the community. 
+
+!!! warning
+    These presets are built from feedback from the community, they are not routinely tested. Use at your own risk.
+
+### Filter SSO Resources
+
+This is a preset to filter out AWS SSO resources.
+
+```yaml
+presets:
+  sso:
+    filters:
+      IAMSAMLProvider:
+        - type: "regex"
+          value: "AWSSSO_.*_DO_NOT_DELETE"
+      IAMRole:
+        - type: "glob"
+          value: "AWSReservedSSO_*"
+      IAMRolePolicyAttachment:
+        - type: "glob"
+          value: "AWSReservedSSO_*"
+```
+
+### Filter Control Tower
+
+This is a preset to filter out AWS Control Tower resources.
+
+```yaml
+presets:
+  controltower:
+    filters:
+      CloudTrailTrail:
+        - type: "contains"
+          value: "aws-controltower"
+      CloudWatchEventsRule:
+        - type: "contains"
+          value: "aws-controltower"
+      EC2VPCEndpoint:
+        - type: "contains"
+          value: "aws-controltower"
+      EC2VPC:
+        - type: "contains"
+          value: "aws-controltower"
+      OpsWorksUserProfile:
+        - type: "contains"
+          value: "AWSControlTowerExecution"
+      CloudWatchLogsLogGroup:
+        - type: "contains"
+          value: "aws-controltower"
+        - type: "contains"
+          value: "AWSControlTowerBP"
+      CloudWatchEventsTarget:
+        - type: "contains"
+          value: "aws-controltower"
+      SNSSubscription:
+        - type: "contains"
+          value: "aws-controltower"
+      SNSTopic:
+        - type: "contains"
+          value: "aws-controltower"
+      EC2Subnet:
+        - type: "contains"
+          value: "aws-controltower"
+      ConfigServiceDeliveryChannel:
+        - type: "contains"
+          value: "aws-controltower"
+      ConfigServiceConfigurationRecorder:
+        - type: "contains"
+          value: "aws-controltower"
+      CloudFormationStack:
+        - type: "contains"
+          value: "AWSControlTower"
+      EC2RouteTable:
+        - type: "contains"
+          value: "aws-controltower"
+      LambdaFunction:
+        - type: "contains"
+          value: "aws-controltower"
+      EC2DHCPOption:
+        - type: "contains"
+          value: "aws-controltower"
+      IAMRole:
+        - type: "contains"
+          value: "aws-controltower"
+        - type: "contains"
+          value: "AWSControlTower"
+      IAMRolePolicyAttachment:
+        - type: "contains"
+          value: "aws-controltower"
+        - type: "contains"
+          value: "AWSControlTower"
+      IAMRolePolicy:
+        - type: "contains"
+          value: "aws-controltower"
+```

--- a/docs/resources/ec2-image.md
+++ b/docs/resources/ec2-image.md
@@ -1,6 +1,6 @@
 # EC2 Image
 
-This will remove all IAM Roles an AWS account.
+This will remove all EC2 Images (AMI) in an AWS account.
 
 ## Resource
 

--- a/docs/resources/ec2-image.md
+++ b/docs/resources/ec2-image.md
@@ -1,0 +1,36 @@
+# EC2 Image
+
+This will remove all IAM Roles an AWS account.
+
+## Resource
+
+```text
+EC2Image
+```
+
+## Settings
+
+- `IncludeDisabled`
+- `IncludeDeprecated`
+- `DisableDeregistrationProtection`
+
+### IncludeDisabled
+
+This will include any EC2 Images (AMI) that are disabled in the deletion process. By default, disabled images are excluded
+from the discovery process.
+
+Default is `false`.
+
+### IncludeDeprecated
+
+This will include any EC2 Images (AMI) that are deprecated in the deletion process. By default, deprecated images are excluded
+from the discovery process.
+
+Default is `false`.
+
+### DisableDeregistrationProtection
+
+This will disable the deregistration protection on the EC2 Image (AMI) prior to deletion. By default, deregistration protection
+is not disabled.
+
+Default is `false`.

--- a/docs/resources/iam-role.md
+++ b/docs/resources/iam-role.md
@@ -2,6 +2,12 @@
 
 This will remove all IAM Roles an AWS account.
 
+## Resource
+
+```text
+IAMRole
+```
+
 ## Settings
 
 - `IncludeServiceLinkedRoles`

--- a/docs/resources/overview.md
+++ b/docs/resources/overview.md
@@ -1,0 +1,5 @@
+# Resources Overview
+
+This is the start of the documentation for all resources handled by aws-nuke. Eventually each resource will have its own
+page with detailed information on how to use it, what settings are available, and what the resource does.
+

--- a/docs/resources/s3-bucket.md
+++ b/docs/resources/s3-bucket.md
@@ -13,6 +13,12 @@ This will remove all S3 buckets from an AWS account. The following actions are p
   - This will include bypassing any Object Lock governance retention settings if the `BypassGovernanceRetention`
     setting is set to `true`
 
+## Resource
+
+```text
+S3Bucket
+```
+
 ## Settings
 
 - `BypassGovernanceRetention` 

--- a/docs/resources/s3-object.md
+++ b/docs/resources/s3-object.md
@@ -1,0 +1,22 @@
+# S3Object
+
+!!! warning
+    **You should exclude this resource by default.** Not doing so can lead to deadlocks and hung runs of the tool. In 
+    the next major version of aws-nuke, this resource will be excluded by default.
+
+!!! important
+    This resource is **NOT** required to remove a [S3Bucket](./s3-bucket.md). The `S3Bucket` resource will remove all
+    objects in the bucket as part of the deletion process using a batch removal process.
+
+This removes all objects from S3 buckets in an AWS account while retaining the S3 bucket itself. This resource is
+useful if you want to remove a single object from a bucket, or a subset of objects without removing the entire bucket.
+
+## Resource
+
+```text
+S3Object
+```
+
+## Settings
+
+**No settings available.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - Presets: config-presets.md
     - Custom Endpoints: config-custom-endpoints.md
     - Migration Guide: config-migration.md
+    - Examples & Presets: config-contrib.md
   - Resources:
     - Overview: resources/overview.md
     - Cognito User Pool: resources/cognito-user-pool.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,9 +92,12 @@ nav:
     - Custom Endpoints: config-custom-endpoints.md
     - Migration Guide: config-migration.md
   - Resources:
+    - Overview: resources/overview.md
     - Cognito User Pool: resources/cognito-user-pool.md
+    - EC2 Image: resources/ec2-image.md
     - IAM Role: resources/iam-role.md
     - S3 Bucket: resources/s3-bucket.md
+    - S3 Object: resources/s3-object.md
   - Development:
     - Overview: development.md
     - Contributing: contributing.md

--- a/resources/apigateway-api-key.go
+++ b/resources/apigateway-api-key.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"go.uber.org/ratelimit"
 	"time"
+
+	"go.uber.org/ratelimit"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"

--- a/resources/apigateway-restapis.go
+++ b/resources/apigateway-restapis.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/ratelimit"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 
@@ -15,6 +17,12 @@ import (
 )
 
 const APIGatewayRestAPIResource = "APIGatewayRestAPI"
+
+// Rate limit to avoid throttling when deleting API Gateway Rest APIs
+// The API Gateway Delete Rest API has a limit of 1 request per 30 seconds for each account
+// https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html
+// Note: due to time drift, set to 31 seconds to be safe.
+var deleteRestAPILimit = ratelimit.New(1, ratelimit.Per(32*time.Second))
 
 func init() {
 	registry.Register(&registry.Registration{
@@ -73,6 +81,8 @@ func (l *APIGatewayRestAPILister) List(_ context.Context, o interface{}) ([]reso
 }
 
 func (f *APIGatewayRestAPI) Remove(_ context.Context) error {
+	deleteRestAPILimit.Take()
+
 	_, err := f.svc.DeleteRestApi(&apigateway.DeleteRestApiInput{
 		RestApiId: f.restAPIID,
 	})

--- a/resources/kms-key.go
+++ b/resources/kms-key.go
@@ -98,6 +98,17 @@ func (l *KMSKeyLister) List(_ context.Context, o interface{}) ([]resource.Resour
 				}
 			}
 
+			keyAliases, err := svc.ListAliases(&kms.ListAliasesInput{
+				KeyId: key.KeyId,
+			})
+			if err != nil {
+				logrus.WithError(err).Error("unable to list aliases")
+			}
+
+			if len(keyAliases.Aliases) > 0 {
+				kmsKey.Alias = keyAliases.Aliases[0].AliasName
+			}
+
 			resources = append(resources, kmsKey)
 		}
 
@@ -118,6 +129,7 @@ type KMSKey struct {
 	ID      *string
 	State   *string
 	Manager *string
+	Alias   *string
 	Tags    []*kms.Tag
 }
 

--- a/resources/kms-key_mock_test.go
+++ b/resources/kms-key_mock_test.go
@@ -56,6 +56,14 @@ func Test_Mock_KMSKey_List(t *testing.T) {
 		},
 	)
 
+	mockKMS.EXPECT().ListAliases(&kms.ListAliasesInput{
+		KeyId: aws.String("test-key-id"),
+	}).Return(&kms.ListAliasesOutput{
+		Aliases: []*kms.AliasListEntry{
+			{AliasName: aws.String("alias/test-key-id")},
+		},
+	}, nil)
+
 	lister := KMSKeyLister{
 		mockSvc: mockKMS,
 	}
@@ -123,6 +131,14 @@ func Test_Mock_KMSKey_List_WithAccessDenied(t *testing.T) {
 		},
 	)
 
+	mockKMS.EXPECT().ListAliases(&kms.ListAliasesInput{
+		KeyId: aws.String("test-key-id-1"),
+	}).Return(&kms.ListAliasesOutput{
+		Aliases: []*kms.AliasListEntry{
+			{AliasName: aws.String("alias/test-key-id-1")},
+		},
+	}, nil)
+
 	lister := KMSKeyLister{
 		mockSvc: mockKMS,
 	}
@@ -180,6 +196,7 @@ func Test_Mock_KMSKey_Properties(t *testing.T) {
 		ID:      ptr.String("test-key-id"),
 		State:   ptr.String(kms.KeyStateEnabled),
 		Manager: ptr.String(kms.KeyManagerTypeCustomer),
+		Alias:   ptr.String("alias/test-key-id"),
 		Tags: []*kms.Tag{
 			{TagKey: aws.String("Environment"), TagValue: aws.String("Test")},
 		},
@@ -189,6 +206,7 @@ func Test_Mock_KMSKey_Properties(t *testing.T) {
 	assert.Equal(t, kms.KeyStateEnabled, kmsKey.Properties().Get("State"))
 	assert.Equal(t, kms.KeyManagerTypeCustomer, kmsKey.Properties().Get("Manager"))
 	assert.Equal(t, "Test", kmsKey.Properties().Get("tag:Environment"))
+	assert.Equal(t, "alias/test-key-id", kmsKey.Properties().Get("Alias"))
 }
 
 func Test_Mock_KMSKey_Remove(t *testing.T) {

--- a/resources/neptune-instances.go
+++ b/resources/neptune-instances.go
@@ -32,6 +32,12 @@ func (l *NeptuneInstanceLister) List(_ context.Context, o interface{}) ([]resour
 
 	params := &neptune.DescribeDBInstancesInput{
 		MaxRecords: aws.Int64(100),
+		Filters: []*neptune.Filter{
+			{
+				Name:   aws.String("engine"),
+				Values: []*string{aws.String("neptune")},
+			},
+		},
 	}
 
 	for {

--- a/resources/opensearchservice-pipeline.go
+++ b/resources/opensearchservice-pipeline.go
@@ -1,0 +1,83 @@
+package resources
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/osis"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const OSPipelineResource = "OSPipeline"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:   OSPipelineResource,
+		Scope:  nuke.Account,
+		Lister: &OSPipelineLister{},
+	})
+}
+
+type OSPipelineLister struct{}
+
+func (l *OSPipelineLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	var resources []resource.Resource
+
+	svc := osis.New(opts.Session)
+
+	params := &osis.ListPipelinesInput{}
+
+	for {
+		res, err := svc.ListPipelines(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, p := range res.Pipelines {
+			resources = append(resources, &OSPipeline{
+				svc:       svc,
+				Name:      p.PipelineName,
+				Tags:      p.Tags,
+				Status:    p.Status,
+				CreatedAt: p.CreatedAt,
+			})
+		}
+
+		if res.NextToken == nil {
+			break
+		}
+
+		params.NextToken = res.NextToken
+	}
+
+	return resources, nil
+}
+
+type OSPipeline struct {
+	svc       *osis.OSIS
+	Name      *string
+	Status    *string
+	CreatedAt *time.Time
+	Tags      []*osis.Tag
+}
+
+func (r *OSPipeline) Remove(_ context.Context) error {
+	_, err := r.svc.DeletePipeline(&osis.DeletePipelineInput{
+		PipelineName: r.Name,
+	})
+	return err
+}
+
+func (r *OSPipeline) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *OSPipeline) String() string {
+	return *r.Name
+}


### PR DESCRIPTION
## Overview

Improvements to the documentation around EC2Image and S3Object resource types. Additionally implements rate limiting fixes for API Gateway Rest API and API Key, both of which can only delete 1 resource per 30 seconds. 

- Fixes a bug with `NeptuneInstance` returning non-neptune engine RDS instances.
- Adds new `OSPipeline` resource
- Fixes issue where AWS managed secrets weren't being excluded
- Adds first KMS Alias to KMS Key as property `Alias` for filtering purposes

## References

- Resolves #374 
- Resolves #371
- Resolves #301
- Resolves #132
- Resolves #330
- Resolves #133
- Resolves #334 
- Resolves #367 