### PR TITLE
feat(ec2-vpc-endpoint-connection): add tags to properties

### DIFF
--- a/resources/ec2-vpc-endpoint-connection.go
+++ b/resources/ec2-vpc-endpoint-connection.go
@@ -52,7 +52,7 @@ func (l *EC2VPCEndpointConnectionLister) List(_ context.Context, o interface{}) 
 				VPCEndpointID: endpointConnection.VpcEndpointId,
 				State:         endpointConnection.VpcEndpointState,
 				Owner:         endpointConnection.VpcEndpointOwner,
-				tags:          endpointConnection.Tags,
+				Tags:          endpointConnection.Tags,
 			})
 		}
 
@@ -72,7 +72,7 @@ type EC2VPCEndpointConnection struct {
 	VPCEndpointID *string
 	State         *string
 	Owner         *string
-	tags          []*ec2.Tag
+	Tags          []*ec2.Tag
 }
 
 func (r *EC2VPCEndpointConnection) Filter() error {

--- a/resources/ec2-vpc-endpoint-connection.go
+++ b/resources/ec2-vpc-endpoint-connection.go
@@ -52,6 +52,7 @@ func (l *EC2VPCEndpointConnectionLister) List(_ context.Context, o interface{}) 
 				VPCEndpointID: endpointConnection.VpcEndpointId,
 				State:         endpointConnection.VpcEndpointState,
 				Owner:         endpointConnection.VpcEndpointOwner,
+				tags:          endpointConnection.Tags,
 			})
 		}
 
@@ -71,6 +72,7 @@ type EC2VPCEndpointConnection struct {
 	VPCEndpointID *string
 	State         *string
 	Owner         *string
+	tags          []*ec2.Tag
 }
 
 func (r *EC2VPCEndpointConnection) Filter() error {


### PR DESCRIPTION
* Adds `tags` support for `EC2VPCEndpointConnection` resource
* I see some resources in the repo use `tags` and others use `Tags` for the variable naming. I have picked `tags` as that seems more prevalent