### PR TITLE
fix(kms-key): filter pending replica deletion state

### DIFF
--- a/resources/kms-key.go
+++ b/resources/kms-key.go
@@ -134,8 +134,8 @@ type KMSKey struct {
 }
 
 func (r *KMSKey) Filter() error {
-	if ptr.ToString(r.State) == kms.KeyStatePendingDeletion {
-		return fmt.Errorf("is already in PendingDeletion state")
+	if state := ptr.ToString(r.State); state == kms.KeyStatePendingDeletion || state == kms.KeyStatePendingReplicaDeletion {
+		return fmt.Errorf("is already in %v state", state)
 	}
 
 	if ptr.ToString(r.Manager) == kms.KeyManagerTypeAws {

--- a/resources/kms-key_mock_test.go
+++ b/resources/kms-key_mock_test.go
@@ -168,6 +168,12 @@ func Test_Mock_KMSKey_Filter(t *testing.T) {
 			error:   "is already in PendingDeletion state",
 		},
 		{
+			name:    "pending-replica-deletion-key",
+			state:   kms.KeyStatePendingReplicaDeletion,
+			manager: kms.KeyManagerTypeCustomer,
+			error:   "is already in PendingReplicaDeletion state",
+		},
+		{
 			name:    "enabled-key",
 			state:   kms.KeyStateEnabled,
 			manager: kms.KeyManagerTypeCustomer,


### PR DESCRIPTION
Filter custom KMS keys in `PendingReplicaDeletion` as they've already been scheduled for deletion.

Closes #408