### PR TITLE
docs: fix usage of libnuke and aws-nuke/v3 in examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,14 +113,14 @@ package example
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
-	"github.com/ekristen/libnuke/pkg/settings"
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
 
-	"github.com/ekristen/aws-nuke/pkg/types"
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -111,16 +111,14 @@ use `go fmt` before committing any change.
 package example
 
 import (
-    "context"
-
-    "github.com/sirupsen/logrus"
-	
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	
-	"github.com/ekristen/libnuke/pkg/settings"
-	
-	"github.com/ekristen/aws-nuke/pkg/types"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 ```
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -32,7 +32,7 @@ import (
     "github.com/ekristen/libnuke/pkg/resource"
     "github.com/ekristen/libnuke/pkg/types"
 
-    "github.com/ekristen/aws-nuke/pkg/nuke"
+    "github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 type ExampleResource struct {
@@ -71,7 +71,7 @@ import (
 
 	"github.com/ekristen/libnuke/pkg/resource"
 
-	"github.com/ekristen/aws-nuke/pkg/nuke"
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 type ExampleResourceLister struct{}
@@ -98,7 +98,7 @@ import (
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/types"
 
-	"github.com/ekristen/aws-nuke/pkg/nuke"
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
 type ExampleResourceLister struct{}


### PR DESCRIPTION
This is a minor change on documentation files.

While setting up a new environment I realized [docs/resources.md](docs/resources.md) was out of date with reference to `github.com/ekristen/aws-nuke/pkg/nuke` instead of `github.com/ekristen/aws-nuke/v3/pkg/nuke`

I changed also in [CONTRIBUTING.md](CONTRIBUTING.md) to have a clean import example. It is probaby not a real world problem mostly because the documentation tells to use `tools/create-resource/main.go` but just for cleanup 😄