### PR TITLE
feat(resource): add code guru profiler profiling group resource

### DIFF
--- a/resources/codeguru-profiling-group.go
+++ b/resources/codeguru-profiling-group.go
@@ -1,0 +1,77 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codeguruprofiler"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const CodeGuruProfilingGroupResource = "CodeGuruProfilingGroup"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:   CodeGuruProfilingGroupResource,
+		Scope:  nuke.Account,
+		Lister: &CodeGuruProfilingGroupResourceLister{},
+	})
+}
+
+type CodeGuruProfilingGroupResourceLister struct{}
+
+func (l *CodeGuruProfilingGroupResourceLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	var resources []resource.Resource
+
+	svc := codeguruprofiler.New(opts.Session)
+
+	params := &codeguruprofiler.ListProfilingGroupsInput{
+		IncludeDescription: aws.Bool(true),
+	}
+
+	for {
+		resp, err := svc.ListProfilingGroups(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, group := range resp.ProfilingGroups {
+			resources = append(resources, &CodeGuruProfilingGroup{
+				svc:             svc,
+				ComputePlatform: group.ComputePlatform,
+				Name:            group.Name,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+type CodeGuruProfilingGroup struct {
+	svc             *codeguruprofiler.CodeGuruProfiler
+	ComputePlatform *string
+	Name            *string
+}
+
+func (r *CodeGuruProfilingGroup) Remove(_ context.Context) error {
+	_, err := r.svc.DeleteProfilingGroup(&codeguruprofiler.DeleteProfilingGroupInput{
+		ProfilingGroupName: r.Name,
+	})
+	return err
+}
+
+func (r *CodeGuruProfilingGroup) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}


### PR DESCRIPTION
PR to add new resource to support CodeGuru Profiler [profiling groups](https://docs.aws.amazon.com/codeguru/latest/profiler-ug/working-with-profiling-groups.html), can rename to match convention if its missing `Profiler` from name (`CodeGuruProfilerProfilingGroup`?).

Tested scan
> aws-nuke - 3.0.0-dev - dirty
Do you really want to nuke the account with the ID [XXX] and the alias '[XXX]'?
Do you want to continue? Enter account alias to continue.
>  \> [XXX]<br>
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-one"] - would remove
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-two"] - would remove
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "AWSLambda", Name: "lambda-one"] - would remove
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "AWSLambda", Name: "lambda-two"] - would remove
Scan complete: 4 total, 4 nukeable, 0 filtered.<br>
The above resources would be deleted with the supplied configuration. Provide --no-dry-run to actually destroy resources.

And nuke `--no-dry-run` with filters
```
    filters:
      CodeGuruProfilingGroup:
        - type: exact
          property: ComputePlatform
          value: AWSLambda
```

> aws-nuke - 3.0.0-dev - dirty
Do you really want to nuke the account with the ID [XXX] and the alias '[XXX]'?
Do you want to continue? Enter account alias to continue.
> \> [XXX]<br>   
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-one"] - would remove
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-two"] - would remove
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "AWSLambda", Name: "lambda-one"] - filtered by config
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "AWSLambda", Name: "lambda-two"] - filtered by config
Scan complete: 4 total, 2 nukeable, 2 filtered.<br>
Do you really want to nuke the account with the ID [XXX] and the alias '[XXX]'?
Do you want to continue? Enter account alias to continue.
\> [XXX]<br>
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-one"] - triggered remove
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-two"] - triggered remove<br>
Removal requested: 2 waiting, 0 failed, 2 skipped, 0 finished<br>
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-one"] - waiting
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-two"] - waiting<br>
Removal requested: 20 waiting, 0 failed, 26 skipped, 0 finished<br>
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-one"] - removed
eu-west-2 - CodeGuruProfilingGroup - [ComputePlatform: "Default", Name: "default-two"] - removed<br>
Removal requested: 0 waiting, 0 failed, 2 skipped, 2 finished<br>
Nuke complete: 0 failed, 2 skipped, 2 finished.


AWS API already does not return the demo `{CodeGuru} DemoProfilingGroup-*` profiling groups so does not need filtering / excluding.