### PR TITLE
feat(resource): support for opensearch serverless collections

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,7 @@ go.uber.org/ratelimit v0.3.1/go.mod h1:6euWsTB6U/Nb3X++xEUXA8ciPJvr19Q/0h1+oDcJh
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -183,6 +184,7 @@ golang.org/x/text v0.20.0/go.mod h1:D4IsuqiFMhST5bX19pQ9ikHC2GsaKyk/oF+pn3ducp4=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/resources/opensearchserverless-collections.go
+++ b/resources/opensearchserverless-collections.go
@@ -1,0 +1,87 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/opensearchserverless"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const OpenSearchServerlessCollectionResource = "OSCollection"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:   OpenSearchServerlessCollectionResource,
+		Scope:  nuke.Account,
+		Lister: &OSCollectionLister{},
+	})
+}
+
+type OSCollectionLister struct{}
+
+func (l *OSCollectionLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+
+	svc := opensearchserverless.New(opts.Session)
+	resources := make([]resource.Resource, 0)
+	var nextToken *string
+
+	for {
+		listResp, err := svc.ListCollections(&opensearchserverless.ListCollectionsInput{NextToken: nextToken})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, collection := range listResp.CollectionSummaries {
+			listTagsOutput, _ := svc.ListTagsForResource(&opensearchserverless.ListTagsForResourceInput{
+				ResourceArn: collection.Arn,
+			})
+			resources = append(resources, &OSCollection{
+				svc:  svc,
+				id:   collection.Id,
+				name: collection.Name,
+				arn:  collection.Arn,
+				tags: listTagsOutput.Tags,
+			})
+		}
+
+		if listResp.NextToken == nil {
+			break
+		}
+
+		nextToken = listResp.NextToken
+	}
+	return resources, nil
+}
+
+type OSCollection struct {
+	svc  *opensearchserverless.OpenSearchServerless
+	id   *string
+	name *string
+	arn  *string
+	tags []*opensearchserverless.Tag
+}
+
+func (o *OSCollection) Remove(_ context.Context) error {
+	_, err := o.svc.DeleteCollection(&opensearchserverless.DeleteCollectionInput{
+		Id: o.id,
+	})
+
+	return err
+}
+
+func (o *OSCollection) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("ID", o.id)
+	properties.Set("NAME", o.name)
+	properties.Set("ARN", o.arn)
+	for _, tagValue := range o.tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	return properties
+}


### PR DESCRIPTION
This PR introduces support for managing OpenSearch serverless collections. It allows deletion of collections based on three properties: ID, ARN, and NAME.

I have tested this feature by running AWS Nuke on an AWS account containing four collections. The tool successfully removed the specified collections based on the provided filters.

This PR fixes #344 