### PR TITLE
feat: pass tags to related resources for kms and route53

### DIFF
--- a/docs/resources/kms-alias.md
+++ b/docs/resources/kms-alias.md
@@ -14,7 +14,11 @@ KMSAlias
 ## Properties
 
 
-- `Name`: No Description
+- `CreationDate`: The creation date of the KMS alias
+- `Name`: The name of the KMS alias
+- `TargetKeyID`: The KMS Key ID that the alias points to
+- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
+	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
 
 !!! note - Using Properties
     Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property

--- a/resources/route53-resource-record_test.go
+++ b/resources/route53-resource-record_test.go
@@ -1,0 +1,49 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/gotidy/ptr"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+func TestRoute53ResourceRecordSet_Properties(t *testing.T) {
+	cases := []struct {
+		name       string
+		recordType string
+	}{
+		{
+			name:       "example.com",
+			recordType: "NS",
+		},
+		{
+			name:       "example.com",
+			recordType: "SOA",
+		},
+		{
+			name:       "subdomain.example.com",
+			recordType: "A",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Route53ResourceRecordSet{
+				resourceRecordSet: &route53.ResourceRecordSet{
+					Name: ptr.String(tc.name),
+					Type: ptr.String(tc.recordType),
+				},
+				Name: ptr.String(tc.name),
+				Type: ptr.String(tc.recordType),
+			}
+
+			got := r.Properties()
+			assert.Equal(t, tc.name, got.Get("Name"))
+			assert.Equal(t, tc.recordType, got.Get("Type"))
+
+			assert.Equal(t, tc.name, r.String())
+		})
+	}
+}


### PR DESCRIPTION
This passes the tags from the KMS Key to the KMS Alias as well as the Route53 Zone to the Route53 Record Set.

Each are prefixed by `key:tag:` and `zone:tag` respectively.

- Resolves #457 
- Resolves #297