### PR TITLE
feat: expand resource names

### DIFF
--- a/docs/features/name-expansion.md
+++ b/docs/features/name-expansion.md
@@ -1,0 +1,51 @@
+# Name Expansion
+
+This allows you to use wildcards in the resource names to match multiple resources. This is primarily useful when you
+want to target a group of resource type for either inclusion or exclusion. 
+
+Resource Name expansion is valid for use in the following areas:
+
+!!! warning
+This feature is currently **NOT** supported in filters.
+
+- cli includes/excludes
+- config resource types includes/excludes
+- account resource types includes/excludes
+
+## Examples
+
+### CLI
+
+```console
+aws-nuke run --config config.yaml --include "Cognito*"
+```
+
+This can also be used with `resource-types` subcommand to see what resource types are available, and you can specify
+multiple wildcard arguments.
+
+```console
+aws-nuke resource-types "Cognito*" "IAM*"
+```
+
+### Config
+
+```yaml
+resource-types:
+  includes:
+    - "Cognito*"
+  excludes:
+    - "OpsWorks*"
+```
+
+### Account Config
+
+```yaml
+accounts:
+  '012345678912':
+    resource-types:
+      includes:
+        - "Cognito*"
+      excludes:
+        - "OpsWorks*"
+```
+

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -6,6 +6,8 @@ Some of the new features include:
 - [Run Against All Enabled Regions](enabled-regions.md)
 - [Bypass Alias Check - Allow the skip of an alias on an account](bypass-alias-check.md)
 - [Signed Binaries](signed-binaries.md)
+- [Filter Groups (Experimental)](filter-groups.md)
+- [Name Expansion](name-expansion.md)
 
 Additionally, there are a few new sub commands to the tool to help with setup and debugging purposes:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ This is not a comprehensive list, but here are some of the highlights:
 * New Feature: [Run Against All Enabled Regions](features/enabled-regions.md)
 * New Feature: [Bypass Alias Check - Allow the skip of an alias on an account](features/bypass-alias-check.md)
 * New Feature: [Filter Groups (Experimental)](features/filter-groups.md)
+* New Feature: [Name Expansion](features/name-expansion.md)
 * Breaking Change: `root` command no longer triggers the run, must use subcommand `run` (alias: `nuke`)
 * Completely rewrote the core of the tool as a dedicated library [libnuke](https://github.com/ekristen/libnuke)
   * This library has over 95% test coverage which makes iteration and new features easier to implement.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - Global Filters: features/global-filters.md
     - Filter Groups: features/filter-groups.md
     - Enabled Regions: features/enabled-regions.md
+    - Name Expansion: features/name-expansion.md
     - Signed Binaries: features/signed-binaries.md
   - CLI:
     - Usage: cli-usage.md

--- a/pkg/commands/list/list.go
+++ b/pkg/commands/list/list.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/fatih/color"
@@ -15,9 +14,12 @@ import (
 )
 
 func execute(c *cli.Context) error {
-	ls := registry.GetNames()
-
-	sort.Strings(ls)
+	var ls []string
+	if c.Args().Len() > 0 {
+		ls = registry.ExpandNames(c.Args().Slice())
+	} else {
+		ls = registry.GetNames()
+	}
 
 	for _, name := range ls {
 		if strings.HasPrefix(name, "AWS::") {

--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -141,17 +141,17 @@ func execute(c *cli.Context) error { //nolint:funlen,gocyclo
 	resourceTypes := types.ResolveResourceTypes(
 		registry.GetNames(),
 		[]types.Collection{
-			n.Parameters.Includes,
+			registry.ExpandNames(n.Parameters.Includes),
 			parsedConfig.ResourceTypes.GetIncludes(),
 			accountConfig.ResourceTypes.GetIncludes(),
 		},
 		[]types.Collection{
-			n.Parameters.Excludes,
+			registry.ExpandNames(n.Parameters.Excludes),
 			parsedConfig.ResourceTypes.Excludes,
 			accountConfig.ResourceTypes.Excludes,
 		},
 		[]types.Collection{
-			n.Parameters.Alternatives,
+			registry.ExpandNames(n.Parameters.Alternatives),
 			parsedConfig.ResourceTypes.GetAlternatives(),
 			accountConfig.ResourceTypes.GetAlternatives(),
 		},


### PR DESCRIPTION
## Overview

This allows for the expansion of resource names using glob patterns supported by https://pkg.go.dev/github.com/mb0/glob?utm_source=godoc

At a basic level `*` is supported. You can now include and exclude using glob patterns. 

> [!IMPORTANT]  
> This feature is **NOT** currently supported for filters. You will need to continue to name resources types by their full name OR use the [Global Filters](https://aws-nuke.ekristen.dev/features/global-filters/) feature.

Please see the documentation included in this PR for more information on it's scope and usage. 

## Quick Example Usage

For example `OpsWorks*` will expand to now match the following resources:

```
OpsWorksApp                                            
OpsWorksCMBackup                                       
OpsWorksCMServer                                       
OpsWorksCMServerState                                  
OpsWorksInstance                                       
OpsWorksLayer                                          
OpsWorksUserProfile   
```

- Resolves https://github.com/ekristen/aws-nuke/issues/302