### PR TITLE
feat(ec2-network-interfaces): add description property

### DIFF
--- a/resources/ec2-network-interfaces.go
+++ b/resources/ec2-network-interfaces.go
@@ -94,7 +94,8 @@ func (e *EC2NetworkInterface) Properties() types.Properties {
 		Set("AvailabilityZone", e.eni.AvailabilityZone).
 		Set("PrivateIPAddress", e.eni.PrivateIpAddress).
 		Set("SubnetID", e.eni.SubnetId).
-		Set("Status", e.eni.Status)
+		Set("Status", e.eni.Status).
+		Set("Description", e.eni.Description)
 	return properties
 }
 


### PR DESCRIPTION
This change allows `EC2NetworkInterface` to be filtered by `Description`. The reason for this change is explained below.

Amazon MSK automatically creates network interfaces (ENIs) in the customer account, and if these are deleted then you lose the ability to connect to the MSK cluster. There is no way to recreate these ENIs apart from deleting and recreating the cluster. These ENIs are untagged but have a Description property in the format `DO NOT DELETE - Amazon MSK network interface for cluster <cluster_arn>.`. We can use this property to prevent aws-nuke deleting these critical resources.

Fixes #528 