### PR TITLE
fix(rds-instances): handle stopped clusters

### DIFF
--- a/resources/rds-instances.go
+++ b/resources/rds-instances.go
@@ -31,7 +31,7 @@ func init() {
 		Lister:   &RDSInstanceLister{},
 		Settings: []string{
 			"DisableDeletionProtection",
-			"StartClusterToDeleteInstance",
+			"StartClusterToDelete",
 		},
 	})
 }
@@ -98,7 +98,7 @@ func (i *RDSInstance) Remove(_ context.Context) error {
 
 	// You can't delete an instance that is part of a cluster in the stopped state.
 	// If the setting is enabled, start the cluster before deleting the instance.
-	if i.settings.GetBool("StartClusterToDeleteInstance") {
+	if i.settings.GetBool("StartClusterToDelete") {
 		status, err = i.getDBClusterStatus()
 		if err != nil {
 			return err
@@ -215,7 +215,7 @@ func (i *RDSInstance) HandleWait(ctx context.Context) error {
 		return liberror.ErrWaitResource("waiting for instance to delete")
 	}
 
-	if i.settings.GetBool("StartClusterToDeleteInstance") {
+	if i.settings.GetBool("StartClusterToDelete") {
 		status, err = i.getDBClusterStatus()
 		if err != nil {
 			return err

--- a/resources/rds-instances.go
+++ b/resources/rds-instances.go
@@ -2,18 +2,22 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/gotidy/ptr"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 
+	liberror "github.com/ekristen/libnuke/pkg/errors"
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	libsettings "github.com/ekristen/libnuke/pkg/settings"
 	"github.com/ekristen/libnuke/pkg/types"
 
+	"github.com/ekristen/aws-nuke/v3/pkg/awsutil"
 	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
 
@@ -27,6 +31,7 @@ func init() {
 		Lister:   &RDSInstanceLister{},
 		Settings: []string{
 			"DisableDeletionProtection",
+			"StartClusterToDeleteInstance",
 		},
 	})
 }
@@ -83,6 +88,36 @@ func (i *RDSInstance) Settings(settings *libsettings.Setting) {
 }
 
 func (i *RDSInstance) Remove(_ context.Context) error {
+	status, err := i.getDBInstanceStatus()
+	if err != nil {
+		return err
+	}
+	if status == awsutil.StateDeleting {
+		return nil
+	}
+
+	// You can't delete an instance that is part of a cluster in the stopped state.
+	// If the setting is enabled, start the cluster before deleting the instance.
+	if i.settings.GetBool("StartClusterToDeleteInstance") {
+		status, err = i.getDBClusterStatus()
+		if err != nil {
+			return err
+		}
+		switch status {
+		case "stopped", "inaccessible-encryption-credentials-recoverable":
+			_, err := i.svc.StartDBCluster(&rds.StartDBClusterInput{
+				DBClusterIdentifier: i.instance.DBClusterIdentifier,
+			})
+			return err
+		case "starting":
+			return nil
+		}
+	}
+
+	return i.deleteDBInstance()
+}
+
+func (i *RDSInstance) deleteDBInstance() error {
 	if aws.BoolValue(i.instance.DeletionProtection) && i.settings.GetBool("DisableDeletionProtection") {
 		modifyParams := &rds.ModifyDBInstanceInput{
 			DBInstanceIdentifier: i.instance.DBInstanceIdentifier,
@@ -105,9 +140,43 @@ func (i *RDSInstance) Remove(_ context.Context) error {
 	return nil
 }
 
+func (i *RDSInstance) getDBInstanceStatus() (string, error) {
+	resp, err := i.svc.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: i.instance.DBInstanceIdentifier,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(resp.DBInstances) == 0 {
+		return "", nil
+	}
+
+	return ptr.ToString(resp.DBInstances[0].DBInstanceStatus), nil
+}
+
+func (i *RDSInstance) getDBClusterStatus() (string, error) {
+	if i.instance.DBClusterIdentifier == nil {
+		// No cluster associated with this instance
+		return "", nil
+	}
+
+	cluster, err := i.svc.DescribeDBClusters(&rds.DescribeDBClustersInput{
+		DBClusterIdentifier: i.instance.DBClusterIdentifier,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(cluster.DBClusters) == 0 {
+		return "", nil
+	}
+
+	return ptr.ToString(cluster.DBClusters[0].Status), nil
+}
+
 func (i *RDSInstance) Properties() types.Properties {
 	properties := types.NewProperties().
 		Set("Identifier", i.instance.DBInstanceIdentifier).
+		Set("ClusterIdentifier", i.instance.DBClusterIdentifier).
 		Set("DeletionProtection", i.instance.DeletionProtection).
 		Set("AvailabilityZone", i.instance.AvailabilityZone).
 		Set("InstanceClass", i.instance.DBInstanceClass).
@@ -129,4 +198,35 @@ func (i *RDSInstance) Properties() types.Properties {
 
 func (i *RDSInstance) String() string {
 	return aws.StringValue(i.instance.DBInstanceIdentifier)
+}
+
+func (i *RDSInstance) HandleWait(ctx context.Context) error {
+	status, err := i.getDBInstanceStatus()
+	if err != nil {
+		var awsErr awserr.Error
+		ok := errors.As(err, &awsErr)
+		if ok && awsErr.Code() == "DBInstanceNotFound" {
+			return nil
+		}
+
+		return err
+	}
+	if status == awsutil.StateDeleting {
+		return liberror.ErrWaitResource("waiting for instance to delete")
+	}
+
+	if i.settings.GetBool("StartClusterToDeleteInstance") {
+		status, err = i.getDBClusterStatus()
+		if err != nil {
+			return err
+		}
+		switch status {
+		case "starting":
+			return liberror.ErrWaitResource("waiting for cluster to start")
+		case "available":
+			return i.deleteDBInstance()
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fixes #347 

To make use of this fix, the `StartClusterToDelete` setting needs to be enabled (which will start the cluster before deleting the instance):

```yaml
settings:
  RDSInstance:
    StartClusterToDelete: true
```
