### PR TITLE
feat(ecs-clusters): return cluster tags properly #306

### DIFF
--- a/resources/ecs-clusters.go
+++ b/resources/ecs-clusters.go
@@ -57,6 +57,7 @@ func (l *ECSClusterLister) List(_ context.Context, o interface{}) ([]resource.Re
 		for _, clusterChunk := range slices.Chunk(output.ClusterArns, 100) {
 			clusters, err := svc.DescribeClusters(&ecs.DescribeClustersInput{
 				Clusters: clusterChunk,
+				Include:  []*string{aws.String("TAGS")},
 			})
 			if err != nil {
 				logrus.WithError(err).Error("unable to retrieve clusters")


### PR DESCRIPTION
This PR adds the missing `Include` parameter to also return the tags associated with ECS clusters, see the [official AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeClusters.html#API_DescribeClusters_RequestSyntax).