### PR TITLE
fix(access-analyzer): scan all types, filter org level

### DIFF
--- a/resources/accessanalyzer-analyzer.go
+++ b/resources/accessanalyzer-analyzer.go
@@ -2,8 +2,11 @@ package resources
 
 import (
 	"context"
+	"errors"
+	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/gotidy/ptr"
+
 	"github.com/aws/aws-sdk-go/service/accessanalyzer"
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -30,12 +33,10 @@ type AccessAnalyzerLister struct{}
 func (l *AccessAnalyzerLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
 	svc := accessanalyzer.New(opts.Session)
-
-	params := &accessanalyzer.ListAnalyzersInput{
-		Type: aws.String("ACCOUNT"),
-	}
-
 	resources := make([]resource.Resource, 0)
+
+	params := &accessanalyzer.ListAnalyzersInput{}
+
 	if err := svc.ListAnalyzersPages(params,
 		func(page *accessanalyzer.ListAnalyzersOutput, lastPage bool) bool {
 			for _, analyzer := range page.Analyzers {
@@ -44,6 +45,7 @@ func (l *AccessAnalyzerLister) List(_ context.Context, o interface{}) ([]resourc
 					ARN:    analyzer.Arn,
 					Name:   analyzer.Name,
 					Status: analyzer.Status,
+					Type:   analyzer.Type,
 					Tags:   analyzer.Tags,
 				})
 			}
@@ -60,7 +62,15 @@ type AccessAnalyzer struct {
 	ARN    *string            `description:"The ARN of the analyzer"`
 	Name   *string            `description:"The name of the analyzer"`
 	Status *string            `description:"The status of the analyzer"`
+	Type   *string            `description:"The type of the analyzer"`
 	Tags   map[string]*string `description:"The tags of the analyzer"`
+}
+
+func (r *AccessAnalyzer) Filter() error {
+	if strings.Contains(ptr.ToString(r.Name), "ORGANIZATION") {
+		return errors.New("cannot delete organization analyzer")
+	}
+	return nil
 }
 
 func (r *AccessAnalyzer) Remove(_ context.Context) error {


### PR DESCRIPTION
Previously this wasn't detecting all analyzers, now it will, but will filter out org level as they are usually not accessible for deletion. 