### PR TITLE
fix(cloudformation-stack): fix nil pointer dereference when stack does not have a roleARN

### DIFF
--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -175,7 +175,8 @@ func (r *CloudFormationStack) removeWithAttempts(ctx context.Context, attempt in
 		var awsErr awserr.Error
 		ok := errors.As(err, &awsErr)
 		if ok && awsErr.Code() == "ValidationError" {
-			if awsErr.Message() == fmt.Sprintf("Role %s is invalid or cannot be assumed", *r.roleARN) {
+			// roleARN could be nil. It is not mandatory to have a roleARN for a stack.
+			if r.roleARN != nil && awsErr.Message() == fmt.Sprintf("Role %s is invalid or cannot be assumed", *r.roleARN) {
 				if r.settings.GetBool("CreateRoleToDeleteStack") {
 					r.logger.Infof("CloudFormationStack stackName=%s attempt=%d maxAttempts=%d creating role to delete stack",
 						*r.Name, attempt, r.maxDeleteAttempts)


### PR DESCRIPTION
CloudFormation stack RoleARN is not required when creating a stack. When a `ValidationError` was happening because the stack had set the TerminationProtection, the first condition evaluated was if a role was invalid or cannot be assumed, but since the stack was created without a role, this caused a nil pointer dereference error, and the `UpdateTerminationProtection` was never executed.

```
Do you really want to nuke the account with the ID 384736907310 and the alias 'alias-384736907310'?
Do you want to continue? Enter account alias to continue.
> alias-384736907310

ERRO[0020] CloudFormationStack stackName=MyStack attempt=0 maxAttempts=3 delete failed: ValidationError: Stack [MyStack] cannot be deleted while TerminationProtection is enabled
        status code: 400, request id: a709aab6-c576-45ff-a26a-491bb64522bf  component=scanner region=us-east-1 resource=CloudFormationType
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5db3da0]

goroutine 1 [running]:
main.main.func1()
        /workspaces/aws-nuke-v2/main.go:28 +0xa4
panic({0x7038340?, 0xcb18420?})
        /usr/local/go/src/runtime/panic.go:785 +0xf0
github.com/ekristen/aws-nuke/v3/resources.(*CloudFormationStack).removeWithAttempts(0x400099a140, {0x8aac488, 0x40004c0190}, 0x0)
        /workspaces/aws-nuke-v2/resources/cloudformation-stack.go:178 +0x4e0
github.com/ekristen/aws-nuke/v3/resources.(*CloudFormationStack).Remove(0x400099a140, {0x8aac488, 0x40004c0190})
        /workspaces/aws-nuke-v2/resources/cloudformation-stack.go:126 +0x3c
github.com/ekristen/libnuke/pkg/nuke.(*Nuke).HandleRemove(0x4000a22320, {0x8aac488, 0x40004c0190}, 0x400072c300)
        /go/pkg/mod/github.com/ekristen/libnuke@v0.24.3/pkg/nuke/nuke.go:607 +0x40
github.com/ekristen/libnuke/pkg/nuke.(*Nuke).HandleQueue(0x4000a22320, {0x8aac488, 0x40004c0190})
        /go/pkg/mod/github.com/ekristen/libnuke@v0.24.3/pkg/nuke/nuke.go:562 +0x1a0
github.com/ekristen/libnuke/pkg/nuke.(*Nuke).run(0x4000a22320, {0x8aac488, 0x40004c0190})
        /go/pkg/mod/github.com/ekristen/libnuke@v0.24.3/pkg/nuke/nuke.go:319 +0x78
github.com/ekristen/libnuke/pkg/nuke.(*Nuke).Run(0x4000a22320, {0x8aac488, 0x40004c0190})
        /go/pkg/mod/github.com/ekristen/libnuke@v0.24.3/pkg/nuke/nuke.go:225 +0x2b8
github.com/ekristen/aws-nuke/v3/pkg/commands/nuke.execute(0x4000199800)
        /workspaces/aws-nuke-v2/pkg/commands/nuke/nuke.go:238 +0x1c04
github.com/urfave/cli/v2.(*Command).Run(0x40004e6420, 0x4000199800, {0x4000199840, 0x4, 0x4})
        /go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/command.go:276 +0xd00
github.com/urfave/cli/v2.(*Command).Run(0x40004e69a0, 0x4000199680, {0x40000700a0, 0x5, 0x5})
        /go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/command.go:269 +0xc60
github.com/urfave/cli/v2.(*App).RunContext(0x4000562000, {0x8aac530, 0xcb69ae0}, {0x40000700a0, 0x5, 0x5})
        /go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/app.go:333 +0x238
github.com/urfave/cli/v2.(*App).Run(0x4000562000, {0x40000700a0, 0x5, 0x5})
        /go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/app.go:307 +0x60
main.main()
        /workspaces/aws-nuke-v2/main.go:50 +0x2f0
```

## Testing

Steps to reproduce the issue:
- Create a CloudFormation template with termination protection enabled

```
## Testing CloudFormation Stack with Termination Protection
randomNum=$(cat /dev/urandom | LANG=c tr -dc '0-9' | head -c 12)
aws s3api create-bucket --bucket test-cf-termination-protection-$randomNum

cat << "EOF" > my-template.yaml
AWSTemplateFormatVersion: 2010-09-09
Description: Part 1 - Build a webapp stack with CloudFormation

Resources:
  WebAppInstance:
    Type: AWS::EC2::Instance
    Properties:
      ImageId: ami-0d5eff06f840b45e9 # ImageID valid only in us-east-1 region
      InstanceType: t2.micro
EOF

aws s3 cp my-template.yaml s3://test-cf-termination-protection-$randomNum/

# The stack has the termination protection enabled
aws cloudformation create-stack \
  --stack-name MyStack \
  --template-url https://s3.amazonaws.com/test-cf-termination-protection-$randomNum/my-template.yaml \
  --capabilities CAPABILITY_NAMED_IAM \
  --enable-termination-protection

aws cloudformation describe-stacks --stack-name MyStack
```
- Clean the `CloudFormationStack ` resources in that account.