### PR TITLE
fix(backup-vaults-access-policies): Allow cross-account assumed roles to delete Backup Vault Policies

### DIFF
--- a/resources/backup-vaults-access-policies.go
+++ b/resources/backup-vaults-access-policies.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/backup"
 )
 
@@ -107,19 +109,19 @@ func (b *BackupVaultAccessPolicy) Remove(_ context.Context) error {
 	//
 	// While deletion is Denied, you can update the policy with one that
 	// doesn't deny and then delete at will.
-	allowDeletionPolicy := `{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-				"AWS": "arn:aws:iam::` + *b.accountID + `:root"
-            },
-            "Action": "backup:DeleteBackupVaultAccessPolicy",
-            "Resource": "*"
-        }
-    ]
-}`
+	allowDeletionPolicy := fmt.Sprintf(`{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"AWS": "arn:aws:iam::%s:root"
+			},
+			"Action": "backup:DeleteBackupVaultAccessPolicy",
+			"Resource": "*"
+		}
+	]
+}`, *b.accountID)
 	// Ignore error from if we can't put permissive backup vault policy in for some reason, that's OK.
 	_, _ = b.svc.PutBackupVaultAccessPolicy(&backup.PutBackupVaultAccessPolicyInput{
 		BackupVaultName: &b.backupVaultName,

--- a/resources/backup-vaults-access-policies.go
+++ b/resources/backup-vaults-access-policies.go
@@ -60,6 +60,7 @@ func (l *AWSBackupVaultAccessPolicyLister) List(_ context.Context, o interface{}
 		if resp.Policy != nil {
 			resources = append(resources, &BackupVaultAccessPolicy{
 				svc:             svc,
+				accountID:       opts.AccountID,
 				backupVaultName: *out.BackupVaultName,
 			})
 		}
@@ -70,6 +71,7 @@ func (l *AWSBackupVaultAccessPolicyLister) List(_ context.Context, o interface{}
 
 type BackupVaultAccessPolicy struct {
 	svc             *backup.Backup
+	accountID       *string
 	backupVaultName string
 }
 
@@ -111,7 +113,7 @@ func (b *BackupVaultAccessPolicy) Remove(_ context.Context) error {
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "*"
+				"AWS": "arn:aws:iam::` + *b.accountID + `:root"
             },
             "Action": "backup:DeleteBackupVaultAccessPolicy",
             "Resource": "*"


### PR DESCRIPTION
Fixes https://github.com/ekristen/aws-nuke/issues/604

# Testing

Using the same setup documented in #604 , I ran the module and the Vault Policy was updated and deleted as expected:

```
aws-nuke - 3.0.0-dev - dirty
no-prompt flag set, continuing without prompting user
waiting 3s before continuing
starting scan for resources
us-east-1 - AWSBackupVaultAccessPolicy - aws/efs/automatic-backup-vault - [] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.

no-prompt flag set, continuing without prompting user
waiting 3s before continuing
us-east-1 - AWSBackupVaultAccessPolicy - aws/efs/automatic-backup-vault - [] - triggered remove
Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished


us-east-1 - AWSBackupVaultAccessPolicy - aws/efs/automatic-backup-vault - [] - waiting for removal
Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished


us-east-1 - AWSBackupVaultAccessPolicy - aws/efs/automatic-backup-vault - [] - removed
Removal requested: 0 waiting, 0 failed, 0 skipped, 1 finished


Nuke complete: 0 failed, 0 skipped, 1 finished.
```