### PR TITLE
feat(cmd/nuke): allow config and override of max queue size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.17
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5
 	github.com/aws/smithy-go v1.22.3
-	github.com/ekristen/libnuke v0.24.5
+	github.com/ekristen/libnuke v0.24.6-0.20250320233452-430158344073
 	github.com/fatih/color v1.18.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.17
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5
 	github.com/aws/smithy-go v1.22.3
-	github.com/ekristen/libnuke v0.24.6-0.20250320233452-430158344073
+	github.com/ekristen/libnuke v1.0.0
 	github.com/fatih/color v1.18.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,10 @@ github.com/ekristen/libnuke v0.24.3 h1:Fkw0Se042dcMoczZ5ICJ8WcavPtYVvqlxsUTdymtB
 github.com/ekristen/libnuke v0.24.3/go.mod h1:RRzJDSxPo35ONoznlk5a+vnXuSFChiHdZS1D9oFz/jU=
 github.com/ekristen/libnuke v0.24.5 h1:s7c6ORxSV/uNwkvl1y2JO7L9vAxRE88mxfnlx1Nvnu8=
 github.com/ekristen/libnuke v0.24.5/go.mod h1:RRzJDSxPo35ONoznlk5a+vnXuSFChiHdZS1D9oFz/jU=
+github.com/ekristen/libnuke v0.24.6-0.20250320232700-4662c681b1a1 h1:F2FzKlbezw/bfh4dOewxiaY6UdtBfjOw3bXHACEijdE=
+github.com/ekristen/libnuke v0.24.6-0.20250320232700-4662c681b1a1/go.mod h1:RRzJDSxPo35ONoznlk5a+vnXuSFChiHdZS1D9oFz/jU=
+github.com/ekristen/libnuke v0.24.6-0.20250320233452-430158344073 h1:GOpe2jBbIucoNQ4iG5rM1QB7DR7siBqA+E8a93HtpYI=
+github.com/ekristen/libnuke v0.24.6-0.20250320233452-430158344073/go.mod h1:RRzJDSxPo35ONoznlk5a+vnXuSFChiHdZS1D9oFz/jU=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/ekristen/libnuke v0.24.6-0.20250320232700-4662c681b1a1 h1:F2FzKlbezw/
 github.com/ekristen/libnuke v0.24.6-0.20250320232700-4662c681b1a1/go.mod h1:RRzJDSxPo35ONoznlk5a+vnXuSFChiHdZS1D9oFz/jU=
 github.com/ekristen/libnuke v0.24.6-0.20250320233452-430158344073 h1:GOpe2jBbIucoNQ4iG5rM1QB7DR7siBqA+E8a93HtpYI=
 github.com/ekristen/libnuke v0.24.6-0.20250320233452-430158344073/go.mod h1:RRzJDSxPo35ONoznlk5a+vnXuSFChiHdZS1D9oFz/jU=
+github.com/ekristen/libnuke v1.0.0 h1:fpTAE/eQIYVgiT1DakRF3Ig1TvMBdL4xqkmtCU2QNZ4=
+github.com/ekristen/libnuke v1.0.0/go.mod h1:RRzJDSxPo35ONoznlk5a+vnXuSFChiHdZS1D9oFz/jU=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=

--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -221,7 +221,9 @@ func execute(c *cli.Context) error { //nolint:funlen,gocyclo
 					"region":    regionName,
 				}),
 			},
-			Logger: logger,
+			Logger:          logger,
+			ParallelQueries: c.Int64("parallel-queries"),
+			QueueSize:       c.Int("max-queue-size"),
 		})
 		if scannerActualErr != nil {
 			return scannerActualErr

--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -210,15 +210,22 @@ func execute(c *cli.Context) error { //nolint:funlen,gocyclo
 		region := nuke.NewRegion(regionName, account.ResourceTypeToServiceType, account.NewSession, account.NewConfig)
 
 		// Step 2 - Create the scannerActual object
-		scannerActual := scanner.New(regionName, resourceTypes, &nuke.ListerOpts{
-			Region:    region,
-			AccountID: ptr.String(account.ID()),
-			Logger: logger.WithFields(logrus.Fields{
-				"component": "scanner",
-				"region":    regionName,
-			}),
+		scannerActual, scannerActualErr := scanner.New(&scanner.Config{
+			Owner:         regionName,
+			ResourceTypes: resourceTypes,
+			Opts: &nuke.ListerOpts{
+				Region:    region,
+				AccountID: ptr.String(account.ID()),
+				Logger: logger.WithFields(logrus.Fields{
+					"component": "scanner",
+					"region":    regionName,
+				}),
+			},
+			Logger: logger,
 		})
-		scannerActual.SetLogger(logger)
+		if scannerActualErr != nil {
+			return scannerActualErr
+		}
 
 		// Step 3 - Register a mutate function that will be called to modify the lister options for each resource type
 		// see pkg/nuke/resource.go for the MutateOpts function. Its purpose is to create the proper session for the
@@ -337,6 +344,20 @@ func init() { //nolint:funlen
 			Name:    "assume-role-external-id",
 			EnvVars: []string{"AWS_ASSUME_ROLE_EXTERNAL_ID"},
 			Usage:   "the external id to provide for the assumed role",
+		},
+		&cli.IntFlag{
+			Name:    "parallel-queries",
+			Usage:   "CAUTION! ADVANCED USAGE! number of parallel resource queries to run at a time",
+			EnvVars: []string{"AWS_NUKE_PARALLEL_QUERIES"},
+			Value:   scanner.DefaultParallelQueries,
+			Hidden:  true,
+		},
+		&cli.IntFlag{
+			Name:    "max-queue-size",
+			Usage:   "CAUTION! ADVANCED USAGE! the max number of items to queue up before aws-nuke will error",
+			EnvVars: []string{"AWS_NUKE_MAX_QUEUE_SIZE"},
+			Value:   scanner.DefaultQueueSize,
+			Hidden:  true,
 		},
 	}
 


### PR DESCRIPTION
## Overview

Introduces two new CLI flags that are configurable via environment variables. These flags are **hidden** by default.

- `--parallel-queries` - `AWS_NUKE_PARALLEL_QUERIES` (default: 16)
- `--max-queue-size` - `AWS_NUKE_MAX_QUEUE_SIZE` (default: 50k)

## Builds

https://github.com/ekristen/aws-nuke/actions/runs/13981419114