### PR TITLE
fix(waf-rules): runtime error due to throttling

### DIFF
--- a/resources/waf-rules.go
+++ b/resources/waf-rules.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
+	"go.uber.org/ratelimit"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -32,20 +33,31 @@ func (l *WAFRuleLister) List(_ context.Context, o interface{}) ([]resource.Resou
 	svc := waf.New(opts.Session)
 	resources := make([]resource.Resource, 0)
 
+	listRl := ratelimit.New(15)
+	getRl := ratelimit.New(10)
+
 	params := &waf.ListRulesInput{
 		Limit: aws.Int64(50),
 	}
 
 	for {
+		listRl.Take() // Wait for ListRules rate limiter
+
 		resp, err := svc.ListRules(params)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, rule := range resp.Rules {
-			ruleResp, _ := svc.GetRule(&waf.GetRuleInput{
+			getRl.Take() // Wait for GetRule rate limiter
+
+			ruleResp, err := svc.GetRule(&waf.GetRuleInput{
 				RuleId: rule.RuleId,
 			})
+			if err != nil {
+				return nil, err
+			}
+
 			resources = append(resources, &WAFRule{
 				svc:  svc,
 				ID:   rule.RuleId,

--- a/resources/wafregional-rule-predicates.go
+++ b/resources/wafregional-rule-predicates.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
+	"go.uber.org/ratelimit"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -33,17 +34,24 @@ func (l *WAFRegionalRulePredicateLister) List(_ context.Context, o interface{}) 
 	svc := wafregional.New(opts.Session)
 	resources := make([]resource.Resource, 0)
 
+	listRl := ratelimit.New(15)
+	getRl := ratelimit.New(10)
+
 	params := &waf.ListRulesInput{
 		Limit: aws.Int64(50),
 	}
 
 	for {
+		listRl.Take() // Wait for ListRules rate limiter
+
 		resp, err := svc.ListRules(params)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, rule := range resp.Rules {
+			getRl.Take() // Wait for GetRule rate limiter
+
 			details, err := svc.GetRule(&waf.GetRuleInput{
 				RuleId: rule.RuleId,
 			})


### PR DESCRIPTION
Fixes below runtime error when removing `WAFRegionalRule` resources due to nil `rule` field. Caused by lack of error checking on `GetRule` function, which was failing due to throttling. I've added error checking and rate limiting.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x5f12e07]
goroutine 1 [running]:
main.main.func1()
	github.com/ekristen/aws-nuke/v3/main.go:28 +0x54
panic({0x70f5640?, 0xd81b2c0?})
	runtime/panic.go:787 +0x132
github.com/ekristen/aws-nuke/v3/resources.(*WAFRegionalRule).Remove(0xc001422600, {0x7940334e2d7df14?, 0xc000d2e580?})
	github.com/ekristen/aws-nuke/v3/resources/wafregional-rules.go:82 +0x47
github.com/ekristen/libnuke/pkg/nuke.(*Nuke).HandleRemove(0xc000f89e60?, {0x8fa8638?, 0xc0001756d0?}, 0xc000f89ec0)
	github.com/ekristen/libnuke@v0.24.5/pkg/nuke/nuke.go:607 +0x2e
github.com/ekristen/libnuke/pkg/nuke.(*Nuke).HandleQueue(0xc000910140, {0x8fa8638, 0xc0001756d0})
	github.com/ekristen/libnuke@v0.24.5/pkg/nuke/nuke.go:562 +0x125
github.com/ekristen/libnuke/pkg/nuke.(*Nuke).run(0xc000910140, {0x8fa8638, 0xc0001756d0})
	github.com/ekristen/libnuke@v0.24.5/pkg/nuke/nuke.go:319 +0x68
github.com/ekristen/libnuke/pkg/nuke.(*Nuke).Run(0xc000910140, {0x8fa8638, 0xc0001756d0})
	github.com/ekristen/libnuke@v0.24.5/pkg/nuke/nuke.go:225 +0x253
github.com/ekristen/aws-nuke/v3/pkg/commands/nuke.execute(0xc00003d6c0)
	github.com/ekristen/aws-nuke/v3/pkg/commands/nuke/nuke.go:238 +0x2305
github.com/urfave/cli/v2.(*Command).Run(0xc00041a580, 0xc00003d6c0, {0xc000175680, 0x5, 0x5})
	github.com/urfave/cli/v2@v2.27.6/command.go:276 +0x7be
github.com/urfave/cli/v2.(*Command).Run(0xc00041ab00, 0xc00003d580, {0xc000100180, 0x6, 0x6})
	github.com/urfave/cli/v2@v2.27.6/command.go:269 +0xa45
github.com/urfave/cli/v2.(*App).RunContext(0xc000426200, {0x8fa8360, 0xd920b80}, {0xc000100180, 0x6, 0x6})
	github.com/urfave/cli/v2@v2.27.6/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
	github.com/urfave/cli/v2@v2.27.6/app.go:307
main.main()
	github.com/ekristen/aws-nuke/v3/main.go:50 +0x1e9
```
