### PR TITLE
feat: Fully support the deletion of IAM ServiceLinkedRoles

### DIFF
--- a/resources/iam-role_mock_test.go
+++ b/resources/iam-role_mock_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gotidy/ptr"
-	"github.com/sirupsen/logrus"
-
 	"github.com/golang/mock/gomock"
+	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	libsettings "github.com/ekristen/libnuke/pkg/settings"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_iamiface"
@@ -104,26 +104,20 @@ func Test_Mock_IAMRole_SLR_Remove(t *testing.T) {
 		Tags: []*iam.Tag{},
 	}
 
-	deletionTaskId := ptr.String("test")
-	status := ptr.String("SUCCEEDED")
+	deletionTaskID := ptr.String("test")
 
 	mockIAM.EXPECT().DeleteServiceLinkedRole(gomock.Eq(&iam.DeleteServiceLinkedRoleInput{
 		RoleName: iamRole.Name,
 	})).Return(&iam.DeleteServiceLinkedRoleOutput{
-		DeletionTaskId: deletionTaskId,
-	}, nil)
-
-	mockIAM.EXPECT().GetServiceLinkedRoleDeletionStatus(gomock.Eq(&iam.GetServiceLinkedRoleDeletionStatusInput{
-		DeletionTaskId: deletionTaskId,
-	})).Return(&iam.GetServiceLinkedRoleDeletionStatusOutput{
-		Status: status,
+		DeletionTaskId: deletionTaskID,
 	}, nil)
 
 	err := iamRole.Remove(context.TODO())
 	a.Nil(err)
+	a.Equal("test", *iamRole.deletionTaskID)
 }
 
-func Test_Mock_IAMRole_SLR_RemovalFails(t *testing.T) {
+func Test_Mock_IAMRole_no_deletionTaskID_HandleWait(t *testing.T) {
 	a := assert.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -131,72 +125,160 @@ func Test_Mock_IAMRole_SLR_RemovalFails(t *testing.T) {
 	mockIAM := mock_iamiface.NewMockIAMAPI(ctrl)
 
 	iamRole := IAMRole{
-		svc:  mockIAM,
-		Name: ptr.String("test"),
-		Path: ptr.String("/aws-service-role/MyRole"),
-		Tags: []*iam.Tag{},
+		svc:            mockIAM,
+		deletionTaskID: nil,
+		Name:           ptr.String("test"),
+		Path:           ptr.String("/aws-service-role/MyRole"),
+		Tags:           []*iam.Tag{},
 	}
 
-	deletionTaskId := ptr.String("test")
-	status := ptr.String("FAILED")
-
-	mockIAM.EXPECT().DeleteServiceLinkedRole(gomock.Eq(&iam.DeleteServiceLinkedRoleInput{
-		RoleName: iamRole.Name,
-	})).Return(&iam.DeleteServiceLinkedRoleOutput{
-		DeletionTaskId: deletionTaskId,
-	}, nil)
-
-	mockIAM.EXPECT().GetServiceLinkedRoleDeletionStatus(gomock.Eq(&iam.GetServiceLinkedRoleDeletionStatusInput{
-		DeletionTaskId: deletionTaskId,
-	})).Return(&iam.GetServiceLinkedRoleDeletionStatusOutput{
-		Status: status,
-		Reason: &iam.DeletionTaskFailureReasonType{},
-	}, nil)
-
-	err := iamRole.Remove(context.TODO())
-	a.Error(err)
-	a.EqualError(err, "failed to delete role test - {\n\n}")
+	err := iamRole.HandleWait(context.TODO())
+	a.Nil(err)
 }
 
-func Test_Mock_IAMRole_SLR_With_Retry_Remove(t *testing.T) {
+func Test_Mock_IAMRole_404_GetDeletionStatus_HandleWait(t *testing.T) {
 	a := assert.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockIAM := mock_iamiface.NewMockIAMAPI(ctrl)
 
+	deletionTaskID := ptr.String("taskId")
+
 	iamRole := IAMRole{
-		svc:    mockIAM,
-		logger: logrus.NewEntry(logrus.StandardLogger()),
-		Name:   ptr.String("test"),
-		Path:   ptr.String("/aws-service-role/MyRole"),
-		Tags:   []*iam.Tag{},
+		svc:            mockIAM,
+		deletionTaskID: deletionTaskID,
+		Name:           ptr.String("test"),
+		Path:           ptr.String("/aws-service-role/MyRole"),
+		Tags:           []*iam.Tag{},
 	}
 
-	deletionTaskId := ptr.String("test")
-	firstStatus := ptr.String("IN_PROGRESS")
-	finalStatus := ptr.String("SUCCEEDED")
+	mockIAM.EXPECT().GetServiceLinkedRoleDeletionStatus(gomock.Eq(&iam.GetServiceLinkedRoleDeletionStatusInput{
+		DeletionTaskId: deletionTaskID,
+	})).Return(nil, awserr.New(iam.ErrCodeNoSuchEntityException, "", nil))
 
-	mockIAM.EXPECT().DeleteServiceLinkedRole(gomock.Eq(&iam.DeleteServiceLinkedRoleInput{
-		RoleName: iamRole.Name,
-	})).Return(&iam.DeleteServiceLinkedRoleOutput{
-		DeletionTaskId: deletionTaskId,
-	}, nil)
+	err := iamRole.HandleWait(context.TODO())
+	var errWait liberrors.ErrWaitResource
+	a.ErrorAs(err, &errWait)
+}
+
+func Test_Mock_IAMRole_Success_HandleWait(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIAM := mock_iamiface.NewMockIAMAPI(ctrl)
+
+	deletionTaskID := ptr.String("taskId")
+
+	iamRole := IAMRole{
+		svc:            mockIAM,
+		deletionTaskID: deletionTaskID,
+		Name:           ptr.String("test"),
+		Path:           ptr.String("/aws-service-role/MyRole"),
+		Tags:           []*iam.Tag{},
+	}
 
 	mockIAM.EXPECT().GetServiceLinkedRoleDeletionStatus(gomock.Eq(&iam.GetServiceLinkedRoleDeletionStatusInput{
-		DeletionTaskId: deletionTaskId,
+		DeletionTaskId: deletionTaskID,
 	})).Return(&iam.GetServiceLinkedRoleDeletionStatusOutput{
-		Status: firstStatus,
+		Status: ptr.String("SUCCEEDED"),
 	}, nil)
 
-	mockIAM.EXPECT().GetServiceLinkedRoleDeletionStatus(gomock.Eq(&iam.GetServiceLinkedRoleDeletionStatusInput{
-		DeletionTaskId: deletionTaskId,
-	})).Return(&iam.GetServiceLinkedRoleDeletionStatusOutput{
-		Status: finalStatus,
-	}, nil)
-
-	err := iamRole.Remove(context.TODO())
+	err := iamRole.HandleWait(context.TODO())
 	a.Nil(err)
+}
+
+func Test_Mock_IAMRole_Failed_NoRoles_HandleWait(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIAM := mock_iamiface.NewMockIAMAPI(ctrl)
+
+	deletionTaskID := ptr.String("taskId")
+
+	iamRole := IAMRole{
+		svc:            mockIAM,
+		deletionTaskID: deletionTaskID,
+		Name:           ptr.String("test"),
+		Path:           ptr.String("/aws-service-role/MyRole"),
+		Tags:           []*iam.Tag{},
+	}
+
+	mockIAM.EXPECT().GetServiceLinkedRoleDeletionStatus(gomock.Eq(&iam.GetServiceLinkedRoleDeletionStatusInput{
+		DeletionTaskId: deletionTaskID,
+	})).Return(&iam.GetServiceLinkedRoleDeletionStatusOutput{
+		Status: ptr.String("FAILED"),
+		Reason: &iam.DeletionTaskFailureReasonType{
+			Reason: ptr.String("internal failure"),
+		},
+	}, nil)
+
+	err := iamRole.HandleWait(context.TODO())
+	a.NotNil(err)
+	a.NotNil(iamRole.deletionTaskID)
+}
+
+func Test_Mock_IAMRole_Failed_UsageRoles_HandleWait(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIAM := mock_iamiface.NewMockIAMAPI(ctrl)
+
+	deletionTaskID := ptr.String("taskId")
+
+	iamRole := IAMRole{
+		svc:            mockIAM,
+		deletionTaskID: deletionTaskID,
+		Name:           ptr.String("test"),
+		Path:           ptr.String("/aws-service-role/MyRole"),
+		Tags:           []*iam.Tag{},
+	}
+
+	mockIAM.EXPECT().GetServiceLinkedRoleDeletionStatus(gomock.Eq(&iam.GetServiceLinkedRoleDeletionStatusInput{
+		DeletionTaskId: deletionTaskID,
+	})).Return(&iam.GetServiceLinkedRoleDeletionStatusOutput{
+		Status: ptr.String("FAILED"),
+		Reason: &iam.DeletionTaskFailureReasonType{
+			Reason:        ptr.String("internal failure"),
+			RoleUsageList: make([]*iam.RoleUsageType, 0),
+		},
+	}, nil)
+
+	err := iamRole.HandleWait(context.TODO())
+	a.NotNil(err)
+	a.Nil(iamRole.deletionTaskID)
+}
+
+func Test_Mock_IAMRole_InProgress_HandleWait(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIAM := mock_iamiface.NewMockIAMAPI(ctrl)
+
+	deletionTaskID := ptr.String("taskId")
+
+	iamRole := IAMRole{
+		svc:            mockIAM,
+		deletionTaskID: deletionTaskID,
+		Name:           ptr.String("test"),
+		Path:           ptr.String("/aws-service-role/MyRole"),
+		Tags:           []*iam.Tag{},
+	}
+
+	mockIAM.EXPECT().GetServiceLinkedRoleDeletionStatus(gomock.Eq(&iam.GetServiceLinkedRoleDeletionStatusInput{
+		DeletionTaskId: deletionTaskID,
+	})).Return(&iam.GetServiceLinkedRoleDeletionStatusOutput{
+		Status: ptr.String("IN_PROGRESS"),
+	}, nil)
+
+	err := iamRole.HandleWait(context.TODO())
+	a.NotNil(err)
+	var errWait liberrors.ErrWaitResource
+	a.ErrorAs(err, &errWait)
 }
 
 func Test_Mock_IAMRole_Filter_ServiceLinked(t *testing.T) {


### PR DESCRIPTION
In order to delete a ServiceLinkedRole, the API [DeleteServiceLinkedRole](https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteServiceLinkedRole.html) should be used. This returns an identifier which can then be used to poll the API [GetServiceLinkedRoleDeletionStatus](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetServiceLinkedRoleDeletionStatus.html). This additional business logic is forked using the same methodology as the existing `Filter()`, however, it does not check for the setting a second time as that must be true to have reached this stage.

There are two `sleep` calls in the PR, one to delay post the initial deletion request which seems to take time to propagate. The second is to delay slightly during polling.