### PR TITLE
fix(resource:OSCollection): added missing string function to opensearchserverless-collections.go

### DIFF
--- a/resources/opensearchserverless-collections.go
+++ b/resources/opensearchserverless-collections.go
@@ -85,3 +85,7 @@ func (o *OSCollection) Properties() types.Properties {
 	}
 	return properties
 }
+
+func (o *OSCollection) String() string {
+	return *o.name
+}


### PR DESCRIPTION
fix: missing string function causing oscollection to print out incorrectly to the screen:

without string()
<img width="958" alt="image" src="https://github.com/user-attachments/assets/c529b5fa-aeb4-4fa5-aef9-aa1ac5de5af2" />


with string()
<img width="957" alt="image" src="https://github.com/user-attachments/assets/d062bdf6-9d77-4b84-a39e-204e9054889e" />
