### PR TITLE
feat: Add configurable S3Object deletion batch size

### DIFF
--- a/pkg/awsmod/batch.go
+++ b/pkg/awsmod/batch.go
@@ -15,7 +15,7 @@ const (
 	// DefaultBatchSize is the batch size we initialize when constructing a batch delete client.
 	// This value is used when calling DeleteObjects. This represents how many objects to delete
 	// per DeleteObjects call.
-	DefaultBatchSize = 100
+	DefaultBatchSize = 1000
 )
 
 // BatchError will contain the key and bucket of the object that failed to

--- a/pkg/awsmod/batch.go
+++ b/pkg/awsmod/batch.go
@@ -227,10 +227,14 @@ type BatchDelete struct {
 //	}); err != nil {
 //		return err
 //	}
-func NewBatchDeleteWithClient(s3client DeleteObjectsAPIClient, options ...func(*BatchDelete)) *BatchDelete {
+func NewBatchDeleteWithClient(s3client DeleteObjectsAPIClient, batchSize int, options ...func(*BatchDelete)) *BatchDelete {
 	svc := &BatchDelete{
 		Client:    s3client,
 		BatchSize: DefaultBatchSize,
+	}
+
+	if batchSize != -1 {
+		svc.BatchSize = batchSize
 	}
 
 	for _, opt := range options {
@@ -261,9 +265,10 @@ func NewBatchDeleteWithClient(s3client DeleteObjectsAPIClient, options ...func(*
 //	}); err != nil {
 //		return err
 //	}
-func NewBatchDelete(c *aws.Config, options ...func(*BatchDelete)) *BatchDelete {
+func NewBatchDelete(c *aws.Config, batchSize int, options ...func(*BatchDelete)) *BatchDelete {
 	s3client := s3.NewFromConfig(*c)
-	return NewBatchDeleteWithClient(s3client, options...)
+
+	return NewBatchDeleteWithClient(s3client, batchSize, options...)
 }
 
 // BatchDeleteObject is a wrapper object for calling the batch delete operation.

--- a/resources/s3-bucket.go
+++ b/resources/s3-bucket.go
@@ -231,7 +231,8 @@ func (r *S3Bucket) RemoveAllVersions(ctx context.Context) error {
 	}
 
 	iterator := newS3DeleteVersionListIterator(r.svc, params, setBypass)
-	return awsmod.NewBatchDeleteWithClient(r.svc).Delete(ctx, iterator, opts...)
+	batchSize := r.settings.GetInt("S3VersionDeleteBatchSize")
+	return awsmod.NewBatchDeleteWithClient(r.svc, batchSize).Delete(ctx, iterator, opts...)
 }
 
 func (r *S3Bucket) RemoveAllObjects(ctx context.Context) error {
@@ -248,7 +249,8 @@ func (r *S3Bucket) RemoveAllObjects(ctx context.Context) error {
 	}
 
 	iterator := newS3ObjectDeleteListIterator(r.svc, params, setBypass)
-	return awsmod.NewBatchDeleteWithClient(r.svc).Delete(ctx, iterator, opts...)
+	batchSize := r.settings.GetInt("S3ObjectDeleteBatchSize")
+	return awsmod.NewBatchDeleteWithClient(r.svc, batchSize).Delete(ctx, iterator, opts...)
 }
 
 func (r *S3Bucket) Settings(settings *libsettings.Setting) {


### PR DESCRIPTION
S3 has a maximum batch deletion for S3Objects of 1000. When clearing buckets with large quantities of S3Objects, a larger batch size improves speeds. In personal testing I've found that using a 1000 count batch size has improved the deletion of a S3 bucket containing 50,000 objects was reduced from about 8min to 2min.

This change makes the batch size for S3Object deletion configurable