### PR TITLE
fix(cloudformation): improve termination protection message matching

### DIFF
--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -188,7 +188,8 @@ func (r *CloudFormationStack) removeWithAttempts(ctx context.Context, attempt in
 						*r.Name, attempt, r.maxDeleteAttempts)
 					return err
 				}
-			} else if awsErr.Message() == fmt.Sprintf("Stack [%s] cannot be deleted while TerminationProtection is enabled", *r.Name) {
+			} else if strings.Contains(awsErr.Message(), "cannot be deleted while TerminationProtection is enabled") &&
+				strings.Contains(awsErr.Message(), *r.Name) {
 				// check if the setting for the resource is set to allow deletion protection to be disabled
 				if r.settings.GetBool("DisableDeletionProtection") {
 					r.logger.Infof("CloudFormationStack stackName=%s attempt=%d maxAttempts=%d updating termination protection",


### PR DESCRIPTION
This is a bug fix to address an issue where TerminationProtection is not disabled on CF stacks in the region `ap-southeast-3`. This was traced back to the error message received from CloudFormation where it does not wrap brackets around the stack name. This fix is accomplished via a less-strict, but still reasonably so, conditional for the expected error message.

```
AWS Nuke: time="2025-06-18T22:21:50Z" level=error msg="CloudFormationStack stackName=Test attempt=0 maxAttempts=3 delete failed: ValidationError: Stack Test cannot be deleted while TerminationProtection is enabled\n\tstatus code: 400, request id: 2f3ebe96-358d-4ec3-bae7-88f5954b1dc8" component=scanner region=ap-southeast-3 resource=FSxFileSystem
```

I do not have explanation for the difference in the error message across regions, but also confirmed brackets still exist in other regions.