### PR TITLE
fix(EC2VPCPeeringConnection): filter on proper final states

### DIFF
--- a/pkg/awsutil/consts.go
+++ b/pkg/awsutil/consts.go
@@ -11,3 +11,9 @@ const StateDeleting = "deleting"
 
 // StateRejected is a generic constant for the word rejected for state
 const StateRejected = "rejected"
+
+// StateExpired is a generic constant for the word expired for state
+const StateExpired = "expired"
+
+// StateFailed is a generic constant for the word failed for state
+const StateFailed = "failed"

--- a/resources/ec2-vpc-peering-connections.go
+++ b/resources/ec2-vpc-peering-connections.go
@@ -58,8 +58,12 @@ type EC2VPCPeeringConnection struct {
 }
 
 func (p *EC2VPCPeeringConnection) Filter() error {
-	if *p.status == awsutil.StateDeleting || *p.status == awsutil.StateDeleted {
-		return fmt.Errorf("already deleted")
+	if *p.status == awsutil.StateDeleting ||
+		*p.status == awsutil.StateDeleted ||
+		*p.status == awsutil.StateRejected ||
+		*p.status == awsutil.StateExpired ||
+		*p.status == awsutil.StateFailed {
+		return fmt.Errorf("already removed (%s)", *p.status)
 	}
 
 	return nil


### PR DESCRIPTION
Adds filtering for a few other final states that should be considered as removed.

Resolves #723 