### PR TITLE
fix(iam-user): allow bypass permission boundary removal

### DIFF
--- a/docs/resources/bedrock-agent-alias.md
+++ b/docs/resources/bedrock-agent-alias.md
@@ -2,27 +2,21 @@
 generated: true
 ---
 
-# MGNWave
+# BedrockAgentAlias
 
 
 ## Resource
 
 ```text
-MGNWave
+BedrockAgentAlias
 ```
 
 ## Properties
 
 
-- `Arn`: The ARN of the wave
-- `CreationDateTime`: The date and time the wave was created
-- `Description`: The description of the wave
-- `IsArchived`: Whether the wave is archived
-- `LastModifiedDateTime`: The date and time the wave was last modified
-- `Name`: The name of the wave
-- `WaveID`: The unique identifier of the wave
-- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
-	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
+- `AgentAliasID`: No Description
+- `AgentAliasName`: No Description
+- `AgentID`: No Description
 
 !!! note - Using Properties
     Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
@@ -35,4 +29,12 @@ resources support properties. To write a filter against the string representatio
 the filter.
 
 The string value is always what is used in the output of the log format when a resource is identified.
+
+### DependsOn
+
+!!! important - Experimental Feature
+    This resource depends on a resource using the experimental feature. This means that the resource will
+    only be deleted if all the resources of a particular type are deleted first or reach a terminal state.
+
+- [BedrockAgent](./bedrock-agent.md)
 

--- a/docs/resources/bedrock-flow-alias.md
+++ b/docs/resources/bedrock-flow-alias.md
@@ -2,27 +2,21 @@
 generated: true
 ---
 
-# MGNWave
+# BedrockFlowAlias
 
 
 ## Resource
 
 ```text
-MGNWave
+BedrockFlowAlias
 ```
 
 ## Properties
 
 
-- `Arn`: The ARN of the wave
-- `CreationDateTime`: The date and time the wave was created
-- `Description`: The description of the wave
-- `IsArchived`: Whether the wave is archived
-- `LastModifiedDateTime`: The date and time the wave was last modified
-- `Name`: The name of the wave
-- `WaveID`: The unique identifier of the wave
-- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
-	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
+- `FlowAliasID`: No Description
+- `FlowAliasName`: No Description
+- `FlowID`: No Description
 
 !!! note - Using Properties
     Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property

--- a/docs/resources/iam-user.md
+++ b/docs/resources/iam-user.md
@@ -37,6 +37,21 @@ the filter.
 
 The string value is always what is used in the output of the log format when a resource is identified.
 
+## Settings
+
+- `IgnorePermissionBoundary`
+
+
+### IgnorePermissionBoundary
+
+!!! note
+    There is currently no description for this setting. Often times settings are fairly self-explanatory. However, we
+    are working on adding descriptions for all settings.
+
+```text
+IgnorePermissionBoundary
+```
+
 ### DependsOn
 
 !!! important - Experimental Feature

--- a/docs/resources/mgn-application.md
+++ b/docs/resources/mgn-application.md
@@ -4,7 +4,6 @@ generated: true
 
 # MGNApplication
 
-AWS Application Migration Service (MGN) Application represents a logical grouping of source servers in AWS MGN. Applications help organize and manage collections of servers that work together as part of a business application or workload.
 
 ## Resource
 
@@ -14,17 +13,26 @@ MGNApplication
 
 ## Properties
 
-- `ApplicationID` - The unique identifier of the application
-- `Arn` - The ARN of the application
-- `Name` - The name of the application
-- `Description` - The description of the application
-- `IsArchived` - Whether the application is archived
-- `CreationDateTime` - The date and time the application was created
-- `LastModifiedDateTime` - The date and time the application was last modified
-- `Tags` - The tags associated with the application
 
-## Deletion Process
+- `ApplicationID`: The unique identifier of the application
+- `Arn`: The ARN of the application
+- `CreationDateTime`: The date and time the application was created
+- `Description`: The description of the application
+- `IsArchived`: Whether the application is archived
+- `LastModifiedDateTime`: The date and time the application was last modified
+- `Name`: The name of the application
+- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
+	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
 
-MGN Applications are deleted directly using the `DeleteApplication` API call. This removes the application grouping from AWS MGN.
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
 
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
 

--- a/docs/resources/mgn-job.md
+++ b/docs/resources/mgn-job.md
@@ -4,7 +4,6 @@ generated: true
 
 # MGNJob
 
-AWS Application Migration Service (MGN) Job represents a migration job that has been initiated within AWS MGN. Jobs can be of different types such as LAUNCH, TERMINATE, and others, and track the progress of migration operations.
 
 ## Resource
 
@@ -14,16 +13,26 @@ MGNJob
 
 ## Properties
 
-- `JobID` - The unique identifier of the job
-- `Arn` - The ARN of the job
-- `Type` - The type of job (LAUNCH, TERMINATE, etc.)
-- `Status` - The status of the job
-- `InitiatedBy` - Who initiated the job
-- `CreationDateTime` - The date and time the job was created
-- `EndDateTime` - The date and time the job ended
-- `Tags` - The tags associated with the job
 
-## Deletion Process
+- `Arn`: The ARN of the job
+- `CreationDateTime`: The date and time the job was created
+- `EndDateTime`: The date and time the job ended
+- `InitiatedBy`: Who initiated the job
+- `JobID`: The unique identifier of the job
+- `Status`: The status of the job
+- `Type`: The type of job (LAUNCH, TERMINATE, etc.)
+- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
+	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
 
-MGN Jobs are deleted directly using the `DeleteJob` API call. This removes the job record from AWS MGN.
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
 

--- a/docs/resources/mgn-launch-configuration-template.md
+++ b/docs/resources/mgn-launch-configuration-template.md
@@ -4,7 +4,6 @@ generated: true
 
 # MGNLaunchConfigurationTemplate
 
-AWS Application Migration Service (MGN) Launch Configuration Template defines the configuration settings for launching target instances during the migration process. This template specifies EC2 instance settings, networking configuration, and other launch parameters.
 
 ## Resource
 
@@ -14,19 +13,27 @@ MGNLaunchConfigurationTemplate
 
 ## Properties
 
-- `LaunchConfigurationTemplateID` - The unique identifier of the launch configuration template
-- `Arn` - The ARN of the launch configuration template
-- `Ec2LaunchTemplateID` - The ID of the associated EC2 launch template
-- `LaunchDisposition` - The launch disposition (STOPPED, STARTED)
-- `TargetInstanceTypeRightSizingMethod` - The method for right-sizing the target instance type
-- `CopyPrivateIp` - Whether to copy the private IP address
-- `CopyTags` - Whether to copy tags to the launched instance
-- `EnableMapAutoTagging` - Whether to enable automatic tagging
-- `Tags` - The tags associated with the template
 
-## Deletion Process
+- `Arn`: The ARN of the launch configuration template
+- `CopyPrivateIp`: Whether to copy the private IP address
+- `CopyTags`: Whether to copy tags to the launched instance
+- `Ec2LaunchTemplateID`: The ID of the associated EC2 launch template
+- `EnableMapAutoTagging`: Whether to enable automatic tagging
+- `LaunchConfigurationTemplateID`: The unique identifier of the launch configuration template
+- `LaunchDisposition`: The launch disposition (STOPPED, STARTED)
+- `TargetInstanceTypeRightSizingMethod`: The method for right-sizing the target instance type
+- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
+	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
 
-MGN Launch Configuration Templates are deleted directly using the `DeleteLaunchConfigurationTemplate` API call. This removes the template configuration from AWS MGN.
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
 
+### String Property
 
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
 

--- a/docs/resources/mgn-replication-configuration-template.md
+++ b/docs/resources/mgn-replication-configuration-template.md
@@ -4,7 +4,6 @@ generated: true
 
 # MGNReplicationConfigurationTemplate
 
-AWS Application Migration Service (MGN) Replication Configuration Template defines the settings for data replication during the migration process. This template specifies replication server configuration, networking settings, bandwidth throttling, and encryption parameters.
 
 ## Resource
 
@@ -14,23 +13,31 @@ MGNReplicationConfigurationTemplate
 
 ## Properties
 
-- `ReplicationConfigurationTemplateID` - The unique identifier of the replication configuration template
-- `Arn` - The ARN of the replication configuration template
-- `StagingAreaSubnetId` - The subnet ID for the staging area
-- `AssociateDefaultSecurityGroup` - Whether to associate the default security group
-- `BandwidthThrottling` - The bandwidth throttling setting
-- `CreatePublicIP` - Whether to create a public IP
-- `DataPlaneRouting` - The data plane routing setting
-- `DefaultLargeStagingDiskType` - The default large staging disk type
-- `EbsEncryption` - The EBS encryption setting
-- `EbsEncryptionKeyArn` - The ARN of the EBS encryption key
-- `ReplicationServerInstanceType` - The instance type for the replication server
-- `UseDedicatedReplicationServer` - Whether to use a dedicated replication server
-- `Tags` - The tags associated with the template
 
-## Deletion Process
+- `Arn`: The ARN of the replication configuration template
+- `AssociateDefaultSecurityGroup`: Whether to associate the default security group
+- `BandwidthThrottling`: The bandwidth throttling setting
+- `CreatePublicIP`: Whether to create a public IP
+- `DataPlaneRouting`: The data plane routing setting
+- `DefaultLargeStagingDiskType`: The default large staging disk type
+- `EbsEncryption`: The EBS encryption setting
+- `EbsEncryptionKeyArn`: The ARN of the EBS encryption key
+- `ReplicationConfigurationTemplateID`: The unique identifier of the replication configuration template
+- `ReplicationServerInstanceType`: The instance type for the replication server
+- `StagingAreaSubnetId`: The subnet ID for the staging area
+- `UseDedicatedReplicationServer`: Whether to use a dedicated replication server
+- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
+	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
 
-MGN Replication Configuration Templates are deleted directly using the `DeleteReplicationConfigurationTemplate` API call. This removes the template configuration from AWS MGN.
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
 
+### String Property
 
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
 

--- a/docs/resources/mgn-source-server.md
+++ b/docs/resources/mgn-source-server.md
@@ -4,7 +4,6 @@ generated: true
 
 # MGNSourceServer
 
-AWS Application Migration Service (MGN) Source Server represents a server that has been configured for migration using AWS MGN. Source servers are the physical or virtual machines in your source environment that you want to migrate to AWS.
 
 ## Resource
 
@@ -14,21 +13,26 @@ MGNSourceServer
 
 ## Properties
 
-- `SourceServerID` - The unique identifier of the source server
-- `Arn` - The ARN of the source server
-- `ReplicationType` - The type of replication (AGENT_BASED, etc.)
-- `IsArchived` - Whether the source server is archived
-- `LifeCycleState` - The lifecycle state of the source server
-- `Hostname` - The hostname of the source server
-- `FQDN` - The fully qualified domain name of the source server
-- `Tags` - The tags associated with the source server
 
-## Deletion Process
+- `Arn`: The ARN of the source server
+- `FQDN`: The fully qualified domain name of the source server
+- `Hostname`: The hostname of the source server
+- `IsArchived`: Whether the source server is archived
+- `LifeCycleState`: The lifecycle state of the source server
+- `ReplicationType`: The type of replication (AGENT_BASED, etc.)
+- `SourceServerID`: The unique identifier of the source server
+- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
+	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
 
-When deleting an MGN Source Server, aws-nuke performs the following steps:
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
 
-1. First disconnects the source server from the MGN service using `DisconnectFromService`
-2. Then deletes the source server using `DeleteSourceServer`
+### String Property
 
-This ensures that replication is properly stopped before the resource is removed.
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
 

--- a/docs/resources/network-firewall-logging-configuration.md
+++ b/docs/resources/network-firewall-logging-configuration.md
@@ -1,0 +1,42 @@
+---
+generated: true
+---
+
+# NetworkFirewallLoggingConfiguration
+
+
+## Resource
+
+```text
+NetworkFirewallLoggingConfiguration
+```
+
+### Alternative Resource
+
+!!! warning - Cloud Control API - Alternative Resource
+    This resource conflicts with an alternative resource that can be controlled and used via Cloud Control API. If you
+    use this alternative resource, please note that any properties listed on this page may not be valid. You will need
+    run the tool to determine what properties are available for the alternative resource via the Cloud Control API.
+    Please refer to the documentation for [Cloud Control Resources](../config-cloud-control.md) for more information.
+
+```text
+AWS::NetworkFirewall::LoggingConfiguration
+```
+## Properties
+
+
+- `ARN`: The ARN of the firewall.
+- `Name`: The name of the firewall.
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
+

--- a/docs/resources/network-firewall-policy.md
+++ b/docs/resources/network-firewall-policy.md
@@ -1,0 +1,42 @@
+---
+generated: true
+---
+
+# NetworkFirewallPolicy
+
+
+## Resource
+
+```text
+NetworkFirewallPolicy
+```
+
+### Alternative Resource
+
+!!! warning - Cloud Control API - Alternative Resource
+    This resource conflicts with an alternative resource that can be controlled and used via Cloud Control API. If you
+    use this alternative resource, please note that any properties listed on this page may not be valid. You will need
+    run the tool to determine what properties are available for the alternative resource via the Cloud Control API.
+    Please refer to the documentation for [Cloud Control Resources](../config-cloud-control.md) for more information.
+
+```text
+AWS::NetworkFirewall::FirewallPolicy
+```
+## Properties
+
+
+- `ARN`: The ARN of the firewall policy.
+- `Name`: The name of the firewall policy.
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
+

--- a/docs/resources/network-firewall-rule-group.md
+++ b/docs/resources/network-firewall-rule-group.md
@@ -1,0 +1,42 @@
+---
+generated: true
+---
+
+# NetworkFirewallRuleGroup
+
+
+## Resource
+
+```text
+NetworkFirewallRuleGroup
+```
+
+### Alternative Resource
+
+!!! warning - Cloud Control API - Alternative Resource
+    This resource conflicts with an alternative resource that can be controlled and used via Cloud Control API. If you
+    use this alternative resource, please note that any properties listed on this page may not be valid. You will need
+    run the tool to determine what properties are available for the alternative resource via the Cloud Control API.
+    Please refer to the documentation for [Cloud Control Resources](../config-cloud-control.md) for more information.
+
+```text
+AWS::NetworkFirewall::RuleGroup
+```
+## Properties
+
+
+- `ARN`: The ARN of the rule group.
+- `Name`: The name of the rule group.
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
+

--- a/docs/resources/network-firewall.md
+++ b/docs/resources/network-firewall.md
@@ -1,0 +1,50 @@
+---
+generated: true
+---
+
+# NetworkFirewall
+
+
+## Resource
+
+```text
+NetworkFirewall
+```
+
+### Alternative Resource
+
+!!! warning - Cloud Control API - Alternative Resource
+    This resource conflicts with an alternative resource that can be controlled and used via Cloud Control API. If you
+    use this alternative resource, please note that any properties listed on this page may not be valid. You will need
+    run the tool to determine what properties are available for the alternative resource via the Cloud Control API.
+    Please refer to the documentation for [Cloud Control Resources](../config-cloud-control.md) for more information.
+
+```text
+AWS::NetworkFirewall::Firewall
+```
+## Properties
+
+
+- `ARN`: The ARN of the firewall.
+- `Name`: The name of the firewall.
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
+
+### DependsOn
+
+!!! important - Experimental Feature
+    This resource depends on a resource using the experimental feature. This means that the resource will
+    only be deleted if all the resources of a particular type are deleted first or reach a terminal state.
+
+- [NetworkFirewallLoggingConfiguration](./network-firewall-logging-configuration.md)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,10 +185,12 @@ nav:
     - Batch Compute Environment: resources/batch-compute-environment.md
     - Batch Job Queue State: resources/batch-job-queue-state.md
     - Batch Job Queue: resources/batch-job-queue.md
+    - Bedrock Agent Alias: resources/bedrock-agent-alias.md
     - Bedrock Agent: resources/bedrock-agent.md
     - Bedrock Custom Model: resources/bedrock-custom-model.md
     - Bedrock Data Source: resources/bedrock-data-source.md
     - Bedrock Evaluation Job: resources/bedrock-evaluation-job.md
+    - Bedrock Flow Alias: resources/bedrock-flow-alias.md
     - Bedrock Guardrail: resources/bedrock-guardrail.md
     - Bedrock Knowledge Base: resources/bedrock-knowledge-base.md
     - Bedrock Model Customization Job: resources/bedrock-model-customization-job.md

--- a/resources/iam-user.go
+++ b/resources/iam-user.go
@@ -57,7 +57,7 @@ type IAMUser struct {
 }
 
 func (r *IAMUser) Remove(_ context.Context) error {
-	if r.HasPermissionBoundary && r.settings.GetBool("IgnorePermissionBoundary") == false {
+	if r.HasPermissionBoundary && !r.settings.GetBool("IgnorePermissionBoundary") {
 		fmt.Println("Removing permission boundary for user", *r.Name)
 		_, err := r.svc.DeleteUserPermissionsBoundary(&iam.DeleteUserPermissionsBoundaryInput{
 			UserName: r.Name,

--- a/resources/iam-user_mock_test.go
+++ b/resources/iam-user_mock_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	libsettings "github.com/ekristen/libnuke/pkg/settings"
 	"github.com/golang/mock/gomock"
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
@@ -68,6 +69,7 @@ func Test_Mock_IAMUser_Remove(t *testing.T) {
 		svc:                   mockIAM,
 		Name:                  ptr.String("foobar"),
 		HasPermissionBoundary: true,
+		settings:              &libsettings.Setting{},
 	}
 
 	err := iamUser.Remove(context.TODO())


### PR DESCRIPTION
This adds a setting to the `IAMUser` that allows for bypassing the removal the permission boundary. User @npellegrin has pointed out that they have a SCP that prevents removing of boundaries and the AWS API does not require the removal of the permission boundary before the user, therefore to keep existing flow in place, but allow use of tool by others that have more restrictions.

Resolves https://github.com/ekristen/aws-nuke/issues/715