### PR TITLE
feat: add configuration flag to support maximum retries on resource failure

### DIFF
--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -57,14 +57,15 @@ func execute(baseCtx context.Context, c *cli.Command) error { //nolint:funlen,go
 
 	// Create the parameters object that will be used to configure the nuke process.
 	params := &libnuke.Parameters{
-		Force:          c.Bool("force"),
-		ForceSleep:     c.Int("force-sleep"),
-		Quiet:          c.Bool("quiet"),
-		NoDryRun:       c.Bool("no-dry-run"),
-		Includes:       c.StringSlice("include"),
-		Excludes:       c.StringSlice("exclude"),
-		Alternatives:   c.StringSlice("cloud-control"),
-		MaxWaitRetries: c.Int("max-wait-retries"),
+		Force:             c.Bool("force"),
+		ForceSleep:        c.Int("force-sleep"),
+		Quiet:             c.Bool("quiet"),
+		NoDryRun:          c.Bool("no-dry-run"),
+		Includes:          c.StringSlice("include"),
+		Excludes:          c.StringSlice("exclude"),
+		Alternatives:      c.StringSlice("cloud-control"),
+		MaxWaitRetries:    c.Int("max-wait-retries"),
+		MaxFailureRetries: c.Int("max-failure-retries"),
 	}
 
 	if len(c.StringSlice("feature-flag")) > 0 {
@@ -294,6 +295,11 @@ func init() { //nolint:funlen
 		&cli.IntFlag{
 			Name:   "max-wait-retries",
 			Usage:  "maximum number of retries to wait for dependencies to be removed",
+			Action: common.CheckRealInt,
+		},
+		&cli.IntFlag{
+			Name:   "max-failure-retries",
+			Usage:  "maximum number of retries to wait for failed dependencies to be removed",
 			Action: common.CheckRealInt,
 		},
 		&cli.DurationFlag{


### PR DESCRIPTION
Adds a command line flag to use the new configuration parameter controlling the maximum number of retries when all that remains are failed resources implemented in https://github.com/ekristen/libnuke/pull/139

Fixes: https://github.com/ekristen/aws-nuke/issues/760