### PR TITLE
docs: fix invalid links

### DIFF
--- a/docs/resources/iot-site-wise-asset-model.md
+++ b/docs/resources/iot-site-wise-asset-model.md
@@ -38,5 +38,5 @@ The string value is always what is used in the output of the log format when a r
     This resource depends on a resource using the experimental feature. This means that the resource will
     only be deleted if all the resources of a particular type are deleted first or reach a terminal state.
 
-- [IoTSiteWiseAsset](./io-tsite-wise-asset.md)
+- [IoTSiteWiseAsset](./iot-site-wise-asset.md)
 

--- a/docs/resources/iot-site-wise-portal.md
+++ b/docs/resources/iot-site-wise-portal.md
@@ -35,6 +35,6 @@ The string value is always what is used in the output of the log format when a r
     This resource depends on a resource using the experimental feature. This means that the resource will
     only be deleted if all the resources of a particular type are deleted first or reach a terminal state.
 
-- [IoTSiteWiseProject](./io-tsite-wise-project.md)
-- [IoTSiteWiseAccessPolicy](./io-tsite-wise-access-policy.md)
+- [IoTSiteWiseProject](./iot-site-wise-project.md)
+- [IoTSiteWiseAccessPolicy](./iot-site-wise-access-policy.md)
 

--- a/docs/resources/iot-site-wise-project.md
+++ b/docs/resources/iot-site-wise-project.md
@@ -35,6 +35,6 @@ The string value is always what is used in the output of the log format when a r
     This resource depends on a resource using the experimental feature. This means that the resource will
     only be deleted if all the resources of a particular type are deleted first or reach a terminal state.
 
-- [IoTSiteWiseDashboard](./io-tsite-wise-dashboard.md)
-- [IoTSiteWiseAccessPolicy](./io-tsite-wise-access-policy.md)
+- [IoTSiteWiseDashboard](./iot-site-wise-dashboard.md)
+- [IoTSiteWiseAccessPolicy](./iot-site-wise-access-policy.md)
 

--- a/docs/resources/iot-twin-maker-workspace.md
+++ b/docs/resources/iot-twin-maker-workspace.md
@@ -36,8 +36,8 @@ The string value is always what is used in the output of the log format when a r
     This resource depends on a resource using the experimental feature. This means that the resource will
     only be deleted if all the resources of a particular type are deleted first or reach a terminal state.
 
-- [IoTTwinMakerComponentType](./io-ttwin-maker-component-type.md)
-- [IoTTwinMakerEntity](./io-ttwin-maker-entity.md)
-- [IoTTwinMakerScene](./io-ttwin-maker-scene.md)
-- [IoTTwinMakerSyncJob](./io-ttwin-maker-sync-job.md)
+- [IoTTwinMakerComponentType](./iot-twin-maker-component-type.md)
+- [IoTTwinMakerEntity](./iot-twin-maker-entity.md)
+- [IoTTwinMakerScene](./iot-twin-maker-scene.md)
+- [IoTTwinMakerSyncJob](./iot-twin-maker-sync-job.md)
 


### PR DESCRIPTION
Fixed invalid links with `gsed -i 's/io-t/iot-/g' docs/**/*.md`.

### Before

```shellsession
❯ make docs-build
docker run --rm -it -p 8000:8000 -v /Users/eggplants/prog/aws-nuke:/docs squidfunk/mkdocs-material build
Unable to find image 'squidfunk/mkdocs-material:latest' locally
latest: Pulling from squidfunk/mkdocs-material
6349979f771f: Pull complete
62cc65cd32d5: Pull complete
Digest: sha256:980e11fed03b8e7851e579be9f34b1210f516c9f0b4da1a1457f21a460bd6628
Status: Downloaded newer image for squidfunk/mkdocs-material:latest
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /docs/public
WARNING -  Doc file 'resources/iot-site-wise-asset-model.md' contains a link './io-tsite-wise-asset.md', but the target 'resources/io-tsite-wise-asset.md' is not found among documentation
           files.
WARNING -  Doc file 'resources/iot-site-wise-portal.md' contains a link './io-tsite-wise-project.md', but the target 'resources/io-tsite-wise-project.md' is not found among documentation
           files.
WARNING -  Doc file 'resources/iot-site-wise-portal.md' contains a link './io-tsite-wise-access-policy.md', but the target 'resources/io-tsite-wise-access-policy.md' is not found among
           documentation files.
WARNING -  Doc file 'resources/iot-site-wise-project.md' contains a link './io-tsite-wise-dashboard.md', but the target 'resources/io-tsite-wise-dashboard.md' is not found among documentation
           files.
WARNING -  Doc file 'resources/iot-site-wise-project.md' contains a link './io-tsite-wise-access-policy.md', but the target 'resources/io-tsite-wise-access-policy.md' is not found among
           documentation files.
WARNING -  Doc file 'resources/iot-twin-maker-workspace.md' contains a link './io-ttwin-maker-component-type.md', but the target 'resources/io-ttwin-maker-component-type.md' is not found among
           documentation files.
WARNING -  Doc file 'resources/iot-twin-maker-workspace.md' contains a link './io-ttwin-maker-entity.md', but the target 'resources/io-ttwin-maker-entity.md' is not found among documentation
           files.
WARNING -  Doc file 'resources/iot-twin-maker-workspace.md' contains a link './io-ttwin-maker-scene.md', but the target 'resources/io-ttwin-maker-scene.md' is not found among documentation
           files.
WARNING -  Doc file 'resources/iot-twin-maker-workspace.md' contains a link './io-ttwin-maker-sync-job.md', but the target 'resources/io-ttwin-maker-sync-job.md' is not found among
           documentation files.
INFO    -  Doc file 'installation.md' contains a link '#ekristens-homebrew-tap-macoslinux', but there is no such anchor on this page.
INFO    -  Documentation built in 5.25 seconds
```

### After

```shellsession
❯ make docs-build
docker run --rm -it -p 8000:8000 -v /Users/eggplants/prog/aws-nuke:/docs squidfunk/mkdocs-material build
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /docs/public
INFO    -  Doc file 'installation.md' contains a link '#ekristens-homebrew-tap-macoslinux', but there is no such anchor on this page.
INFO    -  Documentation built in 5.24 seconds
```