### PR TITLE
chore(cloudwatchlogs-loggroup): add depends on for LambdaFunction

### DIFF
--- a/resources/cloudwatchlogs-loggroup.go
+++ b/resources/cloudwatchlogs-loggroup.go
@@ -29,7 +29,8 @@ func init() {
 		Resource: &CloudWatchLogsLogGroup{},
 		Lister:   &CloudWatchLogsLogGroupLister{},
 		DependsOn: []string{
-			EC2VPCResource, // Reason: flow logs, if log group is cleaned before vpc, vpc can write more flow logs
+			EC2VPCResource,         // Reason: flow logs, if log group is cleaned before vpc, vpc can write more flow logs
+			LambdaFunctionResource, // Reason: Lambda functions can recreate log groups due to invocations, automatic container provisioning, etc.
 		},
 	})
 }


### PR DESCRIPTION
I ran into an issue where log groups were deleted before their associated Lambda functions. Some of those functions were invoked later, which caused the groups to be recreated automatically when the functions tried to write logs. Since Nuke had already successfully deleted the original groups, it reported an overall success, even though the newly created groups still existed in the account.