### PR TITLE
fix(cloudwatchlogs): convert LastEvent to UTC and remove deprecated logGroupName property

### DIFF
--- a/resources/cloudwatchlogs-loggroup.go
+++ b/resources/cloudwatchlogs-loggroup.go
@@ -119,7 +119,7 @@ func (l *CloudWatchLogsLogGroupLister) List(ctx context.Context, o interface{}) 
 				Name:            logGroup.LogGroupName,
 				CreatedTime:     logGroup.CreationTime,
 				CreationTime:    ptr.Time(time.Unix(*logGroup.CreationTime/1000, 0).UTC()),
-				LastEvent:       ptr.Time(lastEvent), // TODO(v4): convert to UTC
+				LastEvent:       ptr.Time(lastEvent.UTC()),
 				RetentionInDays: retentionInDays,
 				Tags:            tagResp.Tags,
 				protection:      logGroup.DeletionProtectionEnabled,
@@ -167,8 +167,7 @@ func (r *CloudWatchLogsLogGroup) String() string {
 }
 
 func (r *CloudWatchLogsLogGroup) Properties() types.Properties {
-	return types.NewPropertiesFromStruct(r).
-		Set("logGroupName", r.Name) // TODO(v4): remove this property
+	return types.NewPropertiesFromStruct(r)
 }
 
 func (r *CloudWatchLogsLogGroup) Settings(setting *libsettings.Setting) {

--- a/resources/cloudwatchlogs-loggroup_test.go
+++ b/resources/cloudwatchlogs-loggroup_test.go
@@ -24,7 +24,6 @@ func TestCloudWatchLogsLogGroupProperties(t *testing.T) {
 	}
 
 	properties := r.Properties()
-	assert.Equal(t, properties.Get("logGroupName"), "test-log-group")
 	assert.Equal(t, properties.Get("Name"), "test-log-group")
 	assert.Equal(t, properties.Get("CreatedTime"), strconv.Itoa(int(now.Unix())))
 	assert.Equal(t, properties.Get("CreationTime"), now.Format(time.RFC3339))


### PR DESCRIPTION
## Description
This PR addresses two `TODO(v4)` items in the CloudWatchLogsLogGroup resource.

### Changes

1. **Convert `LastEvent` to UTC** (Line 122)
   - The `LastEvent` timestamp is now converted to UTC using `.UTC()`
   - This ensures consistency with `CreationTime` which already uses UTC

2. **Remove deprecated `logGroupName` property** (Line 169-171)
   - Removed the redundant `logGroupName` property alias
   - Users should use the `Name` property instead (which is auto-generated by `NewPropertiesFromStruct`)

### Breaking Change

⚠️ **This is a breaking change for filters**

Users who filter CloudWatchLogsLogGroup resources using `logGroupName` must update their configurations to use `Name` instead:

# Before (deprecated)
CloudWatchLogsLogGroup:
  - property: logGroupName
    value: "my-log-group"

# After
CloudWatchLogsLogGroup:
  - property: Name
    value: "my-log-group"

###Test Result:
<img width="659" height="70" alt="image" src="https://github.com/user-attachments/assets/5d50c788-754a-4f5b-b1cc-3d022cfc062b" />
