### PR TITLE
feat: add DisableDeletionProtection for firewall rule group association mutation protection

### DIFF
--- a/docs/resources/route-53-resolver-firewall-domain-list.md
+++ b/docs/resources/route-53-resolver-firewall-domain-list.md
@@ -1,0 +1,34 @@
+---
+generated: true
+---
+
+# Route53ResolverFirewallDomainList
+
+
+## Resource
+
+```text
+Route53ResolverFirewallDomainList
+```
+
+## Properties
+
+
+- `Arn`: No Description
+- `CreatorRequestID`: No Description
+- `ID`: No Description
+- `ManagedOwnerName`: No Description
+- `Name`: No Description
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
+

--- a/docs/resources/route-53-resolver-firewall-rule-group-association.md
+++ b/docs/resources/route-53-resolver-firewall-rule-group-association.md
@@ -1,0 +1,55 @@
+---
+generated: true
+---
+
+# Route53ResolverFirewallRuleGroupAssociation
+
+
+## Resource
+
+```text
+Route53ResolverFirewallRuleGroupAssociation
+```
+
+## Properties
+
+
+- `Arn`: The ARN of the firewall rule group association
+- `CreationTime`: The time the association was created (Unix time, UTC)
+- `CreatorRequestID`: The unique ID for the request that created the association
+- `FirewallRuleGroupID`: The ID of the associated firewall rule group
+- `ID`: The ID of the firewall rule group association
+- `ManagedOwnerName`: The owner of the association, if not managed by you
+- `ModificationTime`: The time the association was last changed (Unix time, UTC)
+- `MutationProtection`: Whether mutation protection is enabled for the association
+- `Name`: The name of the firewall rule group association
+- `Priority`: The processing order of the rule group within the VPC
+- `Status`: The current status of the association
+- `VpcID`: The ID of the associated VPC
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
+
+## Settings
+
+- `DisableDeletionProtection`
+
+
+### DisableDeletionProtection
+
+Disables mutation protection for the Firewall Rule Group/VPC association so that a protected association can be deleted.
+
+
+```text
+DisableDeletionProtection
+```
+

--- a/docs/resources/route-53-resolver-firewall-rule-group.md
+++ b/docs/resources/route-53-resolver-firewall-rule-group.md
@@ -1,0 +1,35 @@
+---
+generated: true
+---
+
+# Route53ResolverFirewallRuleGroup
+
+
+## Resource
+
+```text
+Route53ResolverFirewallRuleGroup
+```
+
+## Properties
+
+
+- `Arn`: The ARN of the firewall rule group
+- `CreatorRequestID`:  The unique identifier (ID) for the request that created the firewall rule group
+- `ID`:  The unique identifier (ID) for the firewall rule group
+- `Name`:  Name of the firewall rule group
+- `OwnerID`:  ID of the AWS account that created the firewall rule group
+- `ShareStatus`:  The current sharing status of the firewall rule group
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
+

--- a/docs/resources/route-53-resolver-query-log-config.md
+++ b/docs/resources/route-53-resolver-query-log-config.md
@@ -1,0 +1,39 @@
+---
+generated: true
+---
+
+# Route53ResolverQueryLogConfig
+
+
+## Resource
+
+```text
+Route53ResolverQueryLogConfig
+```
+
+## Properties
+
+
+- `Arn`: No Description
+- `AssociationCount`: No Description
+- `CreationTime`: No Description
+- `CreatorRequestID`: No Description
+- `DestinationArn`: No Description
+- `ID`: No Description
+- `Name`: No Description
+- `OwnerID`: No Description
+- `ShareStatus`: No Description
+- `Status`: No Description
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -584,6 +584,9 @@ nav:
     - Route 53 Profile Association: resources/route-53-profile-association.md
     - Route 53 Profile: resources/route-53-profile.md
     - Route 53 Resolver Endpoint: resources/route-53-resolver-endpoint.md
+    - Route 53 Resolver Firewall Query Log Config: resources/route-53-resolver-firewall-query-log-config.md
+    - Route 53 Resolver Firewall Rule Group: resources/route-53-resolver-firewall-rule-group.md
+    - Route 53 Resolver Firewall Domain List: resources/route-53-resolver-firewall-domain-list.md
     - Route 53 Resolver Rule: resources/route-53-resolver-rule.md
     - Route 53 Resource Record Set: resources/route-53-resource-record-set.md
     - Route 53 Traffic Policy: resources/route-53-traffic-policy.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -588,6 +588,10 @@ nav:
     - Route 53 Profile Association: resources/route-53-profile-association.md
     - Route 53 Profile: resources/route-53-profile.md
     - Route 53 Resolver Endpoint: resources/route-53-resolver-endpoint.md
+    - Route 53 Resolver Firewall Domain List: resources/route-53-resolver-firewall-domain-list.md
+    - Route 53 Resolver Firewall Rule Group Association: resources/route-53-resolver-firewall-rule-group-association.md
+    - Route 53 Resolver Firewall Rule Group: resources/route-53-resolver-firewall-rule-group.md
+    - Route 53 Resolver Query Log Config: resources/route-53-resolver-query-log-config.md
     - Route 53 Resolver Rule: resources/route-53-resolver-rule.md
     - Route 53 Resource Record Set: resources/route-53-resource-record-set.md
     - Route 53 Traffic Policy: resources/route-53-traffic-policy.md
@@ -596,6 +600,9 @@ nav:
     - S3 Access Grants Location: resources/s3-access-grants-location.md
     - S3 Access Point: resources/s3-access-point.md
     - S3 Bucket: resources/s3-bucket.md
+    - S3 Files Access Point: resources/s3-files-access-point.md
+    - S3 Files File System: resources/s3-files-file-system.md
+    - S3 Files Mount Target: resources/s3-files-mount-target.md
     - S3 Multipart Upload: resources/s3-multipart-upload.md
     - S3 Object: resources/s3-object.md
     - S3 Tables Bucket: resources/s3-tables-bucket.md
@@ -605,9 +612,6 @@ nav:
     - S3 Vectors Index: resources/s3-vectors-index.md
     - S3 Vectors Vector: resources/s3-vectors-vector.md
     - SNS Endpoint: resources/sns-endpoint.md
-    - S3Files File System: resources/s3-files-file-system.md
-    - S3Files Mount Target: resources/s3-files-mount-target.md
-    - S3Files Access Point: resources/s3-files-access-point.md
     - SNS Platform Application: resources/sns-platform-application.md
     - SNS Subscription: resources/sns-subscription.md
     - SNS Topic: resources/sns-topic.md

--- a/mocks/mock_route53resolverv2/mock.go
+++ b/mocks/mock_route53resolverv2/mock.go
@@ -17,7 +17,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-
 // MockRoute53ResolverAPI is a mock of Route53ResolverAPI interface.
 type MockRoute53ResolverAPI struct {
 	ctrl     *gomock.Controller
@@ -282,3 +281,22 @@ func (mr *MockRoute53ResolverAPIMockRecorder) ListResolverQueryLogConfigs(ctx, p
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResolverQueryLogConfigs", reflect.TypeOf((*MockRoute53ResolverAPI)(nil).ListResolverQueryLogConfigs), varargs...)
 }
 
+// UpdateFirewallRuleGroupAssociation mocks base method.
+func (m *MockRoute53ResolverAPI) UpdateFirewallRuleGroupAssociation(ctx context.Context, params *route53resolver.UpdateFirewallRuleGroupAssociationInput, optFns ...func(*route53resolver.Options)) (*route53resolver.UpdateFirewallRuleGroupAssociationOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateFirewallRuleGroupAssociation", varargs...)
+	ret0, _ := ret[0].(*route53resolver.UpdateFirewallRuleGroupAssociationOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateFirewallRuleGroupAssociation indicates an expected call of UpdateFirewallRuleGroupAssociation.
+func (mr *MockRoute53ResolverAPIMockRecorder) UpdateFirewallRuleGroupAssociation(ctx, params any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFirewallRuleGroupAssociation", reflect.TypeOf((*MockRoute53ResolverAPI)(nil).UpdateFirewallRuleGroupAssociation), varargs...)
+}

--- a/resources/route53-resolver-api-interface.go
+++ b/resources/route53-resolver-api-interface.go
@@ -33,6 +33,9 @@ type Route53ResolverAPI interface {
 	ListResolverQueryLogConfigAssociations(ctx context.Context,
 		params *r53r.ListResolverQueryLogConfigAssociationsInput,
 		optFns ...func(*r53r.Options)) (*r53r.ListResolverQueryLogConfigAssociationsOutput, error)
+	UpdateFirewallRuleGroupAssociation(ctx context.Context,
+		params *r53r.UpdateFirewallRuleGroupAssociationInput,
+		optFns ...func(*r53r.Options)) (*r53r.UpdateFirewallRuleGroupAssociationOutput, error)
 }
 
 type Route53ResolverClient struct {
@@ -108,4 +111,9 @@ func (c *Route53ResolverClient) ListResolverQueryLogConfigs(ctx context.Context,
 	params *r53r.ListResolverQueryLogConfigsInput,
 	optFns ...func(*r53r.Options)) (*r53r.ListResolverQueryLogConfigsOutput, error) {
 	return c.Client.ListResolverQueryLogConfigs(ctx, params, optFns...)
+}
+func (c *Route53ResolverClient) UpdateFirewallRuleGroupAssociation(ctx context.Context,
+	params *r53r.UpdateFirewallRuleGroupAssociationInput,
+	optFns ...func(*r53r.Options)) (*r53r.UpdateFirewallRuleGroupAssociationOutput, error) {
+	return c.Client.UpdateFirewallRuleGroupAssociation(ctx, params, optFns...)
 }

--- a/resources/route53-resolver-firewall-rule-group-association.go
+++ b/resources/route53-resolver-firewall-rule-group-association.go
@@ -1,0 +1,193 @@
+package resources
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sirupsen/logrus"
+
+	r53r "github.com/aws/aws-sdk-go-v2/service/route53resolver"
+	r53rtypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
+
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	libsettings "github.com/ekristen/libnuke/pkg/settings"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const Route53ResolverFirewallRuleGroupAssociationResource = "Route53ResolverFirewallRuleGroupAssociation"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     Route53ResolverFirewallRuleGroupAssociationResource,
+		Scope:    nuke.Account,
+		Resource: &Route53ResolverFirewallRuleGroupAssociation{},
+		Lister:   &Route53ResolverFirewallRuleGroupAssociationLister{},
+		Settings: []string{
+			"DisableDeletionProtection",
+		},
+	})
+}
+
+type Route53ResolverFirewallRuleGroupAssociationLister struct {
+	svc Route53ResolverAPI
+}
+
+// List returns all Route53 Resolver Firewall Rule Group to VPC associations in the account.
+func (l *Route53ResolverFirewallRuleGroupAssociationLister) List(ctx context.Context, o interface{}) (
+	[]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	var resources []resource.Resource
+
+	if l.svc == nil {
+		l.svc = r53r.NewFromConfig(*opts.Config)
+	}
+
+	params := &r53r.ListFirewallRuleGroupAssociationsInput{}
+	for {
+		resp, err := l.svc.ListFirewallRuleGroupAssociations(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range resp.FirewallRuleGroupAssociations {
+			assoc := resp.FirewallRuleGroupAssociations[i]
+			resources = append(resources, &Route53ResolverFirewallRuleGroupAssociation{
+				svc:                 l.svc,
+				ID:                  assoc.Id,
+				Arn:                 assoc.Arn,
+				Name:                assoc.Name,
+				FirewallRuleGroupID: assoc.FirewallRuleGroupId,
+				VpcID:               assoc.VpcId,
+				Priority:            assoc.Priority,
+				MutationProtection:  assoc.MutationProtection,
+				Status:              assoc.Status,
+				CreatorRequestID:    assoc.CreatorRequestId,
+				ManagedOwnerName:    assoc.ManagedOwnerName,
+				CreationTime:        assoc.CreationTime,
+				ModificationTime:    assoc.ModificationTime,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+// Route53ResolverFirewallRuleGroupAssociation is the resource type for a single FRG to VPC association.
+type Route53ResolverFirewallRuleGroupAssociation struct {
+	svc                 Route53ResolverAPI
+	settings            *libsettings.Setting
+	ID                  *string                                      `description:"The ID of the firewall rule group association"`
+	Arn                 *string                                      `description:"The ARN of the firewall rule group association"`
+	Name                *string                                      `description:"The name of the firewall rule group association"`
+	FirewallRuleGroupID *string                                      `description:"The ID of the associated firewall rule group"`
+	VpcID               *string                                      `description:"The ID of the associated VPC"`
+	Priority            *int32                                       `description:"The processing order of the rule group within the VPC"`
+	MutationProtection  r53rtypes.MutationProtectionStatus           `description:"Whether mutation protection is enabled for the association"`
+	Status              r53rtypes.FirewallRuleGroupAssociationStatus `description:"The current status of the association"`
+	CreatorRequestID    *string                                      `description:"The unique ID for the request that created the association"`
+	ManagedOwnerName    *string                                      `description:"The owner of the association, if not managed by you"`
+	CreationTime        *string                                      `description:"The time the association was created (Unix time, UTC)"`
+	ModificationTime    *string                                      `description:"The time the association was last changed (Unix time, UTC)"`
+}
+
+func (r *Route53ResolverFirewallRuleGroupAssociation) Settings(settings *libsettings.Setting) {
+	r.settings = settings
+}
+
+// Filter excludes associations that are managed by another owner (e.g. Firewall Manager) since
+// those cannot be disassociated directly.
+func (r *Route53ResolverFirewallRuleGroupAssociation) Filter() error {
+	if r.ManagedOwnerName != nil && *r.ManagedOwnerName != "" {
+		return errors.New("cannot delete association managed by another owner")
+	}
+	return nil
+}
+
+// Remove implements Resource. It disables mutation protection (when permitted) before
+// disassociating the firewall rule group from the VPC. Disassociation is asynchronous.
+func (r *Route53ResolverFirewallRuleGroupAssociation) Remove(ctx context.Context) error {
+	var notFound *r53rtypes.ResourceNotFoundException
+
+	if r.settings.GetBool("DisableDeletionProtection") &&
+		r.MutationProtection == r53rtypes.MutationProtectionStatusEnabled {
+		// Disable mutation protection so the association can be removed.
+		// This call is fast and appears to be synchronous.
+		_, err := r.svc.UpdateFirewallRuleGroupAssociation(ctx,
+			&r53r.UpdateFirewallRuleGroupAssociationInput{
+				FirewallRuleGroupAssociationId: r.ID,
+				MutationProtection:             r53rtypes.MutationProtectionStatusDisabled,
+			},
+		)
+		if err != nil && !errors.As(err, &notFound) {
+			return err
+		}
+	}
+
+	// Remove the association. This results in an async disassociation which can take some
+	// time to complete.
+	_, err := r.svc.DisassociateFirewallRuleGroup(ctx, &r53r.DisassociateFirewallRuleGroupInput{
+		FirewallRuleGroupAssociationId: r.ID,
+	})
+	if err != nil {
+		// ignore notFound, probably already disassociated
+		if errors.As(err, &notFound) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (r *Route53ResolverFirewallRuleGroupAssociation) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *Route53ResolverFirewallRuleGroupAssociation) String() string {
+	return *r.ID
+}
+
+// HandleWait waits for the disassociation to complete. Disassociation is asynchronous so we poll
+// the association status until it is gone (deleted) or no longer in a pending state.
+func (r *Route53ResolverFirewallRuleGroupAssociation) HandleWait(ctx context.Context) error {
+	var notFound *r53rtypes.ResourceNotFoundException
+
+	params := &r53r.ListFirewallRuleGroupAssociationsInput{
+		FirewallRuleGroupId: r.FirewallRuleGroupID,
+	}
+
+	resp, err := r.svc.ListFirewallRuleGroupAssociations(ctx, params)
+	if err != nil {
+		// Not found means the association (and its rule group) are gone.
+		if errors.As(err, &notFound) {
+			return nil
+		}
+		return err
+	}
+
+	for i := range resp.FirewallRuleGroupAssociations {
+		assoc := resp.FirewallRuleGroupAssociations[i]
+		if assoc.Id == nil || *assoc.Id != *r.ID {
+			continue
+		}
+
+		if assoc.Status == r53rtypes.FirewallRuleGroupAssociationStatusDeleting ||
+			assoc.Status == r53rtypes.FirewallRuleGroupAssociationStatusUpdating {
+			logrus.Infof("Association %s is in status %s", *r.ID, assoc.Status)
+			return liberrors.ErrWaitResource("waiting for association to stabilize")
+		}
+	}
+
+	// The association is no longer present (or no longer pending), disassociation is complete.
+	return nil
+}

--- a/resources/route53-resolver-firewall-rule-group-association_mock_test.go
+++ b/resources/route53-resolver-firewall-rule-group-association_mock_test.go
@@ -1,0 +1,220 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gotidy/ptr"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	r53r "github.com/aws/aws-sdk-go-v2/service/route53resolver"
+	r53rtypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
+
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
+	libsettings "github.com/ekristen/libnuke/pkg/settings"
+
+	"github.com/ekristen/aws-nuke/v3/mocks/mock_route53resolverv2"
+)
+
+func Test_Mock_Route53ResolverFirewallRuleGroupAssociation_List(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRoute53Resolver := mock_route53resolverv2.NewMockRoute53ResolverAPI(ctrl)
+
+	mockRoute53Resolver.EXPECT().ListFirewallRuleGroupAssociations(gomock.Any(),
+		gomock.Any()).Return(&r53r.ListFirewallRuleGroupAssociationsOutput{
+		FirewallRuleGroupAssociations: []r53rtypes.FirewallRuleGroupAssociation{
+			{
+				Id:                  ptr.String("rslvr-frgassoc-1"),
+				Arn:                 ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group-association/rslvr-frgassoc-1"),
+				FirewallRuleGroupId: ptr.String("rslvr-frg-1"),
+				Name:                ptr.String("association-1"),
+				Priority:            ptr.Int32(100),
+				Status:              r53rtypes.FirewallRuleGroupAssociationStatusComplete,
+				MutationProtection:  r53rtypes.MutationProtectionStatusDisabled,
+				VpcId:               ptr.String("vpc-12345"),
+			},
+			{
+				Id:                  ptr.String("rslvr-frgassoc-2"),
+				Arn:                 ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group-association/rslvr-frgassoc-2"),
+				FirewallRuleGroupId: ptr.String("rslvr-frg-2"),
+				Name:                ptr.String("association-2"),
+				Priority:            ptr.Int32(200),
+				Status:              r53rtypes.FirewallRuleGroupAssociationStatusComplete,
+				MutationProtection:  r53rtypes.MutationProtectionStatusEnabled,
+				VpcId:               ptr.String("vpc-67890"),
+			},
+		},
+	}, nil)
+
+	lister := &Route53ResolverFirewallRuleGroupAssociationLister{
+		svc: mockRoute53Resolver,
+	}
+
+	resources, err := lister.List(context.TODO(), testListerOpts)
+	a.Nil(err)
+	a.Len(resources, 2)
+
+	first := resources[0].(*Route53ResolverFirewallRuleGroupAssociation)
+	a.Equal("rslvr-frgassoc-1", *first.ID)
+	a.Equal("rslvr-frg-1", *first.FirewallRuleGroupID)
+	a.Equal("vpc-12345", *first.VpcID)
+	a.Equal(r53rtypes.MutationProtectionStatusDisabled, first.MutationProtection)
+
+	second := resources[1].(*Route53ResolverFirewallRuleGroupAssociation)
+	a.Equal("rslvr-frgassoc-2", *second.ID)
+	a.Equal(r53rtypes.MutationProtectionStatusEnabled, second.MutationProtection)
+}
+
+func Test_Mock_Route53ResolverFirewallRuleGroupAssociation_Remove(t *testing.T) {
+	isEnabled := true
+	notEnabled := false
+
+	testCases := []struct {
+		name               string
+		disableProtection  *bool
+		mutationProtection r53rtypes.MutationProtectionStatus
+		expectUpdate       bool
+	}{
+		{"protection_enabled_setting_on", &isEnabled, r53rtypes.MutationProtectionStatusEnabled, true},
+		{"protection_enabled_setting_off", &notEnabled, r53rtypes.MutationProtectionStatusEnabled, false},
+		{"protection_enabled_setting_unset", nil, r53rtypes.MutationProtectionStatusEnabled, false},
+		{"protection_disabled_setting_on", &isEnabled, r53rtypes.MutationProtectionStatusDisabled, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRoute53Resolver := mock_route53resolverv2.NewMockRoute53ResolverAPI(ctrl)
+
+			if tc.expectUpdate {
+				mockRoute53Resolver.EXPECT().
+					UpdateFirewallRuleGroupAssociation(gomock.Any(), gomock.Eq(&r53r.UpdateFirewallRuleGroupAssociationInput{
+						FirewallRuleGroupAssociationId: ptr.String("rslvr-frgassoc-1"),
+						MutationProtection:             r53rtypes.MutationProtectionStatusDisabled,
+					})).Return(&r53r.UpdateFirewallRuleGroupAssociationOutput{}, nil)
+			} else {
+				mockRoute53Resolver.EXPECT().
+					UpdateFirewallRuleGroupAssociation(gomock.Any(), gomock.Any()).Times(0)
+			}
+
+			mockRoute53Resolver.EXPECT().
+				DisassociateFirewallRuleGroup(gomock.Any(), gomock.Eq(&r53r.DisassociateFirewallRuleGroupInput{
+					FirewallRuleGroupAssociationId: ptr.String("rslvr-frgassoc-1"),
+				})).Return(&r53r.DisassociateFirewallRuleGroupOutput{}, nil)
+
+			settings := &libsettings.Setting{}
+			if tc.disableProtection != nil {
+				settings = &libsettings.Setting{
+					"DisableDeletionProtection": *tc.disableProtection,
+				}
+			}
+
+			assoc := &Route53ResolverFirewallRuleGroupAssociation{
+				svc:                 mockRoute53Resolver,
+				settings:            settings,
+				ID:                  ptr.String("rslvr-frgassoc-1"),
+				FirewallRuleGroupID: ptr.String("rslvr-frg-1"),
+				VpcID:               ptr.String("vpc-12345"),
+				MutationProtection:  tc.mutationProtection,
+			}
+
+			err := assoc.Remove(context.TODO())
+			a.Nil(err)
+		})
+	}
+}
+
+func Test_Mock_Route53ResolverFirewallRuleGroupAssociation_Properties(t *testing.T) {
+	a := assert.New(t)
+
+	assoc := &Route53ResolverFirewallRuleGroupAssociation{
+		ID:                  ptr.String("rslvr-frgassoc-1"),
+		Name:                ptr.String("association-1"),
+		FirewallRuleGroupID: ptr.String("rslvr-frg-1"),
+		VpcID:               ptr.String("vpc-12345"),
+		Status:              r53rtypes.FirewallRuleGroupAssociationStatusComplete,
+		MutationProtection:  r53rtypes.MutationProtectionStatusEnabled,
+	}
+
+	props := assoc.Properties()
+	a.Equal("rslvr-frgassoc-1", props.Get("ID"))
+	a.Equal("rslvr-frg-1", props.Get("FirewallRuleGroupID"))
+	a.Equal("vpc-12345", props.Get("VpcID"))
+	a.Equal("COMPLETE", props.Get("Status"))
+	a.Equal("rslvr-frgassoc-1", assoc.String())
+}
+
+func Test_Mock_Route53ResolverFirewallRuleGroupAssociation_Filter(t *testing.T) {
+	a := assert.New(t)
+
+	managed := &Route53ResolverFirewallRuleGroupAssociation{
+		ID:               ptr.String("rslvr-frgassoc-1"),
+		ManagedOwnerName: ptr.String("Firewall Manager"),
+	}
+	a.Error(managed.Filter())
+
+	unmanaged := &Route53ResolverFirewallRuleGroupAssociation{
+		ID: ptr.String("rslvr-frgassoc-2"),
+	}
+	a.Nil(unmanaged.Filter())
+}
+
+func Test_Mock_Route53ResolverFirewallRuleGroupAssociation_HandleWait(t *testing.T) {
+	testCases := []struct {
+		name      string
+		present   bool
+		status    r53rtypes.FirewallRuleGroupAssociationStatus
+		expectErr bool
+	}{
+		{"status_deleting", true, r53rtypes.FirewallRuleGroupAssociationStatusDeleting, true},
+		{"status_updating", true, r53rtypes.FirewallRuleGroupAssociationStatusUpdating, true},
+		{"status_complete", true, r53rtypes.FirewallRuleGroupAssociationStatusComplete, false},
+		{"status_gone", false, "", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRoute53Resolver := mock_route53resolverv2.NewMockRoute53ResolverAPI(ctrl)
+
+			associations := []r53rtypes.FirewallRuleGroupAssociation{}
+			if tc.present {
+				associations = append(associations, r53rtypes.FirewallRuleGroupAssociation{
+					Id:                  ptr.String("rslvr-frgassoc-1"),
+					FirewallRuleGroupId: ptr.String("rslvr-frg-1"),
+					Status:              tc.status,
+				})
+			}
+
+			mockRoute53Resolver.EXPECT().ListFirewallRuleGroupAssociations(gomock.Any(),
+				gomock.Any()).Return(&r53r.ListFirewallRuleGroupAssociationsOutput{
+				FirewallRuleGroupAssociations: associations,
+			}, nil)
+
+			assoc := &Route53ResolverFirewallRuleGroupAssociation{
+				svc:                 mockRoute53Resolver,
+				ID:                  ptr.String("rslvr-frgassoc-1"),
+				FirewallRuleGroupID: ptr.String("rslvr-frg-1"),
+			}
+
+			err := assoc.HandleWait(context.TODO())
+
+			if tc.expectErr {
+				var expectedErrType liberrors.ErrWaitResource
+				a.ErrorAs(err, &expectedErrType)
+			} else {
+				a.Nil(err)
+			}
+		})
+	}
+}

--- a/resources/route53-resolver-firewall-rule-group.go
+++ b/resources/route53-resolver-firewall-rule-group.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 
+	"github.com/sirupsen/logrus"
+
 	r53r "github.com/aws/aws-sdk-go-v2/service/route53resolver"
 	r53rtypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
 
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
+	libsettings "github.com/ekristen/libnuke/pkg/settings"
 	"github.com/ekristen/libnuke/pkg/types"
 
 	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
@@ -22,6 +26,9 @@ func init() {
 		Scope:    nuke.Account,
 		Resource: &Route53ResolverFirewallRuleGroup{},
 		Lister:   &Route53ResolverFirewallRuleGroupLister{},
+		Settings: []string{
+			"DisableDeletionProtection",
+		},
 	})
 }
 
@@ -57,15 +64,15 @@ func (l *Route53ResolverFirewallRuleGroupLister) List(ctx context.Context, o int
 			}
 
 			resources = append(resources, &Route53ResolverFirewallRuleGroup{
-				svc:               l.svc,
-				vpcAssociationIds: vpcAssociations[*firewallRuleGroup.Id],
-				rules:             firewallRules,
-				Arn:               firewallRuleGroup.Arn,
-				CreatorRequestID:  firewallRuleGroup.CreatorRequestId,
-				ID:                firewallRuleGroup.Id,
-				OwnerID:           firewallRuleGroup.OwnerId,
-				Name:              firewallRuleGroup.Name,
-				ShareStatus:       firewallRuleGroup.ShareStatus,
+				svc:              l.svc,
+				vpcAssociations:  vpcAssociations[*firewallRuleGroup.Id],
+				rules:            firewallRules,
+				Arn:              firewallRuleGroup.Arn,
+				CreatorRequestID: firewallRuleGroup.CreatorRequestId,
+				ID:               firewallRuleGroup.Id,
+				OwnerID:          firewallRuleGroup.OwnerId,
+				Name:             firewallRuleGroup.Name,
+				ShareStatus:      firewallRuleGroup.ShareStatus,
 			})
 		}
 
@@ -87,17 +94,27 @@ type Route53ResolverFirewallRule struct {
 	FirewallThreatProtectionID *string
 }
 
+type Route53ResolverFirewallRuleGroupVpcAssociation struct {
+	ID                 *string
+	MutationProtection r53rtypes.MutationProtectionStatus
+}
+
 // Route53ResolverFirewallRuleGroup is the resource type
 type Route53ResolverFirewallRuleGroup struct {
-	svc               Route53ResolverAPI
-	vpcAssociationIds []*string
-	rules             []*Route53ResolverFirewallRule
-	Arn               *string
-	CreatorRequestID  *string
-	ID                *string
-	OwnerID           *string
-	Name              *string
-	ShareStatus       r53rtypes.ShareStatus
+	svc              Route53ResolverAPI
+	settings         *libsettings.Setting
+	vpcAssociations  []*Route53ResolverFirewallRuleGroupVpcAssociation
+	rules            []*Route53ResolverFirewallRule
+	Arn              *string               `description:"The ARN of the firewall rule group"`
+	CreatorRequestID *string               `description:" The unique identifier (ID) for the request that created the firewall rule group"`
+	ID               *string               `description:" The unique identifier (ID) for the firewall rule group"`
+	OwnerID          *string               `description:" ID of the AWS account that created the firewall rule group"`
+	Name             *string               `description:" Name of the firewall rule group"`
+	ShareStatus      r53rtypes.ShareStatus `description:" The current sharing status of the firewall rule group"`
+}
+
+func (r *Route53ResolverFirewallRuleGroup) Settings(settings *libsettings.Setting) {
+	r.settings = settings
 }
 
 // Remove implements Resource
@@ -105,12 +122,29 @@ func (r *Route53ResolverFirewallRuleGroup) Remove(ctx context.Context) error {
 	var notFound *r53rtypes.ResourceNotFoundException
 
 	// disassociate VPCs first since that's slower
-	for _, associationID := range r.vpcAssociationIds {
+	for _, vpcAssociation := range r.vpcAssociations {
+		if r.settings.GetBool("DisableDeletionProtection") && vpcAssociation.MutationProtection == r53rtypes.MutationProtectionStatusEnabled {
+			// disable mutation protection for any associations that have it enabled
+			// This call is very fast and seems to be synchronous
+			_, err := r.svc.UpdateFirewallRuleGroupAssociation(ctx,
+				&r53r.UpdateFirewallRuleGroupAssociationInput{
+					FirewallRuleGroupAssociationId: vpcAssociation.ID,
+					MutationProtection:             r53rtypes.MutationProtectionStatusDisabled,
+				},
+			)
+			// ignore, probably already disassociated
+			if errors.As(err, &notFound) {
+				continue
+			}
+		}
+
+		// Remove the association.  This call results in an async dissociation which can
+		// take some time to complete
 		_, err := r.svc.DisassociateFirewallRuleGroup(ctx, &r53r.DisassociateFirewallRuleGroupInput{
-			FirewallRuleGroupAssociationId: associationID,
+			FirewallRuleGroupAssociationId: vpcAssociation.ID,
 		})
 		if err != nil {
-			// ignore, probably already associated
+			// ignore notFound, probably already disassociated
 			if errors.As(err, &notFound) {
 				continue
 			}
@@ -136,8 +170,13 @@ func (r *Route53ResolverFirewallRuleGroup) Remove(ctx context.Context) error {
 		}
 	}
 
+	err := waitForAssociationToStabilize(ctx, r.svc, r)
+	if err != nil {
+		return err
+	}
+
 	// finally delete the FRG
-	_, err := r.svc.DeleteFirewallRuleGroup(ctx, &r53r.DeleteFirewallRuleGroupInput{
+	_, err = r.svc.DeleteFirewallRuleGroup(ctx, &r53r.DeleteFirewallRuleGroupInput{
 		FirewallRuleGroupId: r.ID,
 	})
 
@@ -159,12 +198,14 @@ func (r *Route53ResolverFirewallRuleGroup) String() string {
 
 // ruleGroupsToAssociationIds - Associate all the FRG association ids to their firewall rule group ID to be
 // disassociated before deleting the rule.
-func ruleGroupsToAssociationIds(ctx context.Context, svc Route53ResolverAPI) (map[string][]*string, error) {
-	vpcAssociations := map[string][]*string{}
+func ruleGroupsToAssociationIds(ctx context.Context, svc Route53ResolverAPI) (map[string][]*Route53ResolverFirewallRuleGroupVpcAssociation,
+	error) {
+	vpcAssociations := map[string][]*Route53ResolverFirewallRuleGroupVpcAssociation{}
 
 	params := &r53r.ListFirewallRuleGroupAssociationsInput{}
 
 	for {
+		// Lists ALL FRG->VPC associations for all FRGs
 		resp, err := svc.ListFirewallRuleGroupAssociations(ctx, params)
 
 		if err != nil {
@@ -177,10 +218,16 @@ func ruleGroupsToAssociationIds(ctx context.Context, svc Route53ResolverAPI) (ma
 			if associationID != nil {
 				frgID := *frgas[i].FirewallRuleGroupId
 
+				frgAssoc := Route53ResolverFirewallRuleGroupVpcAssociation{
+					ID:                 associationID,
+					MutationProtection: frgas[i].MutationProtection,
+				}
+
 				if _, ok := vpcAssociations[frgID]; !ok {
-					vpcAssociations[frgID] = []*string{associationID}
+					associations := []*Route53ResolverFirewallRuleGroupVpcAssociation{&frgAssoc}
+					vpcAssociations[frgID] = associations
 				} else {
-					vpcAssociations[frgID] = append(vpcAssociations[frgID], associationID)
+					vpcAssociations[frgID] = append(vpcAssociations[frgID], &frgAssoc)
 				}
 			}
 		}
@@ -229,4 +276,41 @@ func getFirewallRules(ctx context.Context, svc Route53ResolverAPI, firewallRuleG
 	}
 
 	return rules, nil
+}
+
+// Wait for the FRG-to-VPC association to stabilize.
+func waitForAssociationToStabilize(ctx context.Context, svc Route53ResolverAPI, frg *Route53ResolverFirewallRuleGroup) error {
+	params := &r53r.ListFirewallRuleGroupAssociationsInput{
+		FirewallRuleGroupId: frg.ID,
+	}
+
+	resp, err := svc.ListFirewallRuleGroupAssociations(ctx, params)
+	frgas := resp.FirewallRuleGroupAssociations
+
+	// Not found means we successfully deleted this FRG
+	var notFound *r53rtypes.ResourceNotFoundException
+	if errors.As(err, &notFound) {
+		return err
+	}
+
+	statusIsPending := false
+	for i := range frgas {
+		currentStatus := frgas[i].Status
+		associationID := frgas[i].Id
+
+		if currentStatus == r53rtypes.FirewallRuleGroupAssociationStatusUpdating ||
+			currentStatus == r53rtypes.FirewallRuleGroupAssociationStatusDeleting {
+			logrus.Infof("Association %s on firewall rule group %s is in status %s",
+				*associationID, *frg.ID, currentStatus)
+			statusIsPending = true
+			break
+		}
+	}
+
+	if statusIsPending {
+		// Return an ErrHoldResource to put the resource in ItemStateHold and retry later
+		return liberrors.ErrHoldResource("waiting for associations to stabilize")
+	}
+
+	return nil
 }

--- a/resources/route53-resolver-firewall-rule-group.go
+++ b/resources/route53-resolver-firewall-rule-group.go
@@ -38,11 +38,6 @@ func (l *Route53ResolverFirewallRuleGroupLister) List(ctx context.Context, o int
 		l.svc = r53r.NewFromConfig(*opts.Config)
 	}
 
-	vpcAssociations, vpcErr := ruleGroupsToAssociationIds(ctx, l.svc)
-	if vpcErr != nil {
-		return nil, vpcErr
-	}
-
 	params := &r53r.ListFirewallRuleGroupsInput{}
 	for {
 		resp, err := l.svc.ListFirewallRuleGroups(ctx, params)
@@ -57,15 +52,14 @@ func (l *Route53ResolverFirewallRuleGroupLister) List(ctx context.Context, o int
 			}
 
 			resources = append(resources, &Route53ResolverFirewallRuleGroup{
-				svc:               l.svc,
-				vpcAssociationIds: vpcAssociations[*firewallRuleGroup.Id],
-				rules:             firewallRules,
-				Arn:               firewallRuleGroup.Arn,
-				CreatorRequestID:  firewallRuleGroup.CreatorRequestId,
-				ID:                firewallRuleGroup.Id,
-				OwnerID:           firewallRuleGroup.OwnerId,
-				Name:              firewallRuleGroup.Name,
-				ShareStatus:       firewallRuleGroup.ShareStatus,
+				svc:              l.svc,
+				rules:            firewallRules,
+				Arn:              firewallRuleGroup.Arn,
+				CreatorRequestID: firewallRuleGroup.CreatorRequestId,
+				ID:               firewallRuleGroup.Id,
+				OwnerID:          firewallRuleGroup.OwnerId,
+				Name:             firewallRuleGroup.Name,
+				ShareStatus:      firewallRuleGroup.ShareStatus,
 			})
 		}
 
@@ -89,36 +83,22 @@ type Route53ResolverFirewallRule struct {
 
 // Route53ResolverFirewallRuleGroup is the resource type
 type Route53ResolverFirewallRuleGroup struct {
-	svc               Route53ResolverAPI
-	vpcAssociationIds []*string
-	rules             []*Route53ResolverFirewallRule
-	Arn               *string
-	CreatorRequestID  *string
-	ID                *string
-	OwnerID           *string
-	Name              *string
-	ShareStatus       r53rtypes.ShareStatus
+	svc              Route53ResolverAPI
+	rules            []*Route53ResolverFirewallRule
+	Arn              *string               `description:"The ARN of the firewall rule group"`
+	CreatorRequestID *string               `description:"The unique identifier (ID) for the request that created the firewall rule group"`
+	ID               *string               `description:"The unique identifier (ID) for the firewall rule group"`
+	OwnerID          *string               `description:"ID of the AWS account that created the firewall rule group"`
+	Name             *string               `description:"Name of the firewall rule group"`
+	ShareStatus      r53rtypes.ShareStatus `description:"The current sharing status of the firewall rule group"`
 }
 
 // Remove implements Resource
 func (r *Route53ResolverFirewallRuleGroup) Remove(ctx context.Context) error {
 	var notFound *r53rtypes.ResourceNotFoundException
 
-	// disassociate VPCs first since that's slower
-	for _, associationID := range r.vpcAssociationIds {
-		_, err := r.svc.DisassociateFirewallRuleGroup(ctx, &r53r.DisassociateFirewallRuleGroupInput{
-			FirewallRuleGroupAssociationId: associationID,
-		})
-		if err != nil {
-			// ignore, probably already associated
-			if errors.As(err, &notFound) {
-				continue
-			}
-			return err
-		}
-	}
-
-	// then remove rules
+	// Associations are setup as DependsOn, and should have been removed so all
+	// we need to do remove rules which seems to be synchronous or at least very fast
 	for _, rule := range r.rules {
 		_, err := r.svc.DeleteFirewallRule(ctx, &r53r.DeleteFirewallRuleInput{
 			FirewallRuleGroupId:        r.ID,
@@ -136,7 +116,7 @@ func (r *Route53ResolverFirewallRuleGroup) Remove(ctx context.Context) error {
 		}
 	}
 
-	// finally delete the FRG
+	// Delete the FRG
 	_, err := r.svc.DeleteFirewallRuleGroup(ctx, &r53r.DeleteFirewallRuleGroupInput{
 		FirewallRuleGroupId: r.ID,
 	})
@@ -157,42 +137,11 @@ func (r *Route53ResolverFirewallRuleGroup) String() string {
 	return *r.ID
 }
 
-// ruleGroupsToAssociationIds - Associate all the FRG association ids to their firewall rule group ID to be
-// disassociated before deleting the rule.
-func ruleGroupsToAssociationIds(ctx context.Context, svc Route53ResolverAPI) (map[string][]*string, error) {
-	vpcAssociations := map[string][]*string{}
-
-	params := &r53r.ListFirewallRuleGroupAssociationsInput{}
-
-	for {
-		resp, err := svc.ListFirewallRuleGroupAssociations(ctx, params)
-
-		if err != nil {
-			return nil, err
-		}
-
-		frgas := resp.FirewallRuleGroupAssociations
-		for i := range frgas {
-			associationID := frgas[i].Id
-			if associationID != nil {
-				frgID := *frgas[i].FirewallRuleGroupId
-
-				if _, ok := vpcAssociations[frgID]; !ok {
-					vpcAssociations[frgID] = []*string{associationID}
-				} else {
-					vpcAssociations[frgID] = append(vpcAssociations[frgID], associationID)
-				}
-			}
-		}
-
-		if resp.NextToken == nil {
-			break
-		}
-
-		params.NextToken = resp.NextToken
+// DependsOn ensures that firewall rule group associations are removed before the rule group itself.
+func (r *Route53ResolverFirewallRuleGroup) DependsOn() []string {
+	return []string{
+		Route53ResolverFirewallRuleGroupAssociationResource,
 	}
-
-	return vpcAssociations, nil
 }
 
 // Get Firewall rules for the FRG with given firewallRuleGroupID

--- a/resources/route53-resolver-firewall-rule-group_mock_test.go
+++ b/resources/route53-resolver-firewall-rule-group_mock_test.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"testing"
 
-	r53r "github.com/aws/aws-sdk-go-v2/service/route53resolver"
-	r53rtypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
-
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	r53r "github.com/aws/aws-sdk-go-v2/service/route53resolver"
+	r53rtypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
+
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	"github.com/ekristen/libnuke/pkg/resource"
+	libsettings "github.com/ekristen/libnuke/pkg/settings"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_route53resolverv2"
 )
@@ -99,6 +101,7 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_List(t *testing.T) {
 				Name:                ptr.String("association-1"),
 				Priority:            ptr.Int32(100),
 				Status:              "COMPLETE",
+				MutationProtection:  r53rtypes.MutationProtectionStatusDisabled,
 				StatusMessage:       ptr.String(""),
 				VpcId:               ptr.String("vpc-12345"),
 			},
@@ -109,6 +112,7 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_List(t *testing.T) {
 				Name:                ptr.String("association-2"),
 				Priority:            ptr.Int32(200),
 				Status:              "COMPLETE",
+				MutationProtection:  r53rtypes.MutationProtectionStatusEnabled,
 				StatusMessage:       ptr.String(""),
 				VpcId:               ptr.String("vpc-67890"),
 			},
@@ -152,39 +156,44 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_List(t *testing.T) {
 	a.Nil(err)
 	a.Len(resources, 3)
 
+	expectedVpcAssoc1 := &Route53ResolverFirewallRuleGroupVpcAssociation{ptr.String("rslvr-frgassoc-1"),
+		r53rtypes.MutationProtectionStatusDisabled}
+	expectedVpcAssoc2 := &Route53ResolverFirewallRuleGroupVpcAssociation{ptr.String("rslvr-frgassoc-2"),
+		r53rtypes.MutationProtectionStatusEnabled}
+
 	expectedResources := []resource.Resource{
 		&Route53ResolverFirewallRuleGroup{
-			svc:               mockRoute53Resolver,
-			vpcAssociationIds: []*string{ptr.String("rslvr-frgassoc-1")},
-			rules:             []*Route53ResolverFirewallRule{expectedFirewallRule1a},
-			Arn:               ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-1"),
-			CreatorRequestID:  ptr.String("SomeAwsServiceCommand"),
-			ID:                ptr.String("rslvr-frg-1"),
-			OwnerID:           ptr.String("Route 53 Resolver DNS Firewall"),
-			Name:              ptr.String("frgNum1"),
-			ShareStatus:       r53rtypes.ShareStatusNotShared,
+			svc:              mockRoute53Resolver,
+			vpcAssociations:  []*Route53ResolverFirewallRuleGroupVpcAssociation{expectedVpcAssoc1},
+			rules:            []*Route53ResolverFirewallRule{expectedFirewallRule1a},
+			Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-1"),
+			CreatorRequestID: ptr.String("SomeAwsServiceCommand"),
+			ID:               ptr.String("rslvr-frg-1"),
+			OwnerID:          ptr.String("Route 53 Resolver DNS Firewall"),
+			Name:             ptr.String("frgNum1"),
+			ShareStatus:      r53rtypes.ShareStatusNotShared,
 		},
 		&Route53ResolverFirewallRuleGroup{
-			svc:               mockRoute53Resolver,
-			vpcAssociationIds: []*string{ptr.String("rslvr-frgassoc-2")},
-			rules:             []*Route53ResolverFirewallRule{expectedFirewallRule2a, expectedFirewallRule2b},
-			Arn:               ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-2"),
-			CreatorRequestID:  ptr.String("SomeAwsServiceCommand"),
-			ID:                ptr.String("rslvr-frg-2"),
-			OwnerID:           ptr.String("Route 53 Resolver DNS Firewall"),
-			Name:              ptr.String("frgNum2"),
-			ShareStatus:       r53rtypes.ShareStatusSharedByMe,
+			svc:              mockRoute53Resolver,
+			vpcAssociations:  []*Route53ResolverFirewallRuleGroupVpcAssociation{expectedVpcAssoc2},
+			rules:            []*Route53ResolverFirewallRule{expectedFirewallRule2a, expectedFirewallRule2b},
+			Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-2"),
+			CreatorRequestID: ptr.String("SomeAwsServiceCommand"),
+			ID:               ptr.String("rslvr-frg-2"),
+			OwnerID:          ptr.String("Route 53 Resolver DNS Firewall"),
+			Name:             ptr.String("frgNum2"),
+			ShareStatus:      r53rtypes.ShareStatusSharedByMe,
 		},
 		&Route53ResolverFirewallRuleGroup{
-			svc:               mockRoute53Resolver,
-			vpcAssociationIds: nil,
-			rules:             []*Route53ResolverFirewallRule{},
-			Arn:               ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
-			CreatorRequestID:  ptr.String("AWSConsole.88.1762108398672"),
-			ID:                ptr.String("rslvr-frg-3"),
-			OwnerID:           ptr.String("SomeOwnerId"),
-			Name:              ptr.String("UserCreatedRuleGroup"),
-			ShareStatus:       r53rtypes.ShareStatusSharedWithMe,
+			svc:              mockRoute53Resolver,
+			vpcAssociations:  nil,
+			rules:            []*Route53ResolverFirewallRule{},
+			Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
+			CreatorRequestID: ptr.String("AWSConsole.88.1762108398672"),
+			ID:               ptr.String("rslvr-frg-3"),
+			OwnerID:          ptr.String("SomeOwnerId"),
+			Name:             ptr.String("UserCreatedRuleGroup"),
+			ShareStatus:      r53rtypes.ShareStatusSharedWithMe,
 		},
 	}
 
@@ -192,45 +201,96 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_List(t *testing.T) {
 }
 
 func Test_Mock_Route53ResolverFirewallRuleGroup_Remove(t *testing.T) {
-	a := assert.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	isEnabled := true
+	notEnabled := false
 
-	mockRoute53Resolver := mock_route53resolverv2.NewMockRoute53ResolverAPI(ctrl)
-
-	mockRoute53Resolver.EXPECT().
-		DisassociateFirewallRuleGroup(gomock.Any(), gomock.Any()).
-		Return(&r53r.DisassociateFirewallRuleGroupOutput{}, nil)
-
-	mockRoute53Resolver.EXPECT().
-		DeleteFirewallRule(gomock.Any(), gomock.Any()).
-		Return(&r53r.DeleteFirewallRuleOutput{}, nil)
-
-	mockRoute53Resolver.EXPECT().
-		DeleteFirewallRuleGroup(gomock.Any(), gomock.Any()).
-		Return(&r53r.DeleteFirewallRuleGroupOutput{}, nil)
-
-	firewallRules := []*Route53ResolverFirewallRule{
-		{
-			Name:                       ptr.String("rule1"),
-			Qtype:                      ptr.String("AAAA"),
-			FirewallThreatProtectionID: ptr.String("ftpid_123"),
-		},
+	mpTestConfigs := []struct {
+		name       string
+		mpDisabled *bool
+	}{
+		{"delete_protection_enabled", &isEnabled},
+		{"delete_protection_disabled", &notEnabled},
+		{"delete_protection_unset", nil},
 	}
 
-	frg := &Route53ResolverFirewallRuleGroup{
-		svc:               mockRoute53Resolver,
-		vpcAssociationIds: []*string{ptr.String("rslvr-frgassoc-1")},
-		rules:             firewallRules,
-		Arn:               ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
-		CreatorRequestID:  ptr.String("SomeAwsServiceCommand"),
-		ID:                ptr.String("rslvr-frg-3"),
-		OwnerID:           ptr.String("Route 53 Resolver DNS Firewall"),
-		Name:              ptr.String("Internet Resolver"),
-	}
+	for _, tc := range mpTestConfigs {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-	err := frg.Remove(context.TODO())
-	a.Nil(err)
+			mockRoute53Resolver := mock_route53resolverv2.NewMockRoute53ResolverAPI(ctrl)
+
+			mockRoute53Resolver.EXPECT().
+				DisassociateFirewallRuleGroup(gomock.Any(), gomock.Any()).
+				Return(&r53r.DisassociateFirewallRuleGroupOutput{}, nil)
+
+			mockRoute53Resolver.EXPECT().
+				DeleteFirewallRule(gomock.Any(), gomock.Any()).
+				Return(&r53r.DeleteFirewallRuleOutput{}, nil)
+
+			mockRoute53Resolver.EXPECT().
+				DeleteFirewallRuleGroup(gomock.Any(), gomock.Any()).
+				Return(&r53r.DeleteFirewallRuleGroupOutput{}, nil)
+
+			firewallRules := []*Route53ResolverFirewallRule{
+				{
+					Name:                       ptr.String("rule1"),
+					Qtype:                      ptr.String("AAAA"),
+					FirewallThreatProtectionID: ptr.String("ftpid_123"),
+				},
+			}
+
+			mockRoute53Resolver.EXPECT().ListFirewallRuleGroupAssociations(gomock.Any(),
+				gomock.Any()).Return(&r53r.ListFirewallRuleGroupAssociationsOutput{
+				FirewallRuleGroupAssociations: []r53rtypes.FirewallRuleGroupAssociation{},
+			}, nil)
+
+			expectedVpcAssoc1 := &Route53ResolverFirewallRuleGroupVpcAssociation{ptr.String("rslvr-frgassoc-1"),
+				r53rtypes.MutationProtectionStatusEnabled}
+
+			if tc.mpDisabled != nil && *tc.mpDisabled {
+				// DisableDeletionProtection set in this case, expect mutation protection to be disabled for association #2
+				// which has mutation protection enabled
+				mockRoute53Resolver.EXPECT().
+					UpdateFirewallRuleGroupAssociation(context.TODO(), gomock.Eq(&r53r.UpdateFirewallRuleGroupAssociationInput{
+						FirewallRuleGroupAssociationId: ptr.String("rslvr-frgassoc-1"),
+						MutationProtection:             r53rtypes.MutationProtectionStatusDisabled,
+					})).Return(&r53r.UpdateFirewallRuleGroupAssociationOutput{}, nil)
+			} else {
+				// DisableDeletionProtection NOT set in this case so we shouldn't disable mutation protection
+				mockRoute53Resolver.EXPECT().UpdateFirewallRuleGroupAssociation(gomock.Any(), gomock.Any()).Times(0)
+			}
+
+			mpSettings := &libsettings.Setting{}
+			if tc.mpDisabled != nil {
+				if *tc.mpDisabled {
+					mpSettings = &libsettings.Setting{
+						"DisableDeletionProtection": true,
+					}
+				} else {
+					mpSettings = &libsettings.Setting{
+						"DisableDeletionProtection": false,
+					}
+				}
+			}
+
+			frg := &Route53ResolverFirewallRuleGroup{
+				settings:         mpSettings,
+				svc:              mockRoute53Resolver,
+				vpcAssociations:  []*Route53ResolverFirewallRuleGroupVpcAssociation{expectedVpcAssoc1},
+				rules:            firewallRules,
+				Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
+				CreatorRequestID: ptr.String("SomeAwsServiceCommand"),
+				ID:               ptr.String("rslvr-frg-3"),
+				OwnerID:          ptr.String("Route 53 Resolver DNS Firewall"),
+				Name:             ptr.String("Internet Resolver"),
+			}
+
+			err := frg.Remove(context.TODO())
+			a.Nil(err)
+		})
+	}
 }
 
 func Test_Mock_Route53ResolverFirewallRuleGroup_Properties(t *testing.T) {
@@ -245,4 +305,71 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_Properties(t *testing.T) {
 	}
 
 	a.NotNil(frg.Properties())
+}
+
+func Test_Mock_Route53ResolverFirewallRuleGroup_waitForAssociationsToStabilize(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRoute53Resolver := mock_route53resolverv2.NewMockRoute53ResolverAPI(ctrl)
+
+	testCases := []struct {
+		name   string
+		status *string
+	}{
+		{"association deleting", ptr.String(string(r53rtypes.FirewallRuleGroupAssociationStatusDeleting))},
+		{"association complete", ptr.String(string(r53rtypes.FirewallRuleGroupAssociationStatusComplete))},
+		{"no associations", nil},
+	}
+
+	frg := &Route53ResolverFirewallRuleGroup{
+		settings:         &libsettings.Setting{},
+		svc:              mockRoute53Resolver,
+		vpcAssociations:  []*Route53ResolverFirewallRuleGroupVpcAssociation{},
+		rules:            []*Route53ResolverFirewallRule{},
+		Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
+		CreatorRequestID: ptr.String("SomeAwsServiceCommand"),
+		ID:               ptr.String("rslvr-frg-3"),
+		OwnerID:          ptr.String("Route 53 Resolver DNS Firewall"),
+		Name:             ptr.String("Internet Resolver"),
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.status != nil {
+				mockRoute53Resolver.EXPECT().ListFirewallRuleGroupAssociations(gomock.Any(),
+					gomock.Any()).Return(&r53r.ListFirewallRuleGroupAssociationsOutput{
+					FirewallRuleGroupAssociations: []r53rtypes.FirewallRuleGroupAssociation{
+						{
+							Id:                  ptr.String("rslvr-frgassoc-1"),
+							FirewallRuleGroupId: ptr.String("rslvr-frg-1"),
+							ManagedOwnerName:    ptr.String("Route 53 Resolver DNS Firewall"),
+							Name:                ptr.String("association-1"),
+							Priority:            ptr.Int32(100),
+							Status:              r53rtypes.FirewallRuleGroupAssociationStatus(*tc.status),
+							MutationProtection:  r53rtypes.MutationProtectionStatusDisabled,
+							StatusMessage:       ptr.String(""),
+							VpcId:               ptr.String("vpc-12345"),
+						},
+					},
+				}, nil)
+			} else {
+				mockRoute53Resolver.EXPECT().ListFirewallRuleGroupAssociations(gomock.Any(),
+					gomock.Any()).Return(&r53r.ListFirewallRuleGroupAssociationsOutput{
+					FirewallRuleGroupAssociations: []r53rtypes.FirewallRuleGroupAssociation{},
+				}, nil)
+			}
+		})
+
+		err := waitForAssociationToStabilize(context.TODO(), mockRoute53Resolver, frg)
+
+		if tc.status != nil && *tc.status == (string(r53rtypes.FirewallRuleGroupAssociationStatusDeleting)) {
+			var expectedErrType liberrors.ErrHoldResource
+			a.NotNil(err)
+			a.ErrorAs(err, &expectedErrType)
+		} else {
+			a.Nil(err)
+		}
+	}
 }

--- a/resources/route53-resolver-firewall-rule-group_mock_test.go
+++ b/resources/route53-resolver-firewall-rule-group_mock_test.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"testing"
 
-	r53r "github.com/aws/aws-sdk-go-v2/service/route53resolver"
-	r53rtypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
-
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
-	"github.com/ekristen/libnuke/pkg/resource"
+	r53r "github.com/aws/aws-sdk-go-v2/service/route53resolver"
+	r53rtypes "github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_route53resolverv2"
+	"github.com/ekristen/libnuke/pkg/resource"
 )
 
 func Test_Mock_Route53ResolverFirewallRuleGroup_List(t *testing.T) {
@@ -89,32 +88,6 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_List(t *testing.T) {
 		FirewallRules: []r53rtypes.FirewallRule{},
 	}, nil)
 
-	mockRoute53Resolver.EXPECT().ListFirewallRuleGroupAssociations(gomock.Any(),
-		gomock.Any()).Return(&r53r.ListFirewallRuleGroupAssociationsOutput{
-		FirewallRuleGroupAssociations: []r53rtypes.FirewallRuleGroupAssociation{
-			{
-				Id:                  ptr.String("rslvr-frgassoc-1"),
-				FirewallRuleGroupId: ptr.String("rslvr-frg-1"),
-				ManagedOwnerName:    ptr.String("Route 53 Resolver DNS Firewall"),
-				Name:                ptr.String("association-1"),
-				Priority:            ptr.Int32(100),
-				Status:              "COMPLETE",
-				StatusMessage:       ptr.String(""),
-				VpcId:               ptr.String("vpc-12345"),
-			},
-			{
-				Id:                  ptr.String("rslvr-frgassoc-2"),
-				FirewallRuleGroupId: ptr.String("rslvr-frg-2"),
-				ManagedOwnerName:    ptr.String("Route 53 Resolver DNS Firewall"),
-				Name:                ptr.String("association-2"),
-				Priority:            ptr.Int32(200),
-				Status:              "COMPLETE",
-				StatusMessage:       ptr.String(""),
-				VpcId:               ptr.String("vpc-67890"),
-			},
-		},
-	}, nil)
-
 	mockRoute53Resolver.EXPECT().ListFirewallRuleGroups(gomock.Any(), gomock.Any()).Return(&r53r.ListFirewallRuleGroupsOutput{
 		FirewallRuleGroups: []r53rtypes.FirewallRuleGroupMetadata{
 			{
@@ -154,37 +127,34 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_List(t *testing.T) {
 
 	expectedResources := []resource.Resource{
 		&Route53ResolverFirewallRuleGroup{
-			svc:               mockRoute53Resolver,
-			vpcAssociationIds: []*string{ptr.String("rslvr-frgassoc-1")},
-			rules:             []*Route53ResolverFirewallRule{expectedFirewallRule1a},
-			Arn:               ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-1"),
-			CreatorRequestID:  ptr.String("SomeAwsServiceCommand"),
-			ID:                ptr.String("rslvr-frg-1"),
-			OwnerID:           ptr.String("Route 53 Resolver DNS Firewall"),
-			Name:              ptr.String("frgNum1"),
-			ShareStatus:       r53rtypes.ShareStatusNotShared,
+			svc:              mockRoute53Resolver,
+			rules:            []*Route53ResolverFirewallRule{expectedFirewallRule1a},
+			Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-1"),
+			CreatorRequestID: ptr.String("SomeAwsServiceCommand"),
+			ID:               ptr.String("rslvr-frg-1"),
+			OwnerID:          ptr.String("Route 53 Resolver DNS Firewall"),
+			Name:             ptr.String("frgNum1"),
+			ShareStatus:      r53rtypes.ShareStatusNotShared,
 		},
 		&Route53ResolverFirewallRuleGroup{
-			svc:               mockRoute53Resolver,
-			vpcAssociationIds: []*string{ptr.String("rslvr-frgassoc-2")},
-			rules:             []*Route53ResolverFirewallRule{expectedFirewallRule2a, expectedFirewallRule2b},
-			Arn:               ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-2"),
-			CreatorRequestID:  ptr.String("SomeAwsServiceCommand"),
-			ID:                ptr.String("rslvr-frg-2"),
-			OwnerID:           ptr.String("Route 53 Resolver DNS Firewall"),
-			Name:              ptr.String("frgNum2"),
-			ShareStatus:       r53rtypes.ShareStatusSharedByMe,
+			svc:              mockRoute53Resolver,
+			rules:            []*Route53ResolverFirewallRule{expectedFirewallRule2a, expectedFirewallRule2b},
+			Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-2"),
+			CreatorRequestID: ptr.String("SomeAwsServiceCommand"),
+			ID:               ptr.String("rslvr-frg-2"),
+			OwnerID:          ptr.String("Route 53 Resolver DNS Firewall"),
+			Name:             ptr.String("frgNum2"),
+			ShareStatus:      r53rtypes.ShareStatusSharedByMe,
 		},
 		&Route53ResolverFirewallRuleGroup{
-			svc:               mockRoute53Resolver,
-			vpcAssociationIds: nil,
-			rules:             []*Route53ResolverFirewallRule{},
-			Arn:               ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
-			CreatorRequestID:  ptr.String("AWSConsole.88.1762108398672"),
-			ID:                ptr.String("rslvr-frg-3"),
-			OwnerID:           ptr.String("SomeOwnerId"),
-			Name:              ptr.String("UserCreatedRuleGroup"),
-			ShareStatus:       r53rtypes.ShareStatusSharedWithMe,
+			svc:              mockRoute53Resolver,
+			rules:            []*Route53ResolverFirewallRule{},
+			Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
+			CreatorRequestID: ptr.String("AWSConsole.88.1762108398672"),
+			ID:               ptr.String("rslvr-frg-3"),
+			OwnerID:          ptr.String("SomeOwnerId"),
+			Name:             ptr.String("UserCreatedRuleGroup"),
+			ShareStatus:      r53rtypes.ShareStatusSharedWithMe,
 		},
 	}
 
@@ -197,10 +167,6 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_Remove(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRoute53Resolver := mock_route53resolverv2.NewMockRoute53ResolverAPI(ctrl)
-
-	mockRoute53Resolver.EXPECT().
-		DisassociateFirewallRuleGroup(gomock.Any(), gomock.Any()).
-		Return(&r53r.DisassociateFirewallRuleGroupOutput{}, nil)
 
 	mockRoute53Resolver.EXPECT().
 		DeleteFirewallRule(gomock.Any(), gomock.Any()).
@@ -219,14 +185,13 @@ func Test_Mock_Route53ResolverFirewallRuleGroup_Remove(t *testing.T) {
 	}
 
 	frg := &Route53ResolverFirewallRuleGroup{
-		svc:               mockRoute53Resolver,
-		vpcAssociationIds: []*string{ptr.String("rslvr-frgassoc-1")},
-		rules:             firewallRules,
-		Arn:               ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
-		CreatorRequestID:  ptr.String("SomeAwsServiceCommand"),
-		ID:                ptr.String("rslvr-frg-3"),
-		OwnerID:           ptr.String("Route 53 Resolver DNS Firewall"),
-		Name:              ptr.String("Internet Resolver"),
+		svc:              mockRoute53Resolver,
+		rules:            firewallRules,
+		Arn:              ptr.String("arn:aws:route53resolver:us-east-1:123456123456:firewall-rule-group/rslvr-frg-3"),
+		CreatorRequestID: ptr.String("SomeAwsServiceCommand"),
+		ID:               ptr.String("rslvr-frg-3"),
+		OwnerID:          ptr.String("Route 53 Resolver DNS Firewall"),
+		Name:             ptr.String("Internet Resolver"),
 	}
 
 	err := frg.Remove(context.TODO())


### PR DESCRIPTION
See https://github.com/ekristen/aws-nuke/issues/902

- Adds a Route53 Resolver firewall rule groups association resource and makes Firewall Rule Group DependsOn this resource (its VPC association)
- Enables the DisableDeletionProtection settings for Route53 Resolver firewall rule groups Associations that can be used to disable mutation protection on firewall rule group to VPC associations.  
- Some documentation added
