### PR TITLE
fix: prevent cascading discovery failures on per-resource enrichment …

### DIFF
--- a/resources/acm-certificate.go
+++ b/resources/acm-certificate.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/acm" //nolint:staticcheck
 
@@ -59,7 +61,9 @@ func (l *ACMCertificateLister) List(_ context.Context, o interface{}) ([]resourc
 				CertificateArn: certificate.CertificateArn,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *certificate.CertificateArn).
+					Warn("unable to describe ACM certificate, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			tagParams := &acm.ListTagsForCertificateInput{
@@ -68,7 +72,9 @@ func (l *ACMCertificateLister) List(_ context.Context, o interface{}) ([]resourc
 
 			tagResp, tagErr := svc.ListTagsForCertificate(tagParams)
 			if tagErr != nil {
-				return nil, tagErr
+				logrus.WithError(tagErr).WithField("arn", *certificate.CertificateArn).
+					Warn("unable to list tags for ACM certificate, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &ACMCertificate{

--- a/resources/acm-pca-certificate-authority-state.go
+++ b/resources/acm-pca-certificate-authority-state.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"            //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/aws/awserr"     //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/acmpca" //nolint:staticcheck
@@ -60,7 +62,9 @@ func (l *ACMPCACertificateAuthorityStateLister) List(_ context.Context, o interf
 							break
 						}
 					}
-					return nil, tagErr
+					logrus.WithError(tagErr).WithField("arn", *certificateAuthority.Arn).
+						Warn("unable to list tags for ACM PCA certificate authority state, skipping to avoid incorrect filtering")
+					break
 				}
 
 				tags = append(tags, tagResp.Tags...)

--- a/resources/acm-pca-certificate-authority.go
+++ b/resources/acm-pca-certificate-authority.go
@@ -5,6 +5,8 @@ import (
 
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"            //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/aws/awserr"     //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/acmpca" //nolint:staticcheck
@@ -62,7 +64,9 @@ func (l *ACMPCACertificateAuthorityLister) List(_ context.Context, o interface{}
 							break
 						}
 					}
-					return nil, tagErr
+					logrus.WithError(tagErr).WithField("arn", *certificateAuthority.Arn).
+						Warn("unable to list tags for ACM PCA certificate authority, skipping to avoid incorrect filtering")
+					break
 				}
 
 				tags = append(tags, tagResp.Tags...)

--- a/resources/appconfig-configurationprofiles.go
+++ b/resources/appconfig-configurationprofiles.go
@@ -65,7 +65,9 @@ func (l *AppConfigConfigurationProfileLister) List(ctx context.Context, o interf
 			return true
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("app", *application.id).
+				Warn("unable to list configuration profiles for AppConfig application, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 	return resources, nil

--- a/resources/appconfig-environments.go
+++ b/resources/appconfig-environments.go
@@ -61,7 +61,9 @@ func (l *AppConfigEnvironmentLister) List(ctx context.Context, o interface{}) ([
 			return true
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("app", *application.id).
+				Warn("unable to list environments for AppConfig application, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 	return resources, nil

--- a/resources/appconfig-hostedconfigurationversions.go
+++ b/resources/appconfig-hostedconfigurationversions.go
@@ -63,7 +63,9 @@ func (l *AppConfigHostedConfigurationVersionLister) List(ctx context.Context, o 
 			return true
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("profile", *configurationProfile.id).
+				Warn("unable to list hosted configuration versions for AppConfig profile, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 	return resources, nil

--- a/resources/appmesh-gatewayroute.go
+++ b/resources/appmesh-gatewayroute.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/appmesh" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -58,7 +60,9 @@ func (l *AppMeshGatewayRouteLister) List(_ context.Context, o interface{}) ([]re
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("mesh", *meshName).
+				Warn("unable to list virtual gateways for App Mesh, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 
@@ -76,7 +80,9 @@ func (l *AppMeshGatewayRouteLister) List(_ context.Context, o interface{}) ([]re
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("gateway", *vg.VirtualGatewayName).
+				Warn("unable to list gateway routes for App Mesh virtual gateway, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/appmesh-route.go
+++ b/resources/appmesh-route.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/appmesh" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -58,7 +60,9 @@ func (l *AppMeshRouteLister) List(_ context.Context, o interface{}) ([]resource.
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("mesh", *meshName).
+				Warn("unable to list virtual routers for App Mesh, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 
@@ -76,7 +80,9 @@ func (l *AppMeshRouteLister) List(_ context.Context, o interface{}) ([]resource.
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("router", *vr.VirtualRouterName).
+				Warn("unable to list routes for App Mesh virtual router, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/appmesh-virtualgateway.go
+++ b/resources/appmesh-virtualgateway.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/appmesh" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -58,7 +60,9 @@ func (l *AppMeshVirtualGatewayLister) List(_ context.Context, o interface{}) ([]
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("mesh", *meshName).
+				Warn("unable to list virtual gateways for App Mesh, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/appmesh-virtualnode.go
+++ b/resources/appmesh-virtualnode.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/appmesh" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -59,7 +61,9 @@ func (l *AppMeshVirtualNodeLister) List(_ context.Context, o interface{}) ([]res
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("mesh", *meshName).
+				Warn("unable to list virtual nodes for App Mesh, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/appmesh-virtualrouter.go
+++ b/resources/appmesh-virtualrouter.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/appmesh" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -59,7 +61,9 @@ func (l *AppMeshVirtualRouterLister) List(_ context.Context, o interface{}) ([]r
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("mesh", *meshName).
+				Warn("unable to list virtual routers for App Mesh, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/appmesh-virtualservice.go
+++ b/resources/appmesh-virtualservice.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/appmesh" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -59,7 +61,9 @@ func (l *AppMeshVirtualServiceLister) List(_ context.Context, o interface{}) ([]
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("mesh", *meshName).
+				Warn("unable to list virtual services for App Mesh, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/appstream-stack-fleet-attachments.go
+++ b/resources/appstream-stack-fleet-attachments.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/appstream" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -53,7 +55,9 @@ func (l *AppStreamStackFleetAttachmentLister) List(_ context.Context, o interfac
 		stackAssocParams.StackName = stack.Name
 		output, err := svc.ListAssociatedFleets(stackAssocParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("stack", *stack.Name).
+				Warn("unable to list associated fleets for AppStream stack, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, name := range output.Names {

--- a/resources/appsync-api-association.go
+++ b/resources/appsync-api-association.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go-v2/service/appsync"
 	rtypes "github.com/aws/aws-sdk-go-v2/service/appsync/types"
@@ -48,7 +49,9 @@ func (l *AppSyncAPIAssociationLister) List(ctx context.Context, o interface{}) (
 		if err != nil {
 			var notFound *rtypes.NotFoundException
 			if !errors.As(err, &notFound) {
-				return nil, err
+				logrus.WithError(err).WithField("domain", *p.DomainName).
+					Warn("unable to get API association for AppSync domain, skipping to avoid incorrect filtering")
+				continue
 			}
 		} else {
 			resources = append(resources, &AppSyncAPIAssociation{

--- a/resources/athena-named-query.go
+++ b/resources/athena-named-query.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/athena" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -57,7 +59,9 @@ func (l *AthenaNamedQueryLister) List(_ context.Context, o interface{}) ([]resou
 			},
 		)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("workgroup", *wgName).
+				Warn("unable to list named queries for Athena workgroup, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/athena-prepared-statement.go
+++ b/resources/athena-prepared-statement.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"            //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/athena" //nolint:staticcheck
 
@@ -46,7 +48,9 @@ func (l *AthenaPreparedStatementLister) List(_ context.Context, o interface{}) (
 		for {
 			output, err := svc.ListPreparedStatements(params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("workgroup", *workgroup.Name).
+					Warn("unable to list prepared statements for Athena workgroup, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, statement := range output.PreparedStatements {

--- a/resources/autoscaling-lifecycle-hook.go
+++ b/resources/autoscaling-lifecycle-hook.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/autoscaling" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 
@@ -52,7 +54,9 @@ func (l *AutoScalingLifecycleHookLister) List(_ context.Context, o interface{}) 
 			AutoScalingGroupName: asg.AutoScalingGroupName,
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("asg", *asg.AutoScalingGroupName).
+				Warn("unable to describe lifecycle hooks for ASG, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, lch := range lchResp.LifecycleHooks {

--- a/resources/backup-vaults-access-policies.go
+++ b/resources/backup-vaults-access-policies.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/backup" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -54,7 +56,9 @@ func (l *AWSBackupVaultAccessPolicyLister) List(_ context.Context, o interface{}
 				// Non-existent is OK and we skip over them
 				continue
 			default:
-				return nil, err
+				logrus.WithError(err).WithField("vault", *out.BackupVaultName).
+					Warn("unable to get access policy for backup vault, skipping to avoid incorrect filtering")
+				continue
 			}
 		}
 

--- a/resources/bedrock-agent-alias.go
+++ b/resources/bedrock-agent-alias.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                  //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/bedrockagent" //nolint:staticcheck
 
@@ -48,7 +50,9 @@ func (l *BedrockAgentAliasLister) List(_ context.Context, o interface{}) ([]reso
 		for {
 			output, err := svc.ListAgentAliases(params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("agent", agentID).
+					Warn("unable to list aliases for Bedrock agent, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, agentAliasInfo := range output.AgentAliasSummaries {

--- a/resources/bedrock-agent-datasource.go
+++ b/resources/bedrock-agent-datasource.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                  //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/bedrockagent" //nolint:staticcheck
 
@@ -47,7 +49,9 @@ func (l *BedrockDataSourceLister) List(_ context.Context, o interface{}) ([]reso
 		for {
 			resp, err := svc.ListDataSources(params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("knowledgeBase", *knowledgeBaseResponse.KnowledgeBaseId).
+					Warn("unable to list data sources for Bedrock knowledge base, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, item := range resp.DataSourceSummaries {

--- a/resources/bedrock-custom-models.go
+++ b/resources/bedrock-custom-models.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/bedrock" //nolint:staticcheck
 
@@ -48,7 +50,9 @@ func (l *BedrockCustomModelLister) List(_ context.Context, o interface{}) ([]res
 					ResourceARN: modelSummary.ModelArn,
 				})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *modelSummary.ModelArn).
+					Warn("unable to list tags for Bedrock custom model, skipping to avoid incorrect filtering")
+				continue
 			}
 			resources = append(resources, &BedrockCustomModel{
 				svc:  svc,

--- a/resources/bedrock-evaluation-jobs.go
+++ b/resources/bedrock-evaluation-jobs.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/bedrock" //nolint:staticcheck
 
@@ -49,7 +51,9 @@ func (l *BedrockEvaluationJobLister) List(_ context.Context, o interface{}) ([]r
 					ResourceARN: jobSummary.JobArn,
 				})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *jobSummary.JobArn).
+					Warn("unable to list tags for Bedrock evaluation job, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &BedrockEvaluationJob{

--- a/resources/bedrock-flow-alias.go
+++ b/resources/bedrock-flow-alias.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                  //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/bedrockagent" //nolint:staticcheck
 
@@ -47,7 +49,9 @@ func (l *BedrockFlowAliasLister) List(_ context.Context, o interface{}) ([]resou
 		for {
 			output, err := svc.ListFlowAliases(params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("flow", flowID).
+					Warn("unable to list flow aliases for Bedrock flow, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, flowAliasInfo := range output.FlowAliasSummaries {

--- a/resources/bedrock-guardrails.go
+++ b/resources/bedrock-guardrails.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/bedrock" //nolint:staticcheck
 
@@ -48,7 +50,9 @@ func (l *BedrockGuardrailLister) List(_ context.Context, o interface{}) ([]resou
 					ResourceARN: guardrail.Arn,
 				})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *guardrail.Arn).
+					Warn("unable to list tags for Bedrock guardrail, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &BedrockGuardrail{

--- a/resources/bedrock-model-customization-jobs.go
+++ b/resources/bedrock-model-customization-jobs.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/bedrock" //nolint:staticcheck
 
@@ -49,7 +51,9 @@ func (l *BedrockModelCustomizationJobLister) List(_ context.Context, o interface
 					ResourceARN: modelCustomizationJobSummary.JobArn,
 				})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *modelCustomizationJobSummary.JobArn).
+					Warn("unable to list tags for Bedrock model customization job, skipping to avoid incorrect filtering")
+				continue
 			}
 			resources = append(resources, &BedrockModelCustomizationJob{
 				svc:       svc,

--- a/resources/bedrock-provisioned-model-throughputs.go
+++ b/resources/bedrock-provisioned-model-throughputs.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/bedrock" //nolint:staticcheck
 
@@ -48,7 +50,9 @@ func (l *BedrockProvisionedModelThroughputLister) List(_ context.Context, o inte
 					ResourceARN: provisionedModelSummary.ProvisionedModelArn,
 				})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *provisionedModelSummary.ProvisionedModelArn).
+					Warn("unable to list tags for Bedrock provisioned model throughput, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &BedrockProvisionedModelThroughput{

--- a/resources/bedrockagentcorecontrol-gateway.go
+++ b/resources/bedrockagentcorecontrol-gateway.go
@@ -56,7 +56,9 @@ func (l *BedrockAgentCoreGatewayLister) List(ctx context.Context, o interface{})
 				GatewayIdentifier: gateway.GatewayId,
 			})
 			if err != nil {
-				return nil, err
+				opts.Logger.WithError(err).WithField("id", *gateway.GatewayId).
+					Warn("unable to get Bedrock agent core gateway, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			// Get tags for the gateway

--- a/resources/bedrockagentcorecontrol-workloadidentity.go
+++ b/resources/bedrockagentcorecontrol-workloadidentity.go
@@ -56,7 +56,9 @@ func (l *BedrockAgentCoreWorkloadIdentityLister) List(ctx context.Context, o int
 				Name: identity.Name,
 			})
 			if err != nil {
-				return nil, err
+				opts.Logger.WithError(err).WithField("arn", *identity.WorkloadIdentityArn).
+					Warn("unable to get Bedrock agent core workload identity, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			// Get tags for the workload identity

--- a/resources/cloudfront-distribution.go
+++ b/resources/cloudfront-distribution.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
@@ -62,7 +63,9 @@ func (l *CloudFrontDistributionLister) List(ctx context.Context, o interface{}) 
 				Resource: item.ARN,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *item.Id).
+					Warn("unable to list tags for CloudFront distribution, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &CloudFrontDistribution{

--- a/resources/cloudwatch-alarm.go
+++ b/resources/cloudwatch-alarm.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
 	"github.com/aws/aws-sdk-go/aws"                //nolint:staticcheck
@@ -61,7 +62,9 @@ func (l *CloudWatchAlarmLister) List(_ context.Context, o interface{}) ([]resour
 		for _, metricAlarm := range output.MetricAlarms {
 			tags, err := GetAlarmTags(svc, metricAlarm.AlarmArn)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *metricAlarm.AlarmArn).
+					Warn("unable to list tags for CloudWatch alarm, skipping to avoid incorrect filtering")
+				continue
 			}
 			resources = append(resources, &CloudWatchAlarm{
 				svc:  svc,
@@ -74,7 +77,9 @@ func (l *CloudWatchAlarmLister) List(_ context.Context, o interface{}) ([]resour
 		for _, compositeAlarm := range output.CompositeAlarms {
 			tags, err := GetAlarmTags(svc, compositeAlarm.AlarmArn)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *compositeAlarm.AlarmArn).
+					Warn("unable to list tags for CloudWatch alarm, skipping to avoid incorrect filtering")
+				continue
 			}
 			resources = append(resources, &CloudWatchAlarm{
 				svc:  svc,

--- a/resources/cloudwatchevents-rule.go
+++ b/resources/cloudwatchevents-rule.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                      //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents" //nolint:staticcheck
 
@@ -46,7 +48,9 @@ func (l *CloudWatchEventsRuleLister) List(_ context.Context, o interface{}) ([]r
 				EventBusName: bus.Name,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("bus", *bus.Name).
+					Warn("unable to list rules for CloudWatch event bus, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, rule := range resp.Rules {

--- a/resources/cloudwatchevents-target.go
+++ b/resources/cloudwatchevents-target.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchevents" //nolint:staticcheck
 
@@ -44,7 +45,9 @@ func (l *CloudWatchEventsTargetLister) List(_ context.Context, o interface{}) ([
 			EventBusName: bus.Name,
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("bus", *bus.Name).
+				Warn("unable to list rules for CloudWatch event bus, skipping to avoid incorrect filtering")
+			continue
 		}
 		for _, rule := range resp.Rules {
 			targetResp, err := svc.ListTargetsByRule(&cloudwatchevents.ListTargetsByRuleInput{
@@ -52,7 +55,9 @@ func (l *CloudWatchEventsTargetLister) List(_ context.Context, o interface{}) ([
 				EventBusName: bus.Name,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("rule", *rule.Name).
+					Warn("unable to list targets for CloudWatch event rule, skipping to avoid incorrect filtering")
+				continue
 			}
 			for _, target := range targetResp.Targets {
 				resources = append(resources, &CloudWatchEventsTarget{

--- a/resources/codeartifact-domains.go
+++ b/resources/codeartifact-domains.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/codeartifact" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -42,7 +44,9 @@ func (l *CodeArtifactDomainLister) List(_ context.Context, o interface{}) ([]res
 		for _, domain := range resp.Domains {
 			desc, err := svc.DescribeDomain(&codeartifact.DescribeDomainInput{Domain: domain.Name})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("name", *domain.Name).
+					Warn("unable to describe CodeArtifact domain, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &CodeArtifactDomain{

--- a/resources/codedeploy-deployment-group.go
+++ b/resources/codedeploy-deployment-group.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/codedeploy" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -46,7 +48,9 @@ func (l *CodeDeployDeploymentGroupLister) List(_ context.Context, o interface{})
 			}
 			deploymentGroupResp, err := svc.ListDeploymentGroups(deploymentGroupParams)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("app", *appName).
+					Warn("unable to list deployment groups for CodeDeploy application, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, group := range deploymentGroupResp.DeploymentGroups {

--- a/resources/codestar-notifications.go
+++ b/resources/codestar-notifications.go
@@ -5,6 +5,8 @@ import (
 
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                           //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/codestarnotifications" //nolint:staticcheck
 
@@ -48,7 +50,9 @@ func (l *CodeStarNotificationRuleLister) List(_ context.Context, o interface{}) 
 				Arn: notification.Arn,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *notification.Arn).
+					Warn("unable to describe CodeStar notification rule, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &CodeStarNotificationRule{

--- a/resources/cognito-identity-provider.go
+++ b/resources/cognito-identity-provider.go
@@ -59,7 +59,9 @@ func (l *CognitoIdentityProviderLister) List(ctx context.Context, o interface{})
 		for {
 			output, err := svc.ListIdentityProviders(listParams)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("pool", *userPool.ID).
+					Warn("unable to list identity providers for Cognito user pool, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, provider := range output.Providers {

--- a/resources/cognito-userpool-client.go
+++ b/resources/cognito-userpool-client.go
@@ -57,7 +57,9 @@ func (l *CognitoUserPoolClientLister) List(ctx context.Context, o interface{}) (
 		for {
 			output, err := svc.ListUserPoolClients(listParams)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("pool", *userPool.ID).
+					Warn("unable to list clients for Cognito user pool, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, client := range output.UserPoolClients {

--- a/resources/cognito-userpool-domain.go
+++ b/resources/cognito-userpool-domain.go
@@ -51,7 +51,9 @@ func (l *CognitoUserPoolDomainLister) List(ctx context.Context, o interface{}) (
 		}
 		userPoolDetails, err := svc.DescribeUserPool(describeParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("id", *userPool.ID).
+				Warn("unable to describe Cognito user pool, skipping to avoid incorrect filtering")
+			continue
 		}
 		if userPoolDetails.UserPool.Domain == nil {
 			// No domain on this user pool so skip

--- a/resources/dsql-cluster.go
+++ b/resources/dsql-cluster.go
@@ -60,7 +60,9 @@ func (l *DSQLClusterLister) List(ctx context.Context, o interface{}) ([]resource
 				Identifier: clusterSummary.Identifier,
 			})
 			if err != nil {
-				return nil, err
+				opts.Logger.WithError(err).WithField("arn", *clusterSummary.Arn).
+					Warn("unable to get DSQL cluster, skipping to avoid incorrect filtering")
+				continue
 			}
 			// get cluster tags
 			var tags map[string]string

--- a/resources/dynamodb-item.go
+++ b/resources/dynamodb-item.go
@@ -56,7 +56,9 @@ func (l *DynamoDBTableItemLister) List(ctx context.Context, o interface{}) ([]re
 
 		descResp, descErr := svc.DescribeTable(describeParams)
 		if descErr != nil {
-			return nil, descErr
+			logrus.WithError(descErr).WithField("table", *dynamoTable.Name).
+				Warn("unable to describe DynamoDB table, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		keyName := descResp.Table.KeySchema[0].AttributeName
@@ -70,7 +72,9 @@ func (l *DynamoDBTableItemLister) List(ctx context.Context, o interface{}) ([]re
 
 		scanResp, scanErr := svc.Scan(params)
 		if scanErr != nil {
-			return nil, scanErr
+			logrus.WithError(scanErr).WithField("table", *dynamoTable.Name).
+				Warn("unable to scan DynamoDB table, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, itemMap := range scanResp.Items {

--- a/resources/ec2-client-vpn-endpoint-attachment.go
+++ b/resources/ec2-client-vpn-endpoint-attachment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/service/ec2" //nolint:staticcheck
 
@@ -64,7 +65,9 @@ func (l *EC2ClientVpnEndpointAttachmentLister) List(_ context.Context, o interfa
 				return true
 			})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("endpoint", *clientVpnEndpointID).
+				Warn("unable to describe target networks for client VPN endpoint, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/ec2-internet-gateway-attachment.go
+++ b/resources/ec2-internet-gateway-attachment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ec2" //nolint:staticcheck
@@ -56,7 +57,9 @@ func (l *EC2InternetGatewayAttachmentLister) List(_ context.Context, o interface
 
 		resp, err := svc.DescribeInternetGateways(params)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("vpc", *vpc.VpcId).
+				Warn("unable to describe internet gateways for VPC, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, igw := range resp.InternetGateways {

--- a/resources/ec2-vpc-endpoint.go
+++ b/resources/ec2-vpc-endpoint.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ec2" //nolint:staticcheck
 
@@ -55,7 +57,9 @@ func (l *EC2VPCEndpointLister) List(_ context.Context, o interface{}) ([]resourc
 
 		resp, err := svc.DescribeVpcEndpoints(params)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("vpc", *vpc.VpcId).
+				Warn("unable to describe VPC endpoints for VPC, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, vpcEndpoint := range resp.VpcEndpoints {

--- a/resources/ec2-vpn-gateway-attachments.go
+++ b/resources/ec2-vpn-gateway-attachments.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ec2" //nolint:staticcheck
 
@@ -52,7 +54,9 @@ func (l *EC2VPNGatewayAttachmentLister) List(_ context.Context, o interface{}) (
 
 		resp, err := svc.DescribeVpnGateways(params)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("vpc", *vpc.VpcId).
+				Warn("unable to describe VPN gateways for VPC, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, vgw := range resp.VpnGateways {

--- a/resources/ecr-public-repository.go
+++ b/resources/ecr-public-repository.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"               //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/aws/endpoints"     //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ecrpublic" //nolint:staticcheck
@@ -57,7 +59,9 @@ func (l *ECRPublicRepositoryLister) List(_ context.Context, o interface{}) ([]re
 				ResourceArn: repository.RepositoryArn,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *repository.RepositoryArn).
+					Warn("unable to list tags for ECR public repository, skipping to avoid incorrect filtering")
+				continue
 			}
 			resources = append(resources, &ECRPublicRepository{
 				svc:         svc,

--- a/resources/ecr-repository.go
+++ b/resources/ecr-repository.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ecr" //nolint:staticcheck
 
@@ -53,7 +55,9 @@ func (l *ECRRepositoryLister) List(_ context.Context, o interface{}) ([]resource
 				ResourceArn: repository.RepositoryArn,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *repository.RepositoryArn).
+					Warn("unable to list tags for ECR repository, skipping to avoid incorrect filtering")
+				continue
 			}
 			resources = append(resources, &ECRRepository{
 				svc:         svc,

--- a/resources/ecs-clusterinstances.go
+++ b/resources/ecs-clusterinstances.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ecs" //nolint:staticcheck
 
@@ -62,7 +64,9 @@ func (l *ECSClusterInstanceLister) List(_ context.Context, o interface{}) ([]res
 		}
 		output, err := svc.ListContainerInstances(instanceParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("cluster", *clusterArn).
+				Warn("unable to list container instances for ECS cluster, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, instanceArn := range output.ContainerInstanceArns {

--- a/resources/ecs-services.go
+++ b/resources/ecs-services.go
@@ -67,7 +67,9 @@ func (l *ECSServiceLister) List(_ context.Context, o interface{}) ([]resource.Re
 		for {
 			output, err := svc.ListServices(serviceParams)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("cluster", *clusterArn).
+					Warn("unable to list services for ECS cluster, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, serviceArn := range output.ServiceArns {

--- a/resources/ecs-task.go
+++ b/resources/ecs-task.go
@@ -74,7 +74,9 @@ func (l *ECSTaskLister) List(_ context.Context, o interface{}) ([]resource.Resou
 		}
 		output, err := svc.ListTasks(taskParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("cluster", *clusterArn).
+				Warn("unable to list tasks for ECS cluster, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, taskArn := range output.TaskArns {

--- a/resources/efs-filesystem.go
+++ b/resources/efs-filesystem.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
 	"github.com/aws/aws-sdk-go-v2/service/efs"
@@ -51,7 +52,9 @@ func (l *EFSFileSystemLister) List(ctx context.Context, o interface{}) ([]resour
 			fs := resp.FileSystems[idx]
 			lto, err := svc.ListTagsForResource(ctx, &efs.ListTagsForResourceInput{ResourceId: fs.FileSystemId})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *fs.FileSystemId).
+					Warn("unable to list tags for EFS filesystem, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			tagList := make([]*efsTypes.Tag, 0)

--- a/resources/efs-mount-targets.go
+++ b/resources/efs-mount-targets.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/efs" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -42,12 +44,16 @@ func (l *EFSMountTargetLister) List(_ context.Context, o interface{}) ([]resourc
 			FileSystemId: fs.FileSystemId,
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("id", *fs.FileSystemId).
+				Warn("unable to describe mount targets for EFS filesystem, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		lto, err := svc.ListTagsForResource(&efs.ListTagsForResourceInput{ResourceId: fs.FileSystemId})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("id", *fs.FileSystemId).
+				Warn("unable to list tags for EFS filesystem, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, t := range mt.MountTargets {

--- a/resources/eks-clusters.go
+++ b/resources/eks-clusters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -53,7 +54,9 @@ func (l *EKSClusterLister) List(ctx context.Context, o interface{}) ([]resource.
 		for _, cluster := range resp.Clusters {
 			dcResp, err := svc.DescribeCluster(ctx, &eks.DescribeClusterInput{Name: aws.String(cluster)})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("name", cluster).
+					Warn("unable to describe EKS cluster, skipping to avoid incorrect filtering")
+				continue
 			}
 			resources = append(resources, &EKSCluster{
 				svc:        svc,

--- a/resources/eks-nodegroups.go
+++ b/resources/eks-nodegroups.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/eks" //nolint:staticcheck
 
@@ -71,14 +73,18 @@ func (l *EKSNodegroupLister) List(_ context.Context, o interface{}) ([]resource.
 		for {
 			resp, err := svc.ListNodegroups(nodegroupsInputParams)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("cluster", *clusterName).
+					Warn("unable to list nodegroups for EKS cluster, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, nodegroupName := range resp.Nodegroups {
 				describeNodegroupInputParams.NodegroupName = nodegroupName
 				nodegroupDescriptionResponse, err := svc.DescribeNodegroup(describeNodegroupInputParams)
 				if err != nil {
-					return nil, err
+					logrus.WithError(err).WithField("nodegroup", *nodegroupName).
+						Warn("unable to describe EKS nodegroup, skipping to avoid incorrect filtering")
+					continue
 				}
 				resources = append(resources, &EKSNodegroup{
 					svc:       svc,

--- a/resources/elasticsearchservice-domain.go
+++ b/resources/elasticsearchservice-domain.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/elasticsearchservice" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -41,11 +43,15 @@ func (l *ESDomainLister) List(_ context.Context, o interface{}) ([]resource.Reso
 		dedo, err := svc.DescribeElasticsearchDomain(
 			&elasticsearchservice.DescribeElasticsearchDomainInput{DomainName: domain.DomainName})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("name", *domain.DomainName).
+				Warn("unable to describe Elasticsearch domain, skipping to avoid incorrect filtering")
+			continue
 		}
 		lto, err := svc.ListTags(&elasticsearchservice.ListTagsInput{ARN: dedo.DomainStatus.ARN})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("name", *domain.DomainName).
+				Warn("unable to list tags for Elasticsearch domain, skipping to avoid incorrect filtering")
+			continue
 		}
 		resources = append(resources, &ESDomain{
 			svc:        svc,

--- a/resources/elb-elb.go
+++ b/resources/elb-elb.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/elb" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -57,7 +59,10 @@ func (l *ELBLister) List(_ context.Context, o interface{}) ([]resource.Resource,
 			LoadBalancerNames: elbNames[:requestElements],
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).
+				Warn("unable to describe tags for ELB batch, skipping batch to avoid incorrect filtering")
+			elbNames = elbNames[requestElements:]
+			continue
 		}
 		for _, elbTagInfo := range tagResp.TagDescriptions {
 			elbEntity := elbNameToRsc[*elbTagInfo.LoadBalancerName]

--- a/resources/elbv2-alb.go
+++ b/resources/elbv2-alb.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"           //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/aws/awserr"    //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/elbv2" //nolint:staticcheck
@@ -67,7 +69,10 @@ func (l *ELBv2Lister) List(_ context.Context, o interface{}) ([]resource.Resourc
 			ResourceArns: tagReqELBv2ARNs[:requestElements],
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).
+				Warn("unable to describe tags for ELBv2 batch, skipping batch to avoid incorrect filtering")
+			tagReqELBv2ARNs = tagReqELBv2ARNs[requestElements:]
+			continue
 		}
 		for _, elbv2TagInfo := range tagResp.TagDescriptions {
 			elb := elbv2ARNToRsc[*elbv2TagInfo.ResourceArn]

--- a/resources/elbv2-targetgroup.go
+++ b/resources/elbv2-targetgroup.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/elbv2" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -61,7 +63,10 @@ func (l *ELBv2TargetGroupLister) List(_ context.Context, o interface{}) ([]resou
 			ResourceArns: tagReqELBv2TargetGroupARNs[:requestElements],
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).
+				Warn("unable to describe tags for ELBv2 target group batch, skipping batch to avoid incorrect filtering")
+			tagReqELBv2TargetGroupARNs = tagReqELBv2TargetGroupARNs[requestElements:]
+			continue
 		}
 		for _, tagInfo := range tagResp.TagDescriptions {
 			resources = append(resources, &ELBv2TargetGroup{

--- a/resources/ga-endpoints.go
+++ b/resources/ga-endpoints.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                       //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/globalaccelerator" //nolint:staticcheck
 
@@ -67,7 +69,9 @@ func (l *GlobalAcceleratorEndpointGroupLister) List(_ context.Context, o interfa
 		for {
 			output, err := svc.ListListeners(listenerParams)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *acceleratorARN).
+					Warn("unable to list listeners for Global Accelerator, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, listener := range output.Listeners {
@@ -92,7 +96,9 @@ func (l *GlobalAcceleratorEndpointGroupLister) List(_ context.Context, o interfa
 		for {
 			output, err := svc.ListEndpointGroups(params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *listenerArn).
+					Warn("unable to list endpoint groups for Global Accelerator listener, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, endpointGroup := range output.EndpointGroups {

--- a/resources/ga-listeners.go
+++ b/resources/ga-listeners.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                       //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/globalaccelerator" //nolint:staticcheck
 
@@ -66,7 +68,9 @@ func (l *GlobalAcceleratorListenerLister) List(_ context.Context, o interface{})
 		for {
 			output, err := svc.ListListeners(params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *acceleratorARN).
+					Warn("unable to list listeners for Global Accelerator, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, listener := range output.Listeners {

--- a/resources/iam-group-policies.go
+++ b/resources/iam-group-policies.go
@@ -5,6 +5,8 @@ import (
 
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 
@@ -43,7 +45,9 @@ func (l *IAMGroupPolicyLister) List(_ context.Context, o interface{}) ([]resourc
 				GroupName: group.GroupName,
 			})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("group", *group.GroupName).
+				Warn("unable to list policies for IAM group, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, pol := range resp.PolicyNames {

--- a/resources/iam-group-policy-attachments.go
+++ b/resources/iam-group-policy-attachments.go
@@ -5,6 +5,8 @@ import (
 
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 
@@ -48,7 +50,9 @@ func (l *IAMGroupPolicyAttachmentLister) List(_ context.Context, o interface{}) 
 				GroupName: role.GroupName,
 			})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("group", *role.GroupName).
+				Warn("unable to list attached policies for IAM group, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, pol := range resp.AttachedPolicies {

--- a/resources/iam-service-specific-credentials.go
+++ b/resources/iam-service-specific-credentials.go
@@ -53,7 +53,9 @@ func (l *IAMServiceSpecificCredentialLister) List(ctx context.Context, o interfa
 		}
 		serviceCredentials, err := svc.ListServiceSpecificCredentials(params)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *user.Name).
+				Warn("unable to list service specific credentials for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, credential := range serviceCredentials.ServiceSpecificCredentials {

--- a/resources/iam-signing-certificate.go
+++ b/resources/iam-signing-certificate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
@@ -52,7 +53,9 @@ func (l *IAMSigningCertificateLister) List(_ context.Context, o interface{}) ([]
 				UserName: out.UserName,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("user", *out.UserName).
+					Warn("unable to list signing certificates for IAM user, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, signingCert := range resp.Certificates {

--- a/resources/iam-user-access-key.go
+++ b/resources/iam-user-access-key.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 
@@ -88,12 +90,16 @@ func (l *IAMUserAccessKeyLister) List(_ context.Context, o interface{}) ([]resou
 				UserName: role.UserName,
 			})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *role.UserName).
+				Warn("unable to list access keys for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		userTags, err := svc.ListUserTags(&iam.ListUserTagsInput{UserName: role.UserName})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *role.UserName).
+				Warn("unable to list tags for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, meta := range resp.AccessKeyMetadata {

--- a/resources/iam-user-group-attachments.go
+++ b/resources/iam-user-group-attachments.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 
@@ -77,7 +79,9 @@ func (l *IAMUserGroupAttachmentLister) List(_ context.Context, o interface{}) ([
 				UserName: role.UserName,
 			})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *role.UserName).
+				Warn("unable to list groups for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, grp := range resp.Groups {

--- a/resources/iam-user-https-git-credential.go
+++ b/resources/iam-user-https-git-credential.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
@@ -84,12 +86,16 @@ func (l *IAMUserHTTPSGitCredentialLister) List(_ context.Context, o interface{})
 				ServiceName: aws.String("codecommit.amazonaws.com"),
 			})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *role.UserName).
+				Warn("unable to list service specific credentials for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		userTags, err := svc.ListUserTags(&iam.ListUserTagsInput{UserName: role.UserName})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *role.UserName).
+				Warn("unable to list tags for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, meta := range resp.ServiceSpecificCredentials {

--- a/resources/iam-user-mfa-device.go
+++ b/resources/iam-user-mfa-device.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
@@ -54,7 +55,9 @@ func (l *IAMUserMFADeviceLister) List(_ context.Context, o interface{}) ([]resou
 			UserName: user.UserName,
 		})
 		if listErr != nil {
-			return nil, listErr
+			logrus.WithError(listErr).WithField("user", *user.UserName).
+				Warn("unable to list MFA devices for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, p := range res.MFADevices {

--- a/resources/iam-user-policy-attachment.go
+++ b/resources/iam-user-policy-attachment.go
@@ -93,7 +93,9 @@ func (l *IAMUserPolicyAttachmentLister) List(_ context.Context, o interface{}) (
 				UserName: user.UserName,
 			})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *user.UserName).
+				Warn("unable to list attached policies for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, pol := range resp.AttachedPolicies {

--- a/resources/iam-user-policy.go
+++ b/resources/iam-user-policy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 
@@ -67,7 +69,9 @@ func (l *IAMUserPolicyLister) List(_ context.Context, o interface{}) ([]resource
 			UserName: user.UserName,
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *user.UserName).
+				Warn("unable to list policies for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, policyName := range policies.PolicyNames {

--- a/resources/iam-user-ssh-keys.go
+++ b/resources/iam-user-ssh-keys.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 
@@ -43,7 +45,9 @@ func (l *IAMUserSSHPublicKeyLister) List(_ context.Context, o interface{}) ([]re
 		})
 
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("user", *user.UserName).
+				Warn("unable to list SSH public keys for IAM user, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, publicKey := range listOutput.SSHPublicKeys {

--- a/resources/imagebuilder-components.go
+++ b/resources/imagebuilder-components.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/imagebuilder" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -41,7 +43,9 @@ func (l *ImageBuilderComponentLister) List(_ context.Context, o interface{}) ([]
 		for _, out := range resp.ComponentVersionList {
 			resources, err = ListImageBuilderComponentVersions(svc, out.Arn, resources)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *out.Arn).
+					Warn("unable to list component build versions, skipping to avoid incorrect filtering")
+				continue
 			}
 		}
 

--- a/resources/imagebuilder-images.go
+++ b/resources/imagebuilder-images.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/imagebuilder" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -41,7 +43,9 @@ func (l *ImageBuilderImageLister) List(_ context.Context, o interface{}) ([]reso
 		for _, out := range resp.ImageVersionList {
 			resources, err = ImageBuildVersions(svc, out.Arn, resources)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *out.Arn).
+					Warn("unable to list image build versions, skipping to avoid incorrect filtering")
+				continue
 			}
 		}
 

--- a/resources/iot-policies.go
+++ b/resources/iot-policies.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iot" //nolint:staticcheck
@@ -50,12 +51,16 @@ func (l *IoTPolicyLister) List(_ context.Context, o interface{}) ([]resource.Res
 
 			p, err = listIoTPolicyTargets(p)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("name", *policy.PolicyName).
+					Warn("unable to list targets for IoT policy, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			p, err = listIoTPolicyDeprecatedVersions(p)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("name", *policy.PolicyName).
+					Warn("unable to list policy versions for IoT policy, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, p)

--- a/resources/iot-thinggroups.go
+++ b/resources/iot-thinggroups.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iot" //nolint:staticcheck
 
@@ -56,7 +58,9 @@ func (l *IoTThingGroupLister) List(_ context.Context, o interface{}) ([]resource
 			ThingGroupName: thingGroup.GroupName,
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("arn", *thingGroup.GroupArn).
+				Warn("unable to describe IoT thing group, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		thingGroupType := "static"

--- a/resources/iot-things.go
+++ b/resources/iot-things.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iot" //nolint:staticcheck
 
@@ -48,7 +50,9 @@ func (l *IoTThingLister) List(_ context.Context, o interface{}) ([]resource.Reso
 				version: thing.Version,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("name", *thing.ThingName).
+					Warn("unable to list principals for IoT thing, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, t)

--- a/resources/iotsitewise-asset-model.go
+++ b/resources/iotsitewise-asset-model.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iotsitewise" //nolint:staticcheck
 
@@ -50,7 +52,9 @@ func (l *IoTSiteWiseAssetModelLister) List(_ context.Context, o interface{}) ([]
 					ResourceArn: item.Arn,
 				})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *item.Arn).
+					Warn("unable to list tags for IoT SiteWise asset model, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &IoTSiteWiseAssetModel{

--- a/resources/iotsitewise-asset.go
+++ b/resources/iotsitewise-asset.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iotsitewise" //nolint:staticcheck
 
@@ -54,7 +56,9 @@ func (l *IoTSiteWiseAssetLister) List(_ context.Context, o interface{}) ([]resou
 						ResourceArn: item.Arn,
 					})
 				if err != nil {
-					return nil, err
+					logrus.WithError(err).WithField("arn", *item.Arn).
+						Warn("unable to list tags for IoT SiteWise asset, skipping to avoid incorrect filtering")
+					continue
 				}
 
 				resources = append(resources, &IoTSiteWiseAsset{

--- a/resources/iottwinmaker-component-type.go
+++ b/resources/iottwinmaker-component-type.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                  //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iottwinmaker" //nolint:staticcheck
 
@@ -69,7 +71,9 @@ func (l *IoTTwinMakerComponentTypeLister) List(_ context.Context, o interface{})
 							ResourceARN: item.Arn,
 						})
 					if err != nil {
-						return nil, err
+						logrus.WithError(err).WithField("arn", *item.Arn).
+							Warn("unable to list tags for IoT TwinMaker component type, skipping to avoid incorrect filtering")
+						continue
 					}
 					tags = tagResp.Tags
 				}

--- a/resources/iottwinmaker-workspace.go
+++ b/resources/iottwinmaker-workspace.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                  //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iottwinmaker" //nolint:staticcheck
 
@@ -60,7 +62,9 @@ func (l *IoTTwinMakerWorkspaceLister) List(_ context.Context, o interface{}) ([]
 					ResourceARN: item.Arn,
 				})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *item.Arn).
+					Warn("unable to list tags for IoT TwinMaker workspace, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &IoTTwinMakerWorkspace{

--- a/resources/lambda-layers.go
+++ b/resources/lambda-layers.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/lambda" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -59,7 +61,9 @@ func (l *LambdaLayerLister) List(_ context.Context, o interface{}) ([]resource.R
 			return true
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("layer", *layer.LayerName).
+				Warn("unable to list layer versions for Lambda layer, skipping to avoid incorrect filtering")
+			continue
 		}
 	}
 

--- a/resources/managedblockchain-member.go
+++ b/resources/managedblockchain-member.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"                //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/managedblockchain" //nolint:staticcheck
@@ -44,7 +45,9 @@ func (l *ManagedBlockchainMemberLister) List(_ context.Context, o interface{}) (
 			NetworkId: n.Id,
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("network", *n.Id).
+				Warn("unable to list members for ManagedBlockchain network, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, r := range res.Members {

--- a/resources/mediastoredata-items.go
+++ b/resources/mediastoredata-items.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/mediastore"     //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/mediastoredata" //nolint:staticcheck
@@ -68,7 +70,9 @@ func (l *MediaStoreDataItemsLister) List(_ context.Context, o interface{}) ([]re
 		svc.Endpoint = *container.Endpoint
 		output, err := svc.ListItems(params)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("container", *container.Name).
+				Warn("unable to list items for MediaStore container, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, item := range output.Items {

--- a/resources/neptune-graph.go
+++ b/resources/neptune-graph.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/neptunegraph"
 	neptunegraphtypes "github.com/aws/aws-sdk-go-v2/service/neptunegraph/types"
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -52,7 +53,9 @@ func (l *NeptuneGraphLister) List(ctx context.Context, o interface{}) ([]resourc
 				ResourceArn: p.Arn,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *p.Arn).
+					Warn("unable to list tags for Neptune graph, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			snapshots := make([]neptunegraphtypes.GraphSnapshotSummary, 0)
@@ -63,7 +66,9 @@ func (l *NeptuneGraphLister) List(ctx context.Context, o interface{}) ([]resourc
 					NextToken:       snapshotNextToken,
 				})
 				if err != nil {
-					return nil, err
+					logrus.WithError(err).WithField("arn", *p.Arn).
+						Warn("unable to list snapshots for Neptune graph, skipping to avoid incorrect filtering")
+					break
 				}
 				snapshots = append(snapshots, s.GraphSnapshots...)
 				if s.NextToken == nil {

--- a/resources/opensearchservice-domain.go
+++ b/resources/opensearchservice-domain.go
@@ -5,6 +5,8 @@ import (
 
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/opensearchservice" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -59,12 +61,16 @@ func (l *OSDomainLister) List(_ context.Context, o interface{}) ([]resource.Reso
 	for _, domain := range descResp.DomainStatusList {
 		configResp, err := svc.DescribeDomainConfig(&opensearchservice.DescribeDomainConfigInput{DomainName: domain.DomainName})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("arn", *domain.ARN).
+				Warn("unable to describe domain config for OpenSearch domain, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		lto, err := svc.ListTags(&opensearchservice.ListTagsInput{ARN: domain.ARN})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("arn", *domain.ARN).
+				Warn("unable to list tags for OpenSearch domain, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		resources = append(resources, &OSDomain{

--- a/resources/opsworks-apps.go
+++ b/resources/opsworks-apps.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/opsworks" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -43,7 +45,9 @@ func (l *OpsWorksAppLister) List(_ context.Context, o interface{}) ([]resource.R
 		appsParams.StackId = stack.StackId
 		output, err := svc.DescribeApps(appsParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("stack", *stack.StackId).
+				Warn("unable to describe apps for OpsWorks stack, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, app := range output.Apps {

--- a/resources/opsworks-instances.go
+++ b/resources/opsworks-instances.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/opsworks" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -42,7 +44,9 @@ func (l *OpsWorksInstanceLister) List(_ context.Context, o interface{}) ([]resou
 		instanceParams.StackId = stack.StackId
 		output, err := svc.DescribeInstances(instanceParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("stack", *stack.StackId).
+				Warn("unable to describe instances for OpsWorks stack, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, instance := range output.Instances {

--- a/resources/opsworks-layers.go
+++ b/resources/opsworks-layers.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/opsworks" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -43,7 +45,9 @@ func (l *OpsWorksLayerLister) List(_ context.Context, o interface{}) ([]resource
 		layerParams.StackId = stack.StackId
 		output, err := svc.DescribeLayers(layerParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("stack", *stack.StackId).
+				Warn("unable to describe layers for OpsWorks stack, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, layer := range output.Layers {

--- a/resources/qldb-ledger.go
+++ b/resources/qldb-ledger.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"          //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/qldb" //nolint:staticcheck
 
@@ -48,7 +50,9 @@ func (l *QLDBLedgerLister) List(_ context.Context, o interface{}) ([]resource.Re
 		for _, ledger := range resp.Ledgers {
 			ledgerDescription, err := svc.DescribeLedger(&qldb.DescribeLedgerInput{Name: ledger.Name})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("name", *ledger.Name).
+					Warn("unable to describe QLDB ledger, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &QLDBLedger{

--- a/resources/rds-cluster-snapshots.go
+++ b/resources/rds-cluster-snapshots.go
@@ -5,6 +5,8 @@ import (
 
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/rds" //nolint:staticcheck
 
@@ -45,7 +47,9 @@ func (l *RDSClusterSnapshotLister) List(_ context.Context, o interface{}) ([]res
 			ResourceName: snapshot.DBClusterSnapshotArn,
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("arn", *snapshot.DBClusterSnapshotArn).
+				Warn("unable to list tags for RDS cluster snapshot, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		resources = append(resources, &RDSClusterSnapshot{

--- a/resources/rds-snapshots.go
+++ b/resources/rds-snapshots.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/rds" //nolint:staticcheck
 
@@ -46,7 +48,9 @@ func (l *RDSSnapshotLister) List(_ context.Context, o interface{}) ([]resource.R
 			ResourceName: snapshot.DBSnapshotArn,
 		})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("arn", *snapshot.DBSnapshotArn).
+				Warn("unable to list tags for RDS snapshot, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		resources = append(resources, &RDSSnapshot{

--- a/resources/route53-health-checks.go
+++ b/resources/route53-health-checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/route53" //nolint:staticcheck
@@ -47,7 +48,9 @@ func (l *Route53HealthCheckLister) List(_ context.Context, o interface{}) ([]res
 				ResourceType: aws.String("healthcheck"),
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *check.Id).
+					Warn("unable to list tags for Route53 health check, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &Route53HealthCheck{

--- a/resources/route53-hosted-zone.go
+++ b/resources/route53-hosted-zone.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/service/route53" //nolint:staticcheck
 
@@ -58,7 +59,9 @@ func (l *Route53HostedZoneLister) List(_ context.Context, o interface{}) ([]reso
 		})
 
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("id", *hz.Id).
+				Warn("unable to list tags for Route53 hosted zone, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		resources = append(resources, &Route53HostedZone{

--- a/resources/route53-resource-record.go
+++ b/resources/route53-resource-record.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gotidy/ptr"
 
 	"github.com/aws/aws-sdk-go/aws"             //nolint:staticcheck
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/service/route53" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -46,7 +48,9 @@ func (l *Route53ResourceRecordSetLister) List(ctx context.Context, o interface{}
 		zone := r.(*Route53HostedZone)
 		rrs, err := ListResourceRecordsForZone(svc, zone.ID, zone.Name, zone.Tags)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("zone", *zone.ID).
+				Warn("unable to list resource records for Route53 zone, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		resources = append(resources, rrs...)

--- a/resources/route53-traffic-policies.go
+++ b/resources/route53-traffic-policies.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/route53" //nolint:staticcheck
 
@@ -44,7 +46,9 @@ func (l *Route53TrafficPolicyLister) List(_ context.Context, o interface{}) ([]r
 			instances, err := instancesForPolicy(svc, trafficPolicy.Id, trafficPolicy.LatestVersion)
 
 			if err != nil {
-				return nil, fmt.Errorf("failed to get instance for policy %s %w", *trafficPolicy.Id, err)
+				logrus.WithError(err).WithField("id", *trafficPolicy.Id).
+					Warn("unable to list instances for Route53 traffic policy, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &Route53TrafficPolicy{

--- a/resources/s3-multipart-upload.go
+++ b/resources/s3-multipart-upload.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -45,7 +47,9 @@ func (l *S3MultipartUploadLister) List(ctx context.Context, o interface{}) ([]re
 		for {
 			resp, err := svc.ListMultipartUploads(ctx, params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("bucket", *bucket.Name).
+					Warn("unable to list multipart uploads for S3 bucket, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, upload := range resp.Uploads {

--- a/resources/s3-object.go
+++ b/resources/s3-object.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
@@ -48,7 +49,9 @@ func (l *S3ObjectLister) List(ctx context.Context, o interface{}) ([]resource.Re
 		for {
 			resp, err := svc.ListObjectVersions(ctx, params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("bucket", *bucket.Name).
+					Warn("unable to list object versions for S3 bucket, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for i := range resp.Versions {

--- a/resources/s3-object.go
+++ b/resources/s3-object.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
@@ -48,7 +49,9 @@ func (l *S3ObjectLister) List(ctx context.Context, o interface{}) ([]resource.Re
 		for {
 			resp, err := svc.ListObjectVersions(ctx, params)
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("bucket", *bucket.Name).
+					Warn("unable to list object versions for S3 bucket, skipping to avoid incorrect filtering")
+				break
 			}
 
 			for _, out := range resp.Versions {

--- a/resources/servicecatalog-portfolio-constraints-attachments.go
+++ b/resources/servicecatalog-portfolio-constraints-attachments.go
@@ -69,7 +69,9 @@ func (l *ServiceCatalogConstraintPortfolioAttachmentLister) List(_ context.Conte
 		constraintParams.PortfolioId = portfolio.Id
 		resp, err := svc.ListConstraintsForPortfolio(constraintParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("portfolio", *portfolio.Id).
+				Warn("unable to list constraints for ServiceCatalog portfolio, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, constraintDetail := range resp.ConstraintDetails {

--- a/resources/servicecatalog-portfolio-principal-attachments.go
+++ b/resources/servicecatalog-portfolio-principal-attachments.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/servicecatalog" //nolint:staticcheck
 
@@ -63,7 +65,9 @@ func (l *ServiceCatalogPrincipalPortfolioAttachmentLister) List(_ context.Contex
 
 		resp, err := svc.ListPrincipalsForPortfolio(principalParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("portfolio", *portfolio.Id).
+				Warn("unable to list principals for ServiceCatalog portfolio, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, principal := range resp.Principals {

--- a/resources/servicecatalog-portfolio-product-attachments.go
+++ b/resources/servicecatalog-portfolio-product-attachments.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/servicecatalog" //nolint:staticcheck
 
@@ -65,7 +67,9 @@ func (l *ServiceCatalogPortfolioProductAttachmentLister) List(_ context.Context,
 
 		resp, err := svc.ListPortfoliosForProduct(portfolioParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("product", *productID).
+				Warn("unable to list portfolios for ServiceCatalog product, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, portfolioDetail := range resp.PortfolioDetails {

--- a/resources/servicecatalog-portfolio-share-attachments.go
+++ b/resources/servicecatalog-portfolio-share-attachments.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/servicecatalog" //nolint:staticcheck
 
@@ -62,7 +64,9 @@ func (l *ServiceCatalogPortfolioShareAttachmentLister) List(_ context.Context, o
 
 		resp, err := svc.ListPortfolioAccess(accessParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("portfolio", *portfolio.Id).
+				Warn("unable to list portfolio access for ServiceCatalog portfolio, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, account := range resp.AccountIds {

--- a/resources/servicecatalog-portfolio-tagoptions-attachements.go
+++ b/resources/servicecatalog-portfolio-tagoptions-attachements.go
@@ -69,7 +69,9 @@ func (l *ServiceCatalogTagOptionPortfolioAttachmentLister) List(_ context.Contex
 		resourceParams.TagOptionId = tagOption.Id
 		resp, err := svc.ListResourcesForTagOption(resourceParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("tagOption", *tagOption.Id).
+				Warn("unable to list resources for ServiceCatalog tag option, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, resourceDetail := range resp.ResourceDetails {

--- a/resources/servicediscovery-instances.go
+++ b/resources/servicediscovery-instances.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                      //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/servicediscovery" //nolint:staticcheck
 
@@ -63,7 +65,9 @@ func (l *ServiceDiscoveryInstanceLister) List(_ context.Context, o interface{}) 
 
 		output, err := svc.ListInstances(instanceParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("service", *service.Id).
+				Warn("unable to list instances for ServiceDiscovery service, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, instance := range output.Instances {

--- a/resources/ses-receiptrulesets.go
+++ b/resources/ses-receiptrulesets.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"  //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ses" //nolint:staticcheck
 
@@ -60,7 +62,9 @@ func (l *SESReceiptRuleSetLister) List(_ context.Context, o interface{}) ([]reso
 
 		activeRuleSetOutput, err := svc.DescribeActiveReceiptRuleSet(&ses.DescribeActiveReceiptRuleSetInput{})
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("ruleSet", *ruleName).
+				Warn("unable to describe active receipt rule set, skipping to avoid incorrect filtering")
+			continue
 		}
 		if activeRuleSetOutput.Metadata == nil {
 			ruleSetState = false

--- a/resources/shield-protection-group.go
+++ b/resources/shield-protection-group.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go-v2/service/shield"
 	shieldtypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 
@@ -47,7 +49,9 @@ func (l *ShieldProtectionGroupLister) List(ctx context.Context, o interface{}) (
 				ResourceARN: group.ProtectionGroupArn,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *group.ProtectionGroupArn).
+					Warn("unable to list tags for Shield protection group, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &ShieldProtectionGroup{

--- a/resources/shield-protection.go
+++ b/resources/shield-protection.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go-v2/service/shield"
 	shieldtypes "github.com/aws/aws-sdk-go-v2/service/shield/types"
 
@@ -47,7 +49,9 @@ func (l *ShieldProtectionLister) List(ctx context.Context, o interface{}) ([]res
 				ResourceARN: protection.ProtectionArn,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("arn", *protection.ProtectionArn).
+					Warn("unable to list tags for Shield protection, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &ShieldProtection{

--- a/resources/sns-endpoints.go
+++ b/resources/sns-endpoints.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"  //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/sns" //nolint:staticcheck
 
@@ -65,7 +67,9 @@ func (l *SNSEndpointLister) List(_ context.Context, o interface{}) ([]resource.R
 
 		resp, err := svc.ListEndpointsByPlatformApplication(params)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("arn", *platformApplication.PlatformApplicationArn).
+				Warn("unable to list endpoints for SNS platform application, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, endpoint := range resp.Endpoints {

--- a/resources/ssm-parameters.go
+++ b/resources/ssm-parameters.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ssm" //nolint:staticcheck
 
@@ -50,7 +52,9 @@ func (l *SSMParameterLister) List(_ context.Context, o interface{}) ([]resource.
 
 			tagResp, tagErr := svc.ListTagsForResource(tagParams)
 			if tagErr != nil {
-				return nil, tagErr
+				logrus.WithError(tagErr).WithField("name", *parameter.Name).
+					Warn("unable to list tags for SSM parameter, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &SSMParameter{

--- a/resources/textract-adapter-versions.go
+++ b/resources/textract-adapter-versions.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/textract"
 	textracttypes "github.com/aws/aws-sdk-go-v2/service/textract/types"
@@ -60,7 +62,9 @@ func (l *TextractAdapterVersionLister) List(ctx context.Context, o interface{}) 
 			for versionPaginator.HasMorePages() {
 				versionResp, err := versionPaginator.NextPage(ctx)
 				if err != nil {
-					return nil, err
+					logrus.WithError(err).WithField("adapter", *adapter.AdapterId).
+						Warn("unable to list adapter versions for Textract adapter, skipping to avoid incorrect filtering")
+					break
 				}
 
 				for _, item := range versionResp.AdapterVersions {

--- a/resources/textract-adapters.go
+++ b/resources/textract-adapters.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/textract"
 	textracttypes "github.com/aws/aws-sdk-go-v2/service/textract/types"
+	"github.com/sirupsen/logrus"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -52,7 +53,9 @@ func (l *TextractAdapterLister) List(ctx context.Context, o interface{}) ([]reso
 				AdapterId: adapter.AdapterId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *adapter.AdapterId).
+					Warn("unable to get Textract adapter, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &TextractAdapter{

--- a/resources/transfer-server-user.go
+++ b/resources/transfer-server-user.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"              //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/transfer" //nolint:staticcheck
 
@@ -52,7 +54,9 @@ func (l *TransferServerUserLister) List(_ context.Context, o interface{}) ([]res
 			for {
 				userOutput, err := svc.ListUsers(userParams)
 				if err != nil {
-					return nil, err
+					logrus.WithError(err).WithField("server", *item.ServerId).
+						Warn("unable to list users for Transfer server, skipping to avoid incorrect filtering")
+					break
 				}
 
 				for _, user := range userOutput.Users {
@@ -61,7 +65,9 @@ func (l *TransferServerUserLister) List(_ context.Context, o interface{}) ([]res
 						UserName: user.UserName,
 					})
 					if err != nil {
-						return nil, err
+						logrus.WithError(err).WithField("user", *user.UserName).WithField("server", *item.ServerId).
+							Warn("unable to describe Transfer server user, skipping to avoid incorrect filtering")
+						continue
 					}
 
 					resources = append(resources, &TransferServerUser{

--- a/resources/transfer-server.go
+++ b/resources/transfer-server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"              //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/transfer" //nolint:staticcheck
 
@@ -48,7 +50,9 @@ func (l *TransferServerLister) List(_ context.Context, o interface{}) ([]resourc
 				ServerId: item.ServerId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *item.ServerId).
+					Warn("unable to describe Transfer server, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			var protocols []string

--- a/resources/waf-rules.go
+++ b/resources/waf-rules.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
@@ -56,7 +57,9 @@ func (l *WAFRuleLister) List(_ context.Context, o interface{}) ([]resource.Resou
 				RuleId: rule.RuleId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *rule.RuleId).
+					Warn("unable to get WAF rule, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &WAFRule{

--- a/resources/waf-webacl-rule-attachments.go
+++ b/resources/waf-webacl-rule-attachments.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf" //nolint:staticcheck
 
@@ -60,7 +62,9 @@ func (l *WAFWebACLRuleAttachmentLister) List(_ context.Context, o interface{}) (
 
 		resp, err := svc.GetWebACL(webACLParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("id", *webACL.WebACLId).
+				Warn("unable to get WAF WebACL, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, webACLRule := range resp.WebACL.Rules {

--- a/resources/wafregional-byte-match-set-tuples.go
+++ b/resources/wafregional-byte-match-set-tuples.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/wafregional" //nolint:staticcheck
@@ -48,7 +50,9 @@ func (l *WAFRegionalByteMatchSetIPLister) List(_ context.Context, o interface{})
 				ByteMatchSetId: set.ByteMatchSetId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *set.ByteMatchSetId).
+					Warn("unable to get WAF Regional byte match set, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, tuple := range details.ByteMatchSet.ByteMatchTuples {

--- a/resources/wafregional-ip-set-ips.go
+++ b/resources/wafregional-ip-set-ips.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/wafregional" //nolint:staticcheck
@@ -48,7 +50,9 @@ func (l *WAFRegionalIPSetIPLister) List(_ context.Context, o interface{}) ([]res
 				IPSetId: set.IPSetId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *set.IPSetId).
+					Warn("unable to get WAF Regional IP set, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, descriptor := range details.IPSet.IPSetDescriptors {

--- a/resources/wafregional-rate-based-rule-predicates.go
+++ b/resources/wafregional-rate-based-rule-predicates.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/wafregional" //nolint:staticcheck
@@ -48,7 +50,9 @@ func (l *WAFRegionalRateBasedRulePredicateLister) List(_ context.Context, o inte
 				RuleId: rule.RuleId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *rule.RuleId).
+					Warn("unable to get WAF Regional rate based rule, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, predicate := range details.Rule.MatchPredicates {

--- a/resources/wafregional-regex-match-tuples.go
+++ b/resources/wafregional-regex-match-tuples.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/wafregional" //nolint:staticcheck
@@ -48,7 +50,9 @@ func (l *WAFRegionalRegexMatchTupleLister) List(_ context.Context, o interface{}
 				RegexMatchSetId: set.RegexMatchSetId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *set.RegexMatchSetId).
+					Warn("unable to get WAF Regional regex match set, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, tuple := range regexMatchSet.RegexMatchSet.RegexMatchTuples {

--- a/resources/wafregional-regex-pattern-tuples.go
+++ b/resources/wafregional-regex-pattern-tuples.go
@@ -3,6 +3,8 @@ package resources
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/wafregional" //nolint:staticcheck
@@ -48,7 +50,9 @@ func (l *WAFRegionalRegexPatternStringLister) List(_ context.Context, o interfac
 				RegexPatternSetId: set.RegexPatternSetId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *set.RegexPatternSetId).
+					Warn("unable to get WAF Regional regex pattern set, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, patternString := range regexPatternSet.RegexPatternSet.RegexPatternStrings {

--- a/resources/wafregional-rule-predicates.go
+++ b/resources/wafregional-rule-predicates.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/wafregional" //nolint:staticcheck
+	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -56,7 +57,9 @@ func (l *WAFRegionalRulePredicateLister) List(_ context.Context, o interface{}) 
 				RuleId: rule.RuleId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *rule.RuleId).
+					Warn("unable to get WAF Regional rule, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			for _, predicate := range details.Rule.Predicates {

--- a/resources/wafregional-rules.go
+++ b/resources/wafregional-rules.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/wafregional" //nolint:staticcheck
+	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -56,7 +57,9 @@ func (l *WAFRegionalRuleLister) List(_ context.Context, o interface{}) ([]resour
 				RuleId: rule.RuleId,
 			})
 			if err != nil {
-				return nil, err
+				logrus.WithError(err).WithField("id", *rule.RuleId).
+					Warn("unable to get WAF Regional rule, skipping to avoid incorrect filtering")
+				continue
 			}
 
 			resources = append(resources, &WAFRegionalRule{

--- a/resources/wafregional-webacl-rule-attachments.go
+++ b/resources/wafregional-webacl-rule-attachments.go
@@ -5,6 +5,8 @@ import (
 
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"                 //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/waf"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/wafregional" //nolint:staticcheck
@@ -62,7 +64,9 @@ func (l *WAFRegionalWebACLRuleAttachmentLister) List(_ context.Context, o interf
 
 		resp, err := svc.GetWebACL(webACLParams)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).WithField("id", *webACL.WebACLId).
+				Warn("unable to get WAF Regional WebACL, skipping to avoid incorrect filtering")
+			continue
 		}
 
 		for _, webACLRule := range resp.WebACL.Rules {


### PR DESCRIPTION
Reported in #907
Following the fix for CloudWatchLogsLogGroup in #843, an audit of all resource handlers reveals that ~90 resource handlers exhibit the same cascading failure pattern. When a per-resource enrichment API call (e.g., ListTagsForResource, DescribeCluster, ListTags) fails for a single resource inside a List function, the entire listing aborts with return nil, err — causing all resources of that type to silently evade cleanup.

Updated all affected List functions across three categories of resources to log warnings and skip individual resources when per-resource enrichment calls fail, allowing discovery to continue for remaining resources:

Category 1 — Tag fetching failures: ListTagsForResource, ListTags, DescribeTags calls on individual resources 
Category 2 — Describe/Get enrichment failures: DescribeCertificate, DescribeCluster, GetAdapter and similar per-resource detail calls
Category 3 — Nested listing failures: Sub-resource listing per parent such as ListNodegroups per cluster, ListAccessKeys per user, ListTargetsByRule per event bus 