### PR TITLE
fix(ec2-network-interface): use libnuke unique key to ensure removal

### DIFF
--- a/resources/ec2-network-interface.go
+++ b/resources/ec2-network-interface.go
@@ -84,7 +84,7 @@ type EC2NetworkInterface struct {
 	svc       *ec2.EC2
 	accountID *string
 
-	ID               *string
+	ID               *string `libnuke:"uniqueKey"`
 	VPC              *string
 	AttachmentID     *string
 	AvailabilityZone *string


### PR DESCRIPTION
Fixes #575
