### PR TITLE
feat(cloudformation): Add UseCurrentRoleToDeleteStack setting

### DIFF
--- a/docs/resources/cloud-formation-stack.md
+++ b/docs/resources/cloud-formation-stack.md
@@ -37,26 +37,59 @@ The string value is always what is used in the output of the log format when a r
 
 - `DisableDeletionProtection`
 - `CreateRoleToDeleteStack`
+- `UseCurrentRoleToDeleteStack`
 
 
 ### DisableDeletionProtection
 
-!!! note
-    There is currently no description for this setting. Often times settings are fairly self-explanatory. However, we
-    are working on adding descriptions for all settings.
+When enabled, aws-nuke will automatically disable termination protection on a CloudFormation stack before
+attempting to delete it. Without this setting, stacks with termination protection enabled will fail to delete.
 
-```text
-DisableDeletionProtection
+```yaml
+CloudFormationStack:
+  DisableDeletionProtection: "true"
 ```
 
 
 ### CreateRoleToDeleteStack
 
-!!! note
-    There is currently no description for this setting. Often times settings are fairly self-explanatory. However, we
-    are working on adding descriptions for all settings.
+When enabled, aws-nuke will create a temporary IAM role to delete a stack whose original execution role no longer
+exists or cannot be assumed. The temporary role is tagged with `Managed: aws-nuke` and is cleaned up after deletion.
 
-```text
-CreateRoleToDeleteStack
+```yaml
+CloudFormationStack:
+  CreateRoleToDeleteStack: "true"
 ```
+
+
+### UseCurrentRoleToDeleteStack
+
+When enabled, aws-nuke overrides the stack's associated IAM role with the caller's current role during deletion.
+The caller's role ARN is resolved via STS `GetCallerIdentity` and passed as the `RoleARN` parameter on `DeleteStack`
+calls. This applies to both normal deletion and `DELETE_FAILED` retry paths.
+
+This is useful when SCPs deny actions from the stack's original creation role (e.g. CDK `cfn-exec-role`) during
+account cleanup.
+
+```yaml
+CloudFormationStack:
+  UseCurrentRoleToDeleteStack: "true"
+```
+
+!!! warning "Security Consideration"
+    Enabling this setting may broaden the permissions available during stack deletion. The role running aws-nuke
+    typically has broader permissions than the stack's original execution role. Be aware that stack deletion
+    operations (such as deleting resources within the stack) will execute with the caller's role permissions
+    rather than the more constrained original stack role.
+
+!!! note "Assumed Role Requirement"
+    This setting only takes effect when aws-nuke is authenticated via an IAM assumed role. If aws-nuke is running
+    as an IAM user or using any other authentication method that is not an assumed role, this setting is effectively
+    a no-op and stack deletion falls back to normal behavior (using the stack's original role or no role).
+
+!!! note "IAM Path Prefix Limitation"
+    If the assumed role has an IAM path prefix (e.g. `arn:aws:iam::123456789012:role/my-path/MyRole`), the STS
+    assumed-role ARN omits the path component. The reconstructed role ARN will not include the path, which may
+    result in an incorrect ARN. This is uncommon in typical CDK or CloudFormation use cases.
+
 

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/cloudformation" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
+	"github.com/aws/aws-sdk-go/service/sts" //nolint:staticcheck
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -40,6 +41,7 @@ func init() {
 		Settings: []string{
 			"DisableDeletionProtection",
 			"CreateRoleToDeleteStack",
+			"UseCurrentRoleToDeleteStack",
 		},
 	})
 }
@@ -51,6 +53,27 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 
 	svc := cloudformation.New(opts.Session)
 	iamSvc := iam.NewFromConfig(*opts.Config)
+	stsSvc := sts.New(opts.Session)
+
+	// Get the current caller's role ARN so we can use it to override stack roles during deletion
+	var callerRoleARN *string
+	identity, err := stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err == nil && identity.Arn != nil {
+		// Convert assumed-role ARN (arn:aws:sts::ACCT:assumed-role/ROLE/SESSION)
+		// to role ARN (arn:aws:iam::ACCT:role/ROLE)
+		arnStr := *identity.Arn
+		if strings.Contains(arnStr, ":assumed-role/") {
+			parts := strings.Split(arnStr, ":")
+			if len(parts) >= 6 {
+				accountID := parts[4]
+				rolePart := strings.Split(parts[5], "/")
+				if len(rolePart) >= 2 {
+					roleARN := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, rolePart[1])
+					callerRoleARN = &roleARN
+				}
+			}
+		}
+	}
 
 	params := &cloudformation.DescribeStacksInput{}
 	resources := make([]resource.Resource, 0)
@@ -71,6 +94,7 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 				description:       stack.Description,
 				parentID:          stack.ParentId,
 				roleARN:           stack.RoleARN,
+				callerRoleARN:     callerRoleARN,
 				CreationTime:      stack.CreationTime,
 				LastUpdatedTime:   stack.LastUpdatedTime,
 				Tags:              stack.Tags,
@@ -106,6 +130,7 @@ type CloudFormationStack struct {
 	description       *string
 	parentID          *string
 	roleARN           *string
+	callerRoleARN     *string
 	maxDeleteAttempts int
 	roleCreated       bool
 	roleName          string
@@ -150,10 +175,14 @@ func (r *CloudFormationStack) createRole(ctx context.Context) error {
 		},
 	})
 
+	if err != nil {
+		return err
+	}
+
 	r.roleCreated = true
 	r.roleName = roleParts[len(roleParts)-1]
 
-	return err
+	return nil
 }
 
 func (r *CloudFormationStack) removeRole(ctx context.Context) error {
@@ -288,10 +317,19 @@ func (r *CloudFormationStack) doRemove() error { //nolint:gocyclo
 			}
 		}
 
-		if _, err = r.svc.DeleteStack(&cloudformation.DeleteStackInput{
+		deleteInput := &cloudformation.DeleteStackInput{
 			StackName:       r.Name,
 			RetainResources: retain,
-		}); err != nil {
+		}
+		if r.settings.GetBool("UseCurrentRoleToDeleteStack") {
+			if r.callerRoleARN != nil {
+				deleteInput.RoleARN = r.callerRoleARN
+			} else {
+				r.logger.Warnf("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack is enabled but callerRoleARN is nil, falling back to default role behavior", *r.Name)
+			}
+		}
+
+		if _, err = r.svc.DeleteStack(deleteInput); err != nil {
 			return err
 		}
 
@@ -301,9 +339,20 @@ func (r *CloudFormationStack) doRemove() error { //nolint:gocyclo
 	} else {
 		if err := r.waitForStackToStabilize(*stack.StackStatus); err != nil {
 			return err
-		} else if _, err := r.svc.DeleteStack(&cloudformation.DeleteStackInput{
+		}
+
+		deleteInput := &cloudformation.DeleteStackInput{
 			StackName: r.Name,
-		}); err != nil {
+		}
+		if r.settings.GetBool("UseCurrentRoleToDeleteStack") {
+			if r.callerRoleARN != nil {
+				deleteInput.RoleARN = r.callerRoleARN
+			} else {
+				r.logger.Warnf("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack is enabled but callerRoleARN is nil, falling back to default role behavior", *r.Name)
+			}
+		}
+
+		if _, err := r.svc.DeleteStack(deleteInput); err != nil {
 			return err
 		} else if err := r.svc.WaitUntilStackDeleteComplete(&cloudformation.DescribeStacksInput{
 			StackName: r.Name,

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -10,12 +10,12 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/sirupsen/logrus"
 
-	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck
-	"github.com/aws/aws-sdk-go/aws/awserr"             //nolint:staticcheck
-	"github.com/aws/aws-sdk-go/service/cloudformation" //nolint:staticcheck
-	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
-	"github.com/aws/aws-sdk-go/service/sts"            //nolint:staticcheck
-	"github.com/aws/aws-sdk-go/service/sts/stsiface"   //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/aws"                                        //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/aws/awserr"                                 //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/service/cloudformation"                     //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface" //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/service/sts"                                //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"                       //nolint:staticcheck
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -106,24 +106,24 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 }
 
 type CloudFormationStack struct {
-	svc               cloudformationiface.CloudFormationAPI
-	stsSvc            stsiface.STSAPI
-	iamSvc            iamRoleAPI
-	settings          *settings.Setting
-	logger            *logrus.Entry
-	Name              *string
-	Status            *string
-	CreationTime      *time.Time
-	LastUpdatedTime   *time.Time
-	Tags              []*cloudformation.Tag
-	description       *string
-	parentID          *string
-	roleARN           *string
-	callerRoleARN     *string
+	svc                cloudformationiface.CloudFormationAPI
+	stsSvc             stsiface.STSAPI
+	iamSvc             iamRoleAPI
+	settings           *settings.Setting
+	logger             *logrus.Entry
+	Name               *string
+	Status             *string
+	CreationTime       *time.Time
+	LastUpdatedTime    *time.Time
+	Tags               []*cloudformation.Tag
+	description        *string
+	parentID           *string
+	roleARN            *string
+	callerRoleARN      *string
 	callerRoleResolved bool
-	maxDeleteAttempts int
-	roleCreated       bool
-	roleName          string
+	maxDeleteAttempts  int
+	roleCreated        bool
+	roleName           string
 }
 
 func (r *CloudFormationStack) Filter() error {
@@ -244,7 +244,8 @@ func (r *CloudFormationStack) applyRoleOverride(input *cloudformation.DeleteStac
 		r.logger.Infof("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack: overriding RoleARN with %s", *r.Name, *callerRole)
 		input.RoleARN = callerRole
 	} else {
-		r.logger.Warnf("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack is enabled but callerRoleARN could not be resolved, falling back to default role behavior", *r.Name)
+		r.logger.Warnf("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack enabled "+
+			"but callerRoleARN could not be resolved, falling back to default role behavior", *r.Name)
 	}
 }
 

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -14,7 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/cloudformation" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
-	"github.com/aws/aws-sdk-go/service/sts" //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/service/sts"            //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"   //nolint:staticcheck
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -46,6 +47,13 @@ func init() {
 	})
 }
 
+// iamRoleAPI is the subset of the IAM v2 client used by CloudFormationStack for role
+// create/delete operations. Defined as an interface to enable test mocking.
+type iamRoleAPI interface {
+	CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
+	DeleteRole(ctx context.Context, params *iam.DeleteRoleInput, optFns ...func(*iam.Options)) (*iam.DeleteRoleOutput, error)
+}
+
 type CloudFormationStackLister struct{}
 
 func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
@@ -54,26 +62,6 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 	svc := cloudformation.New(opts.Session)
 	iamSvc := iam.NewFromConfig(*opts.Config)
 	stsSvc := sts.New(opts.Session)
-
-	// Get the current caller's role ARN so we can use it to override stack roles during deletion
-	var callerRoleARN *string
-	identity, err := stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-	if err == nil && identity.Arn != nil {
-		// Convert assumed-role ARN (arn:aws:sts::ACCT:assumed-role/ROLE/SESSION)
-		// to role ARN (arn:aws:iam::ACCT:role/ROLE)
-		arnStr := *identity.Arn
-		if strings.Contains(arnStr, ":assumed-role/") {
-			parts := strings.Split(arnStr, ":")
-			if len(parts) >= 6 {
-				accountID := parts[4]
-				rolePart := strings.Split(parts[5], "/")
-				if len(rolePart) >= 2 {
-					roleARN := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, rolePart[1])
-					callerRoleARN = &roleARN
-				}
-			}
-		}
-	}
 
 	params := &cloudformation.DescribeStacksInput{}
 	resources := make([]resource.Resource, 0)
@@ -86,6 +74,7 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 		for _, stack := range resp.Stacks {
 			newResource := &CloudFormationStack{
 				svc:               svc,
+				stsSvc:            stsSvc,
 				iamSvc:            iamSvc,
 				logger:            opts.Logger,
 				maxDeleteAttempts: CloudformationMaxDeleteAttempt,
@@ -94,7 +83,6 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 				description:       stack.Description,
 				parentID:          stack.ParentId,
 				roleARN:           stack.RoleARN,
-				callerRoleARN:     callerRoleARN,
 				CreationTime:      stack.CreationTime,
 				LastUpdatedTime:   stack.LastUpdatedTime,
 				Tags:              stack.Tags,
@@ -119,7 +107,8 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 
 type CloudFormationStack struct {
 	svc               cloudformationiface.CloudFormationAPI
-	iamSvc            *iam.Client
+	stsSvc            stsiface.STSAPI
+	iamSvc            iamRoleAPI
 	settings          *settings.Setting
 	logger            *logrus.Entry
 	Name              *string
@@ -131,6 +120,7 @@ type CloudFormationStack struct {
 	parentID          *string
 	roleARN           *string
 	callerRoleARN     *string
+	callerRoleResolved bool
 	maxDeleteAttempts int
 	roleCreated       bool
 	roleName          string
@@ -194,6 +184,68 @@ func (r *CloudFormationStack) removeRole(ctx context.Context) error {
 		RoleName: ptr.String(r.roleName),
 	})
 	return err
+}
+
+// resolveCallerRoleARN lazily resolves the caller's IAM role ARN from STS on first call.
+// This is only invoked when UseCurrentRoleToDeleteStack is enabled, avoiding unnecessary
+// STS API calls for users who don't use this setting.
+// Note: IAM roles with path prefixes (e.g. /my-path/MyRole) cannot be fully reconstructed
+// from the STS assumed-role ARN because STS omits the path component.
+func (r *CloudFormationStack) resolveCallerRoleARN() *string {
+	if r.callerRoleResolved {
+		return r.callerRoleARN
+	}
+	r.callerRoleResolved = true
+
+	identity, err := r.stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		r.logger.Warnf("CloudFormationStack stackName=%s failed to resolve caller role ARN: %s", *r.Name, err.Error())
+		return nil
+	}
+	if identity.Arn == nil {
+		r.logger.Warnf("CloudFormationStack stackName=%s GetCallerIdentity returned nil ARN", *r.Name)
+		return nil
+	}
+
+	// Convert assumed-role ARN (arn:<partition>:sts::<ACCT>:assumed-role/ROLE/SESSION)
+	// to role ARN (arn:<partition>:iam::<ACCT>:role/ROLE)
+	arnStr := *identity.Arn
+	if !strings.Contains(arnStr, ":assumed-role/") {
+		r.logger.Warnf("CloudFormationStack stackName=%s caller ARN is not an assumed-role ARN (%s), cannot resolve role ARN", *r.Name, arnStr)
+		return nil
+	}
+
+	parts := strings.Split(arnStr, ":")
+	if len(parts) < 6 {
+		r.logger.Warnf("CloudFormationStack stackName=%s caller ARN has unexpected format (%s)", *r.Name, arnStr)
+		return nil
+	}
+
+	partition := parts[1]
+	accountID := parts[4]
+	rolePart := strings.Split(parts[5], "/")
+	if len(rolePart) < 2 {
+		r.logger.Warnf("CloudFormationStack stackName=%s caller ARN resource segment has unexpected format (%s)", *r.Name, parts[5])
+		return nil
+	}
+
+	roleARN := fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, accountID, rolePart[1])
+	r.callerRoleARN = &roleARN
+	return r.callerRoleARN
+}
+
+// applyRoleOverride sets the RoleARN on a DeleteStackInput if UseCurrentRoleToDeleteStack is enabled.
+func (r *CloudFormationStack) applyRoleOverride(input *cloudformation.DeleteStackInput) {
+	if !r.settings.GetBool("UseCurrentRoleToDeleteStack") {
+		return
+	}
+	callerRole := r.resolveCallerRoleARN()
+	if callerRole != nil {
+		r.logger.Infof("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack: overriding RoleARN with %s", *r.Name, *callerRole)
+		input.RoleARN = callerRole
+	} else {
+		r.logger.Warnf("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack is enabled but callerRoleARN could not be resolved, falling back to default role behavior", *r.Name)
+	}
 }
 
 func (r *CloudFormationStack) removeWithAttempts(ctx context.Context, attempt int) error {
@@ -299,7 +351,8 @@ func (r *CloudFormationStack) doRemove() error { //nolint:gocyclo
 			StackName: r.Name,
 		})
 	} else if *stack.StackStatus == cloudformation.StackStatusDeleteFailed {
-		r.logger.Infof("CloudFormationStack stackName=%s delete failed. Attempting to retain and delete stack", *r.Name)
+		r.logger.Infof("CloudFormationStack stackName=%s delete failed (reason=%s). Attempting to retain and delete stack",
+			*r.Name, ptr.ToString(stack.StackStatusReason))
 		// This means the CFS has undetectable resources.
 		// In order to move on with nuking, we retain them in the deletion.
 		retainableResources, err := r.svc.ListStackResources(&cloudformation.ListStackResourcesInput{
@@ -311,9 +364,12 @@ func (r *CloudFormationStack) doRemove() error { //nolint:gocyclo
 
 		retain := make([]*string, 0)
 
-		for _, r := range retainableResources.StackResourceSummaries {
-			if *r.ResourceStatus != cloudformation.ResourceStatusDeleteComplete {
-				retain = append(retain, r.LogicalResourceId)
+		for _, res := range retainableResources.StackResourceSummaries {
+			if *res.ResourceStatus != cloudformation.ResourceStatusDeleteComplete {
+				retain = append(retain, res.LogicalResourceId)
+				r.logger.Infof("CloudFormationStack stackName=%s retaining resource %s (type=%s, status=%s, reason=%s)",
+					*r.Name, ptr.ToString(res.LogicalResourceId), ptr.ToString(res.ResourceType),
+					ptr.ToString(res.ResourceStatus), ptr.ToString(res.ResourceStatusReason))
 			}
 		}
 
@@ -321,13 +377,7 @@ func (r *CloudFormationStack) doRemove() error { //nolint:gocyclo
 			StackName:       r.Name,
 			RetainResources: retain,
 		}
-		if r.settings.GetBool("UseCurrentRoleToDeleteStack") {
-			if r.callerRoleARN != nil {
-				deleteInput.RoleARN = r.callerRoleARN
-			} else {
-				r.logger.Warnf("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack is enabled but callerRoleARN is nil, falling back to default role behavior", *r.Name)
-			}
-		}
+		r.applyRoleOverride(deleteInput)
 
 		if _, err = r.svc.DeleteStack(deleteInput); err != nil {
 			return err
@@ -344,13 +394,7 @@ func (r *CloudFormationStack) doRemove() error { //nolint:gocyclo
 		deleteInput := &cloudformation.DeleteStackInput{
 			StackName: r.Name,
 		}
-		if r.settings.GetBool("UseCurrentRoleToDeleteStack") {
-			if r.callerRoleARN != nil {
-				deleteInput.RoleARN = r.callerRoleARN
-			} else {
-				r.logger.Warnf("CloudFormationStack stackName=%s UseCurrentRoleToDeleteStack is enabled but callerRoleARN is nil, falling back to default role behavior", *r.Name)
-			}
-		}
+		r.applyRoleOverride(deleteInput)
 
 		if _, err := r.svc.DeleteStack(deleteInput); err != nil {
 			return err

--- a/resources/cloudformation-stack_test.go
+++ b/resources/cloudformation-stack_test.go
@@ -410,3 +410,518 @@ func TestCloudformationStack_Remove_RoleARNIsNil(t *testing.T) {
 	err := stack.Remove(context.TODO())
 	a.Nil(err)
 }
+
+// ============================================================================
+// UseCurrentRoleToDeleteStack tests
+// ============================================================================
+
+// Test: Normal deletion path with UseCurrentRoleToDeleteStack enabled and callerRoleARN set.
+// Expects RoleARN to be set on DeleteStackInput.
+func TestCloudformationStack_Remove_UseCurrentRole_NormalDeletion(t *testing.T) {
+	tests := []string{
+		cloudformation.StackStatusCreateComplete,
+		cloudformation.StackStatusUpdateComplete,
+		cloudformation.StackStatusRollbackComplete,
+	}
+
+	for _, stackStatus := range tests {
+		t.Run(stackStatus, func(t *testing.T) {
+			a := assert.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+			callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+
+			stack := CloudFormationStack{
+				svc:    mockCf,
+				logger: logrus.NewEntry(logrus.StandardLogger()),
+				Name:   ptr.String("my-cdk-stack"),
+				roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
+				callerRoleARN: &callerRole,
+				settings: &libsettings.Setting{
+					"UseCurrentRoleToDeleteStack": true,
+				},
+			}
+
+			gomock.InOrder(
+				mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+					StackName: ptr.String("my-cdk-stack"),
+				})).Return(&cloudformation.DescribeStacksOutput{
+					Stacks: []*cloudformation.Stack{
+						{
+							StackStatus: ptr.String(stackStatus),
+						},
+					},
+				}, nil),
+				mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+					StackName: ptr.String("my-cdk-stack"),
+					RoleARN:   &callerRole,
+				})).Return(nil, nil),
+				mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+					StackName: ptr.String("my-cdk-stack"),
+				})).Return(nil),
+			)
+
+			err := stack.Remove(context.TODO())
+			a.Nil(err)
+		})
+	}
+}
+
+// Test: DELETE_FAILED path with UseCurrentRoleToDeleteStack enabled and callerRoleARN set.
+// Expects RoleARN to be set on DeleteStackInput alongside RetainResources.
+func TestCloudformationStack_Remove_UseCurrentRole_DeleteFailedPath(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-cdk-stack"),
+		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
+		callerRoleARN: &callerRole,
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusDeleteFailed),
+				},
+			},
+		}, nil),
+		mockCf.EXPECT().ListStackResources(gomock.Eq(&cloudformation.ListStackResourcesInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(&cloudformation.ListStackResourcesOutput{
+			StackResourceSummaries: []*cloudformation.StackResourceSummary{
+				{
+					ResourceStatus:    ptr.String(cloudformation.ResourceStatusDeleteComplete),
+					LogicalResourceId: ptr.String("CompletedResource"),
+				},
+				{
+					ResourceStatus:    ptr.String(cloudformation.ResourceStatusDeleteFailed),
+					LogicalResourceId: ptr.String("FailedResource"),
+				},
+			},
+		}, nil),
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-cdk-stack"),
+			RoleARN:   &callerRole,
+			RetainResources: []*string{
+				ptr.String("FailedResource"),
+			},
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: UseCurrentRoleToDeleteStack disabled (default). RoleARN must NOT be set on DeleteStackInput,
+// even when callerRoleARN is available. This is the backward-compatibility guarantee.
+func TestCloudformationStack_Remove_UseCurrentRole_Disabled_NormalDeletion(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-cdk-stack"),
+		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
+		callerRoleARN: &callerRole,
+		settings: &libsettings.Setting{
+			"DisableDeletionProtection": true,
+			// UseCurrentRoleToDeleteStack intentionally NOT set
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
+				},
+			},
+		}, nil),
+		// RoleARN must NOT be present — CloudFormation uses the stack's original role
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: UseCurrentRoleToDeleteStack disabled on DELETE_FAILED path. RoleARN must NOT be set.
+func TestCloudformationStack_Remove_UseCurrentRole_Disabled_DeleteFailedPath(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-cdk-stack"),
+		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
+		callerRoleARN: &callerRole,
+		settings: &libsettings.Setting{
+			"DisableDeletionProtection": true,
+			// UseCurrentRoleToDeleteStack intentionally NOT set
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusDeleteFailed),
+				},
+			},
+		}, nil),
+		mockCf.EXPECT().ListStackResources(gomock.Eq(&cloudformation.ListStackResourcesInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(&cloudformation.ListStackResourcesOutput{
+			StackResourceSummaries: []*cloudformation.StackResourceSummary{
+				{
+					ResourceStatus:    ptr.String(cloudformation.ResourceStatusDeleteFailed),
+					LogicalResourceId: ptr.String("FailedResource"),
+				},
+			},
+		}, nil),
+		// RoleARN must NOT be present
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-cdk-stack"),
+			RetainResources: []*string{
+				ptr.String("FailedResource"),
+			},
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: UseCurrentRoleToDeleteStack enabled but callerRoleARN is nil.
+// Should NOT set RoleARN (graceful fallback) and not panic.
+func TestCloudformationStack_Remove_UseCurrentRole_CallerRoleNil(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-cdk-stack"),
+		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
+		callerRoleARN: nil, // nil — e.g. non-assumed-role caller
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
+				},
+			},
+		}, nil),
+		// RoleARN must NOT be present since callerRoleARN is nil
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: UseCurrentRoleToDeleteStack enabled, callerRoleARN nil, DELETE_FAILED path.
+func TestCloudformationStack_Remove_UseCurrentRole_CallerRoleNil_DeleteFailedPath(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-cdk-stack"),
+		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
+		callerRoleARN: nil,
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusDeleteFailed),
+				},
+			},
+		}, nil),
+		mockCf.EXPECT().ListStackResources(gomock.Eq(&cloudformation.ListStackResourcesInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(&cloudformation.ListStackResourcesOutput{
+			StackResourceSummaries: []*cloudformation.StackResourceSummary{
+				{
+					ResourceStatus:    ptr.String(cloudformation.ResourceStatusDeleteFailed),
+					LogicalResourceId: ptr.String("FailedResource"),
+				},
+			},
+		}, nil),
+		// RoleARN must NOT be present since callerRoleARN is nil
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-cdk-stack"),
+			RetainResources: []*string{
+				ptr.String("FailedResource"),
+			},
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-cdk-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: Stack with NO roleARN (nil) and UseCurrentRoleToDeleteStack enabled.
+// Should still use callerRoleARN since the setting is about overriding the deletion role.
+func TestCloudformationStack_Remove_UseCurrentRole_StackHasNoRole(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("no-role-stack"),
+		roleARN:       nil, // stack was created without a role
+		callerRoleARN: &callerRole,
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("no-role-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
+				},
+			},
+		}, nil),
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("no-role-stack"),
+			RoleARN:   &callerRole,
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("no-role-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: UseCurrentRoleToDeleteStack explicitly set to false. Must NOT set RoleARN.
+func TestCloudformationStack_Remove_UseCurrentRole_ExplicitlyFalse(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-stack"),
+		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-exec-role"),
+		callerRoleARN: &callerRole,
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": false,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
+				},
+			},
+		}, nil),
+		// RoleARN must NOT be present
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-stack"),
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: Empty settings (no settings configured at all). Must NOT set RoleARN.
+// Simulates a user who hasn't configured any CloudFormationStack settings.
+func TestCloudformationStack_Remove_UseCurrentRole_EmptySettings(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-stack"),
+		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-exec-role"),
+		callerRoleARN: &callerRole,
+		settings:      &libsettings.Setting{},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
+				},
+			},
+		}, nil),
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-stack"),
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("my-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: UseCurrentRoleToDeleteStack with in-progress stacks that need to stabilize first.
+// Verifies the role override still applies after waiting for stabilization.
+func TestCloudformationStack_Remove_UseCurrentRole_UpdateInProgress(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("updating-stack"),
+		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-exec-role"),
+		callerRoleARN: &callerRole,
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("updating-stack"),
+		})).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{
+					StackStatus: ptr.String(cloudformation.StackStatusUpdateInProgress),
+				},
+			},
+		}, nil),
+		mockCf.EXPECT().WaitUntilStackUpdateComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("updating-stack"),
+		})).Return(nil),
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("updating-stack"),
+			RoleARN:   &callerRole,
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
+			StackName: ptr.String("updating-stack"),
+		})).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// ============================================================================
+// createRole bug fix test — roleCreated must not be set on error
+// ============================================================================
+
+func TestCloudformationStack_CreateRole_ErrorDoesNotSetRoleCreated(t *testing.T) {
+	a := assert.New(t)
+
+	// We can't easily mock the v2 IAM client with gomock, but we can verify
+	// the struct state by testing the removeRole guard. If createRole failed
+	// and roleCreated is false, removeRole should be a no-op.
+	stack := CloudFormationStack{
+		logger:      logrus.NewEntry(logrus.StandardLogger()),
+		roleCreated: false,
+	}
+
+	// removeRole should return nil when roleCreated is false
+	err := stack.removeRole(context.TODO())
+	a.Nil(err)
+	a.False(stack.roleCreated)
+}

--- a/resources/cloudformation-stack_test.go
+++ b/resources/cloudformation-stack_test.go
@@ -807,10 +807,10 @@ func TestCloudformationStack_Remove_UseCurrentRole_EmptySettings(t *testing.T) {
 	mockSts := mock_stsiface.NewMockSTSAPI(ctrl) // no expected calls
 
 	stack := CloudFormationStack{
-		svc:    mockCf,
-		stsSvc: mockSts,
-		logger: logrus.NewEntry(logrus.StandardLogger()),
-		Name:   ptr.String("my-stack"),
+		svc:      mockCf,
+		stsSvc:   mockSts,
+		logger:   logrus.NewEntry(logrus.StandardLogger()),
+		Name:     ptr.String("my-stack"),
 		settings: &libsettings.Setting{},
 	}
 

--- a/resources/cloudformation-stack_test.go
+++ b/resources/cloudformation-stack_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,10 +13,14 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"             //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/cloudformation" //nolint:staticcheck
+	"github.com/aws/aws-sdk-go/service/sts"            //nolint:staticcheck
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 
 	libsettings "github.com/ekristen/libnuke/pkg/settings"
 
 	"github.com/ekristen/aws-nuke/v3/mocks/mock_cloudformationiface"
+	"github.com/ekristen/aws-nuke/v3/mocks/mock_stsiface"
 )
 
 func TestCloudformationStack_Properties(t *testing.T) {
@@ -415,8 +420,17 @@ func TestCloudformationStack_Remove_RoleARNIsNil(t *testing.T) {
 // UseCurrentRoleToDeleteStack tests
 // ============================================================================
 
-// Test: Normal deletion path with UseCurrentRoleToDeleteStack enabled and callerRoleARN set.
-// Expects RoleARN to be set on DeleteStackInput.
+// helper to create a mock STS that returns a given assumed-role ARN
+func mockSTSWithAssumedRole(ctrl *gomock.Controller, arn string) *mock_stsiface.MockSTSAPI {
+	mockSts := mock_stsiface.NewMockSTSAPI(ctrl)
+	mockSts.EXPECT().GetCallerIdentity(gomock.Any()).Return(&sts.GetCallerIdentityOutput{
+		Arn: ptr.String(arn),
+	}, nil).AnyTimes()
+	return mockSts
+}
+
+// Test: Normal deletion with UseCurrentRoleToDeleteStack enabled.
+// STS is called lazily, role ARN is resolved and passed to DeleteStack.
 func TestCloudformationStack_Remove_UseCurrentRole_NormalDeletion(t *testing.T) {
 	tests := []string{
 		cloudformation.StackStatusCreateComplete,
@@ -431,14 +445,14 @@ func TestCloudformationStack_Remove_UseCurrentRole_NormalDeletion(t *testing.T) 
 			defer ctrl.Finish()
 
 			mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-			callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+			mockSts := mockSTSWithAssumedRole(ctrl, "arn:aws:sts::123456789012:assumed-role/MyCleanupRole/session")
+			expectedRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
 
 			stack := CloudFormationStack{
 				svc:    mockCf,
+				stsSvc: mockSts,
 				logger: logrus.NewEntry(logrus.StandardLogger()),
 				Name:   ptr.String("my-cdk-stack"),
-				roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
-				callerRoleARN: &callerRole,
 				settings: &libsettings.Setting{
 					"UseCurrentRoleToDeleteStack": true,
 				},
@@ -449,18 +463,14 @@ func TestCloudformationStack_Remove_UseCurrentRole_NormalDeletion(t *testing.T) 
 					StackName: ptr.String("my-cdk-stack"),
 				})).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
-						{
-							StackStatus: ptr.String(stackStatus),
-						},
+						{StackStatus: ptr.String(stackStatus)},
 					},
 				}, nil),
 				mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
 					StackName: ptr.String("my-cdk-stack"),
-					RoleARN:   &callerRole,
+					RoleARN:   &expectedRole,
 				})).Return(nil, nil),
-				mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-					StackName: ptr.String("my-cdk-stack"),
-				})).Return(nil),
+				mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
 			)
 
 			err := stack.Remove(context.TODO())
@@ -469,436 +479,389 @@ func TestCloudformationStack_Remove_UseCurrentRole_NormalDeletion(t *testing.T) 
 	}
 }
 
-// Test: DELETE_FAILED path with UseCurrentRoleToDeleteStack enabled and callerRoleARN set.
-// Expects RoleARN to be set on DeleteStackInput alongside RetainResources.
+// Test: DELETE_FAILED path with UseCurrentRoleToDeleteStack enabled.
 func TestCloudformationStack_Remove_UseCurrentRole_DeleteFailedPath(t *testing.T) {
 	a := assert.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+	mockSts := mockSTSWithAssumedRole(ctrl, "arn:aws:sts::123456789012:assumed-role/MyCleanupRole/session")
+	expectedRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
 
 	stack := CloudFormationStack{
 		svc:    mockCf,
+		stsSvc: mockSts,
 		logger: logrus.NewEntry(logrus.StandardLogger()),
 		Name:   ptr.String("my-cdk-stack"),
-		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
-		callerRoleARN: &callerRole,
 		settings: &libsettings.Setting{
 			"UseCurrentRoleToDeleteStack": true,
 		},
 	}
 
 	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusDeleteFailed),
-				},
+				{StackStatus: ptr.String(cloudformation.StackStatusDeleteFailed)},
 			},
 		}, nil),
-		mockCf.EXPECT().ListStackResources(gomock.Eq(&cloudformation.ListStackResourcesInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(&cloudformation.ListStackResourcesOutput{
+		mockCf.EXPECT().ListStackResources(gomock.Any()).Return(&cloudformation.ListStackResourcesOutput{
 			StackResourceSummaries: []*cloudformation.StackResourceSummary{
-				{
-					ResourceStatus:    ptr.String(cloudformation.ResourceStatusDeleteComplete),
-					LogicalResourceId: ptr.String("CompletedResource"),
-				},
-				{
-					ResourceStatus:    ptr.String(cloudformation.ResourceStatusDeleteFailed),
-					LogicalResourceId: ptr.String("FailedResource"),
-				},
+				{ResourceStatus: ptr.String(cloudformation.ResourceStatusDeleteFailed), LogicalResourceId: ptr.String("FailedResource")},
 			},
 		}, nil),
 		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
-			StackName: ptr.String("my-cdk-stack"),
-			RoleARN:   &callerRole,
-			RetainResources: []*string{
-				ptr.String("FailedResource"),
-			},
+			StackName:       ptr.String("my-cdk-stack"),
+			RoleARN:         &expectedRole,
+			RetainResources: []*string{ptr.String("FailedResource")},
 		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
 	)
 
 	err := stack.Remove(context.TODO())
 	a.Nil(err)
 }
 
-// Test: UseCurrentRoleToDeleteStack disabled (default). RoleARN must NOT be set on DeleteStackInput,
-// even when callerRoleARN is available. This is the backward-compatibility guarantee.
-func TestCloudformationStack_Remove_UseCurrentRole_Disabled_NormalDeletion(t *testing.T) {
+// Test: UseCurrentRoleToDeleteStack disabled — STS must NOT be called, RoleARN must NOT be set.
+func TestCloudformationStack_Remove_UseCurrentRole_Disabled(t *testing.T) {
 	a := assert.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+	// STS mock with zero expected calls — verifies STS is never called when setting is disabled
+	mockSts := mock_stsiface.NewMockSTSAPI(ctrl)
 
 	stack := CloudFormationStack{
 		svc:    mockCf,
+		stsSvc: mockSts,
 		logger: logrus.NewEntry(logrus.StandardLogger()),
-		Name:   ptr.String("my-cdk-stack"),
-		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
-		callerRoleARN: &callerRole,
+		Name:   ptr.String("my-stack"),
 		settings: &libsettings.Setting{
 			"DisableDeletionProtection": true,
-			// UseCurrentRoleToDeleteStack intentionally NOT set
 		},
 	}
 
 	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
-				},
+				{StackStatus: ptr.String(cloudformation.StackStatusCreateComplete)},
 			},
 		}, nil),
-		// RoleARN must NOT be present — CloudFormation uses the stack's original role
 		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
-			StackName: ptr.String("my-cdk-stack"),
+			StackName: ptr.String("my-stack"),
 		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
 	)
 
 	err := stack.Remove(context.TODO())
 	a.Nil(err)
 }
 
-// Test: UseCurrentRoleToDeleteStack disabled on DELETE_FAILED path. RoleARN must NOT be set.
+// Test: UseCurrentRoleToDeleteStack disabled on DELETE_FAILED path.
 func TestCloudformationStack_Remove_UseCurrentRole_Disabled_DeleteFailedPath(t *testing.T) {
 	a := assert.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+	mockSts := mock_stsiface.NewMockSTSAPI(ctrl) // no expected calls
 
 	stack := CloudFormationStack{
 		svc:    mockCf,
-		logger: logrus.NewEntry(logrus.StandardLogger()),
-		Name:   ptr.String("my-cdk-stack"),
-		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
-		callerRoleARN: &callerRole,
-		settings: &libsettings.Setting{
-			"DisableDeletionProtection": true,
-			// UseCurrentRoleToDeleteStack intentionally NOT set
-		},
-	}
-
-	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
-			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusDeleteFailed),
-				},
-			},
-		}, nil),
-		mockCf.EXPECT().ListStackResources(gomock.Eq(&cloudformation.ListStackResourcesInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(&cloudformation.ListStackResourcesOutput{
-			StackResourceSummaries: []*cloudformation.StackResourceSummary{
-				{
-					ResourceStatus:    ptr.String(cloudformation.ResourceStatusDeleteFailed),
-					LogicalResourceId: ptr.String("FailedResource"),
-				},
-			},
-		}, nil),
-		// RoleARN must NOT be present
-		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
-			StackName: ptr.String("my-cdk-stack"),
-			RetainResources: []*string{
-				ptr.String("FailedResource"),
-			},
-		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(nil),
-	)
-
-	err := stack.Remove(context.TODO())
-	a.Nil(err)
-}
-
-// Test: UseCurrentRoleToDeleteStack enabled but callerRoleARN is nil.
-// Should NOT set RoleARN (graceful fallback) and not panic.
-func TestCloudformationStack_Remove_UseCurrentRole_CallerRoleNil(t *testing.T) {
-	a := assert.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-
-	stack := CloudFormationStack{
-		svc:    mockCf,
-		logger: logrus.NewEntry(logrus.StandardLogger()),
-		Name:   ptr.String("my-cdk-stack"),
-		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
-		callerRoleARN: nil, // nil — e.g. non-assumed-role caller
-		settings: &libsettings.Setting{
-			"UseCurrentRoleToDeleteStack": true,
-		},
-	}
-
-	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
-			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
-				},
-			},
-		}, nil),
-		// RoleARN must NOT be present since callerRoleARN is nil
-		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(nil),
-	)
-
-	err := stack.Remove(context.TODO())
-	a.Nil(err)
-}
-
-// Test: UseCurrentRoleToDeleteStack enabled, callerRoleARN nil, DELETE_FAILED path.
-func TestCloudformationStack_Remove_UseCurrentRole_CallerRoleNil_DeleteFailedPath(t *testing.T) {
-	a := assert.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-
-	stack := CloudFormationStack{
-		svc:    mockCf,
-		logger: logrus.NewEntry(logrus.StandardLogger()),
-		Name:   ptr.String("my-cdk-stack"),
-		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role"),
-		callerRoleARN: nil,
-		settings: &libsettings.Setting{
-			"UseCurrentRoleToDeleteStack": true,
-		},
-	}
-
-	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
-			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusDeleteFailed),
-				},
-			},
-		}, nil),
-		mockCf.EXPECT().ListStackResources(gomock.Eq(&cloudformation.ListStackResourcesInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(&cloudformation.ListStackResourcesOutput{
-			StackResourceSummaries: []*cloudformation.StackResourceSummary{
-				{
-					ResourceStatus:    ptr.String(cloudformation.ResourceStatusDeleteFailed),
-					LogicalResourceId: ptr.String("FailedResource"),
-				},
-			},
-		}, nil),
-		// RoleARN must NOT be present since callerRoleARN is nil
-		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
-			StackName: ptr.String("my-cdk-stack"),
-			RetainResources: []*string{
-				ptr.String("FailedResource"),
-			},
-		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-cdk-stack"),
-		})).Return(nil),
-	)
-
-	err := stack.Remove(context.TODO())
-	a.Nil(err)
-}
-
-// Test: Stack with NO roleARN (nil) and UseCurrentRoleToDeleteStack enabled.
-// Should still use callerRoleARN since the setting is about overriding the deletion role.
-func TestCloudformationStack_Remove_UseCurrentRole_StackHasNoRole(t *testing.T) {
-	a := assert.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
-
-	stack := CloudFormationStack{
-		svc:    mockCf,
-		logger: logrus.NewEntry(logrus.StandardLogger()),
-		Name:   ptr.String("no-role-stack"),
-		roleARN:       nil, // stack was created without a role
-		callerRoleARN: &callerRole,
-		settings: &libsettings.Setting{
-			"UseCurrentRoleToDeleteStack": true,
-		},
-	}
-
-	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("no-role-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
-			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
-				},
-			},
-		}, nil),
-		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
-			StackName: ptr.String("no-role-stack"),
-			RoleARN:   &callerRole,
-		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("no-role-stack"),
-		})).Return(nil),
-	)
-
-	err := stack.Remove(context.TODO())
-	a.Nil(err)
-}
-
-// Test: UseCurrentRoleToDeleteStack explicitly set to false. Must NOT set RoleARN.
-func TestCloudformationStack_Remove_UseCurrentRole_ExplicitlyFalse(t *testing.T) {
-	a := assert.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
-
-	stack := CloudFormationStack{
-		svc:    mockCf,
+		stsSvc: mockSts,
 		logger: logrus.NewEntry(logrus.StandardLogger()),
 		Name:   ptr.String("my-stack"),
-		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-exec-role"),
-		callerRoleARN: &callerRole,
 		settings: &libsettings.Setting{
-			"UseCurrentRoleToDeleteStack": false,
+			"DisableDeletionProtection": true,
 		},
 	}
 
 	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
-				},
+				{StackStatus: ptr.String(cloudformation.StackStatusDeleteFailed)},
 			},
 		}, nil),
-		// RoleARN must NOT be present
+		mockCf.EXPECT().ListStackResources(gomock.Any()).Return(&cloudformation.ListStackResourcesOutput{
+			StackResourceSummaries: []*cloudformation.StackResourceSummary{
+				{ResourceStatus: ptr.String(cloudformation.ResourceStatusDeleteFailed), LogicalResourceId: ptr.String("Res")},
+			},
+		}, nil),
 		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
-			StackName: ptr.String("my-stack"),
+			StackName:       ptr.String("my-stack"),
+			RetainResources: []*string{ptr.String("Res")},
 		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-stack"),
-		})).Return(nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
 	)
 
 	err := stack.Remove(context.TODO())
 	a.Nil(err)
 }
 
-// Test: Empty settings (no settings configured at all). Must NOT set RoleARN.
-// Simulates a user who hasn't configured any CloudFormationStack settings.
+// Test: STS GetCallerIdentity fails — should log warning and fall back to default behavior.
+func TestCloudformationStack_Remove_UseCurrentRole_STSError(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	mockSts := mock_stsiface.NewMockSTSAPI(ctrl)
+	mockSts.EXPECT().GetCallerIdentity(gomock.Any()).Return(nil, fmt.Errorf("access denied")).AnyTimes()
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		stsSvc: mockSts,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-stack"),
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{StackStatus: ptr.String(cloudformation.StackStatusCreateComplete)},
+			},
+		}, nil),
+		// RoleARN must NOT be set since STS failed
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-stack"),
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: Caller is not using an assumed role (e.g. IAM user) — should log warning and fall back.
+func TestCloudformationStack_Remove_UseCurrentRole_NotAssumedRole(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	mockSts := mock_stsiface.NewMockSTSAPI(ctrl)
+	mockSts.EXPECT().GetCallerIdentity(gomock.Any()).Return(&sts.GetCallerIdentityOutput{
+		Arn: ptr.String("arn:aws:iam::123456789012:user/MyUser"),
+	}, nil).AnyTimes()
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		stsSvc: mockSts,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("my-stack"),
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{StackStatus: ptr.String(cloudformation.StackStatusCreateComplete)},
+			},
+		}, nil),
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("my-stack"),
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: GovCloud partition — ARN reconstruction must use aws-us-gov, not aws.
+func TestCloudformationStack_Remove_UseCurrentRole_GovCloudPartition(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	mockSts := mockSTSWithAssumedRole(ctrl, "arn:aws-us-gov:sts::123456789012:assumed-role/GovRole/session")
+	expectedRole := "arn:aws-us-gov:iam::123456789012:role/GovRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		stsSvc: mockSts,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("gov-stack"),
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{StackStatus: ptr.String(cloudformation.StackStatusCreateComplete)},
+			},
+		}, nil),
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("gov-stack"),
+			RoleARN:   &expectedRole,
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: China partition — ARN reconstruction must use aws-cn.
+func TestCloudformationStack_Remove_UseCurrentRole_ChinaPartition(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	mockSts := mockSTSWithAssumedRole(ctrl, "arn:aws-cn:sts::123456789012:assumed-role/ChinaRole/session")
+	expectedRole := "arn:aws-cn:iam::123456789012:role/ChinaRole"
+
+	stack := CloudFormationStack{
+		svc:    mockCf,
+		stsSvc: mockSts,
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Name:   ptr.String("cn-stack"),
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	gomock.InOrder(
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
+			Stacks: []*cloudformation.Stack{
+				{StackStatus: ptr.String(cloudformation.StackStatusCreateComplete)},
+			},
+		}, nil),
+		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+			StackName: ptr.String("cn-stack"),
+			RoleARN:   &expectedRole,
+		})).Return(nil, nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
+	)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: STS is only called once even across multiple deletion attempts (lazy + cached).
+func TestCloudformationStack_Remove_UseCurrentRole_STSCalledOnce(t *testing.T) {
+	a := assert.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
+	mockSts := mock_stsiface.NewMockSTSAPI(ctrl)
+	// Expect exactly 1 STS call even though doRemove is called twice (retry)
+	mockSts.EXPECT().GetCallerIdentity(gomock.Any()).Return(&sts.GetCallerIdentityOutput{
+		Arn: ptr.String("arn:aws:sts::123456789012:assumed-role/MyRole/session"),
+	}, nil).Times(1)
+
+	expectedRole := "arn:aws:iam::123456789012:role/MyRole"
+
+	stack := CloudFormationStack{
+		svc:               mockCf,
+		stsSvc:            mockSts,
+		logger:            logrus.NewEntry(logrus.StandardLogger()),
+		Name:              ptr.String("retry-stack"),
+		maxDeleteAttempts: 3,
+		settings: &libsettings.Setting{
+			"UseCurrentRoleToDeleteStack": true,
+		},
+	}
+
+	// First attempt: DeleteStack fails
+	mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
+		Stacks: []*cloudformation.Stack{
+			{StackStatus: ptr.String(cloudformation.StackStatusCreateComplete)},
+		},
+	}, nil).Times(2)
+
+	firstCall := mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+		StackName: ptr.String("retry-stack"),
+		RoleARN:   &expectedRole,
+	})).Return(nil, awserr.New("InternalError", "transient failure", nil))
+
+	mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
+		StackName: ptr.String("retry-stack"),
+		RoleARN:   &expectedRole,
+	})).After(firstCall).Return(nil, nil)
+
+	mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil)
+
+	err := stack.Remove(context.TODO())
+	a.Nil(err)
+}
+
+// Test: Empty settings — STS must NOT be called.
 func TestCloudformationStack_Remove_UseCurrentRole_EmptySettings(t *testing.T) {
 	a := assert.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+	mockSts := mock_stsiface.NewMockSTSAPI(ctrl) // no expected calls
 
 	stack := CloudFormationStack{
 		svc:    mockCf,
+		stsSvc: mockSts,
 		logger: logrus.NewEntry(logrus.StandardLogger()),
 		Name:   ptr.String("my-stack"),
-		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-exec-role"),
-		callerRoleARN: &callerRole,
-		settings:      &libsettings.Setting{},
+		settings: &libsettings.Setting{},
 	}
 
 	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusCreateComplete),
-				},
+				{StackStatus: ptr.String(cloudformation.StackStatusCreateComplete)},
 			},
 		}, nil),
 		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
 			StackName: ptr.String("my-stack"),
 		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("my-stack"),
-		})).Return(nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
 	)
 
 	err := stack.Remove(context.TODO())
 	a.Nil(err)
 }
 
-// Test: UseCurrentRoleToDeleteStack with in-progress stacks that need to stabilize first.
-// Verifies the role override still applies after waiting for stabilization.
+// Test: UseCurrentRoleToDeleteStack with in-progress stack that needs stabilization.
 func TestCloudformationStack_Remove_UseCurrentRole_UpdateInProgress(t *testing.T) {
 	a := assert.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockCf := mock_cloudformationiface.NewMockCloudFormationAPI(ctrl)
-	callerRole := "arn:aws:iam::123456789012:role/MyCleanupRole"
+	mockSts := mockSTSWithAssumedRole(ctrl, "arn:aws:sts::123456789012:assumed-role/MyRole/session")
+	expectedRole := "arn:aws:iam::123456789012:role/MyRole"
 
 	stack := CloudFormationStack{
 		svc:    mockCf,
+		stsSvc: mockSts,
 		logger: logrus.NewEntry(logrus.StandardLogger()),
 		Name:   ptr.String("updating-stack"),
-		roleARN:       ptr.String("arn:aws:iam::123456789012:role/cdk-exec-role"),
-		callerRoleARN: &callerRole,
 		settings: &libsettings.Setting{
 			"UseCurrentRoleToDeleteStack": true,
 		},
 	}
 
 	gomock.InOrder(
-		mockCf.EXPECT().DescribeStacks(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("updating-stack"),
-		})).Return(&cloudformation.DescribeStacksOutput{
+		mockCf.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 			Stacks: []*cloudformation.Stack{
-				{
-					StackStatus: ptr.String(cloudformation.StackStatusUpdateInProgress),
-				},
+				{StackStatus: ptr.String(cloudformation.StackStatusUpdateInProgress)},
 			},
 		}, nil),
-		mockCf.EXPECT().WaitUntilStackUpdateComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("updating-stack"),
-		})).Return(nil),
+		mockCf.EXPECT().WaitUntilStackUpdateComplete(gomock.Any()).Return(nil),
 		mockCf.EXPECT().DeleteStack(gomock.Eq(&cloudformation.DeleteStackInput{
 			StackName: ptr.String("updating-stack"),
-			RoleARN:   &callerRole,
+			RoleARN:   &expectedRole,
 		})).Return(nil, nil),
-		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Eq(&cloudformation.DescribeStacksInput{
-			StackName: ptr.String("updating-stack"),
-		})).Return(nil),
+		mockCf.EXPECT().WaitUntilStackDeleteComplete(gomock.Any()).Return(nil),
 	)
 
 	err := stack.Remove(context.TODO())
@@ -906,22 +869,56 @@ func TestCloudformationStack_Remove_UseCurrentRole_UpdateInProgress(t *testing.T
 }
 
 // ============================================================================
-// createRole bug fix test — roleCreated must not be set on error
+// createRole bug fix test
 // ============================================================================
 
+// fakeIAMRoleAPI is a minimal test double for the iamRoleAPI interface.
+type fakeIAMRoleAPI struct {
+	createRoleErr error
+	deleteRoleErr error
+}
+
+func (f *fakeIAMRoleAPI) CreateRole(_ context.Context, _ *iam.CreateRoleInput, _ ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+	return nil, f.createRoleErr
+}
+
+func (f *fakeIAMRoleAPI) DeleteRole(_ context.Context, _ *iam.DeleteRoleInput, _ ...func(*iam.Options)) (*iam.DeleteRoleOutput, error) {
+	return nil, f.deleteRoleErr
+}
+
+// Test: When CreateRole fails, roleCreated must remain false so removeRole is a no-op.
 func TestCloudformationStack_CreateRole_ErrorDoesNotSetRoleCreated(t *testing.T) {
 	a := assert.New(t)
 
-	// We can't easily mock the v2 IAM client with gomock, but we can verify
-	// the struct state by testing the removeRole guard. If createRole failed
-	// and roleCreated is false, removeRole should be a no-op.
 	stack := CloudFormationStack{
-		logger:      logrus.NewEntry(logrus.StandardLogger()),
-		roleCreated: false,
+		logger:  logrus.NewEntry(logrus.StandardLogger()),
+		roleARN: ptr.String("arn:aws:iam::123456789012:role/SomeRole"),
+		iamSvc:  &fakeIAMRoleAPI{createRoleErr: fmt.Errorf("AccessDenied: not authorized")},
 	}
 
-	// removeRole should return nil when roleCreated is false
-	err := stack.removeRole(context.TODO())
+	err := stack.createRole(context.TODO())
+	a.NotNil(err)
+	a.Contains(err.Error(), "AccessDenied")
+	a.False(stack.roleCreated, "roleCreated must stay false when CreateRole fails")
+	a.Empty(stack.roleName, "roleName must stay empty when CreateRole fails")
+
+	// Confirm removeRole is a safe no-op after a failed createRole
+	err = stack.removeRole(context.TODO())
 	a.Nil(err)
-	a.False(stack.roleCreated)
+}
+
+// Test: When CreateRole succeeds, roleCreated is set and roleName is populated.
+func TestCloudformationStack_CreateRole_SuccessSetsRoleCreated(t *testing.T) {
+	a := assert.New(t)
+
+	stack := CloudFormationStack{
+		logger:  logrus.NewEntry(logrus.StandardLogger()),
+		roleARN: ptr.String("arn:aws:iam::123456789012:role/SomeRole"),
+		iamSvc:  &fakeIAMRoleAPI{},
+	}
+
+	err := stack.createRole(context.TODO())
+	a.Nil(err)
+	a.True(stack.roleCreated, "roleCreated must be true after successful CreateRole")
+	a.Equal("SomeRole", stack.roleName)
 }


### PR DESCRIPTION
Add a new CloudFormationStack setting that overrides the stack's associated IAM role with the caller's current role during deletion. This resolves failures when SCPs deny actions from the stack's original creation role (e.g. CDK cfn-exec-role) during cleanup.

When enabled, the caller's role ARN is resolved via STS GetCallerIdentity and passed as the RoleARN parameter on DeleteStack calls. This applies to both normal deletion and DELETE_FAILED retry paths.

Also fixes a pre-existing bug where createRole set roleCreated=true before checking for errors, causing removeRole to attempt deletion of a role that was never created.

Changes:
- Register UseCurrentRoleToDeleteStack in CloudFormationStack settings
- Resolve caller role ARN from STS assumed-role ARN during List()
- Apply role override in both doRemove() deletion paths
- Add warning log when setting is enabled but callerRoleARN is nil
- Fix createRole to only set roleCreated on success
- Add 11 new tests covering all combinations of the feature