### PR TITLE
fix(lint): resolve golangci-lint v2.11.4 failures and pin version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,3 +20,5 @@ jobs:
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+        with:
+          version: v2.11.4

--- a/pkg/awsutil/session.go
+++ b/pkg/awsutil/session.go
@@ -44,7 +44,7 @@ type Credentials struct {
 
 	AccessKeyID     string
 	SecretAccessKey string
-	SessionToken    string //nolint:gosec // not a hardcoded credential
+	SessionToken    string
 	AssumeRoleArn   string
 	ExternalID      string
 	RoleSessionName string

--- a/tools/compare-resources/main.go
+++ b/tools/compare-resources/main.go
@@ -36,7 +36,6 @@ func main() { //nolint:funlen,gocyclo
 	var upstreamResourceTypes []string
 	var upstreamTypeToFile = map[string]string{}
 
-	//nolint:gosec // path from CLI args
 	err := filepath.WalkDir(upstreamDirectory, func(path string, di fs.DirEntry, err error) error {
 		if !strings.HasSuffix(path, ".go") {
 			return nil
@@ -54,7 +53,7 @@ func main() { //nolint:funlen,gocyclo
 	}
 
 	for _, file := range upstreamResourceFiles {
-		originalFileContents, err := os.ReadFile(filepath.Clean(filepath.Join(upstreamDirectory, file))) //nolint:gosec // path from CLI args
+		originalFileContents, err := os.ReadFile(filepath.Clean(filepath.Join(upstreamDirectory, file)))
 		if err != nil {
 			panic(err)
 		}

--- a/tools/generate-docs/docs.go
+++ b/tools/generate-docs/docs.go
@@ -173,7 +173,7 @@ dynamically populated and therefore cannot be documented here.`
 	newMkdocs := updateResources(string(mkdocs), newResources)
 
 	if c.Bool("write-to-disk") {
-		err := os.WriteFile("mkdocs.yml", []byte(newMkdocs), 0600)
+		err := os.WriteFile("mkdocs.yml", []byte(newMkdocs), 0600) //nolint:gosec // G703: path is a hardcoded constant, not user input
 		if err != nil {
 			return err
 		}

--- a/tools/migrate-resource/main.go
+++ b/tools/migrate-resource/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	filename := filepath.Clean(filepath.Join(originalSourceDir, args[1]+".go"))
 
-	originalFileContents, err := os.ReadFile(filename) //nolint:gosec // path from CLI args is intentional
+	originalFileContents, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary

- golangci-lint v2.11.4 added a new gosec **G703** rule (path traversal via taint analysis) that fires on the hardcoded `"mkdocs.yml"` write in `generate-docs/docs.go` — added an explicit nolint annotation
- The same release changed which lines gosec flags, leaving four existing `//nolint:gosec` directives dead (caught by `nolintlint`) — removed them from `session.go`, `compare-resources`, and `migrate-resource`
- Pinned `version: v2.11.4` in the workflow so future golangci-lint releases can't silently break CI

These failures were pre-existing on `main` and unrelated to #929.

## Test plan
- [ ] golangci-lint passes in CI on this PR