### PR TITLE
fix(s3-object): avoid struct copy in range loop

### DIFF
--- a/resources/s3-object.go
+++ b/resources/s3-object.go
@@ -51,7 +51,8 @@ func (l *S3ObjectLister) List(ctx context.Context, o interface{}) ([]resource.Re
 				return nil, err
 			}
 
-			for _, out := range resp.Versions {
+			for i := range resp.Versions {
+				out := &resp.Versions[i]
 				if out.Key == nil {
 					continue
 				}


### PR DESCRIPTION
## Summary
- Use index-based iteration in `S3ObjectLister.List` to avoid copying a 128-byte struct on each loop iteration, fixing the `gocritic` `rangeValCopy` lint warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)