### PR TITLE
fix(rds-instances): do not start cluster if credentials are inaccessible

### DIFF
--- a/resources/rds-instances.go
+++ b/resources/rds-instances.go
@@ -109,7 +109,7 @@ func (i *RDSInstance) Remove(_ context.Context) error {
 			return err
 		}
 		switch status {
-		case "stopped", "inaccessible-encryption-credentials-recoverable":
+		case "stopped":
 			_, err := i.svc.StartDBCluster(&rds.StartDBClusterInput{
 				DBClusterIdentifier: i.instance.DBClusterIdentifier,
 			})


### PR DESCRIPTION
This change stops aws-nuke from attempting to start DB clusters in the `inaccessible-encryption-credentials-recoverable` state when the `RDSInstance.StartClusterToDelete` setting is enabled.

The original code attempts to start the cluster if it is in either the `stopped` state or the `inaccessible-encryption-credentials-recoverable` state, because those are the only two states in which `StartDBCluster` can be run. But in latter state, starting the DB cluster usually fails (unless access to the encryption credentials was restored since it entered that state), resulting in a failed nuke.

With this change, deletion of DB instances proceeds immediately if the cluster is in the `inaccessible-encryption-credentials-recoverable` state. I have encountered a DB cluster in this state and tested that its instances can be deleted without needing to start the cluster.
