### PR TITLE
fix: handle CoIP addresses with nil PublicIP in EC2Address resource

### DIFF
--- a/resources/ec2-eip.go
+++ b/resources/ec2-eip.go
@@ -39,10 +39,12 @@ func (l *EC2AddressLister) List(_ context.Context, o interface{}) ([]resource.Re
 	resources := make([]resource.Resource, 0)
 	for _, out := range resp.Addresses {
 		resources = append(resources, &EC2Address{
-			svc:          svc,
-			AllocationID: out.AllocationId,
-			PublicIP:     out.PublicIp,
-			Tags:         out.Tags,
+			svc:                svc,
+			AllocationID:       out.AllocationId,
+			PublicIP:           out.PublicIp,
+			CustomerOwnedIP:    out.CustomerOwnedIp,
+			NetworkBorderGroup: out.NetworkBorderGroup,
+			Tags:               out.Tags,
 		})
 	}
 
@@ -53,6 +55,7 @@ type EC2Address struct {
 	svc                *ec2.EC2
 	AllocationID       *string
 	PublicIP           *string
+	CustomerOwnedIP    *string
 	NetworkBorderGroup *string
 	Tags               []*ec2.Tag
 }
@@ -74,5 +77,14 @@ func (r *EC2Address) Properties() types.Properties {
 }
 
 func (r *EC2Address) String() string {
-	return *r.PublicIP
+	if r.PublicIP != nil {
+		return *r.PublicIP
+	}
+	if r.CustomerOwnedIP != nil {
+		return *r.CustomerOwnedIP
+	}
+	if r.AllocationID != nil {
+		return *r.AllocationID
+	}
+	return ""
 }


### PR DESCRIPTION
## Problem

EC2Address resource fails to release Elastic IPs from customer-owned IP pools (CoIP) on AWS Outposts. Three bugs:

1. `String()` unconditionally dereferences `PublicIP`, which is nil for CoIP addresses - causes a panic that skips all EIPs in the region
2. `NetworkBorderGroup` is never copied from the DescribeAddresses response, despite being passed to ReleaseAddress
3. `CustomerOwnedIp` is ignored entirely, making CoIP addresses unidentifiable

## Fix

- Add `CustomerOwnedIP` field to the struct and populate from API response
- Populate `NetworkBorderGroup` from API response
- Make `String()` nil-safe: falls back to CustomerOwnedIP → AllocationID

## Testing

Verified against account with 4 orphaned EIPs on Outposts (2 standard, 2 CoIP) that survived aws-nuke runs due to this bug.