### PR TITLE
feat: add EC2LocalGatewayRouteTableVPCAssociation resource

### DIFF
--- a/resources/ec2-local-gateway-route-table-vpc-association.go
+++ b/resources/ec2-local-gateway-route-table-vpc-association.go
@@ -1,0 +1,84 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/gotidy/ptr"
+
+	"github.com/aws/aws-sdk-go/service/ec2" //nolint:staticcheck
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const EC2LocalGatewayRouteTableVPCAssociationResource = "EC2LocalGatewayRouteTableVPCAssociation"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     EC2LocalGatewayRouteTableVPCAssociationResource,
+		Scope:    nuke.Account,
+		Resource: &EC2LocalGatewayRouteTableVPCAssociation{},
+		Lister:   &EC2LocalGatewayRouteTableVPCAssociationLister{},
+	})
+}
+
+type EC2LocalGatewayRouteTableVPCAssociationLister struct{}
+
+func (l *EC2LocalGatewayRouteTableVPCAssociationLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+
+	svc := ec2.New(opts.Session)
+
+	resp, err := svc.DescribeLocalGatewayRouteTableVpcAssociations(
+		&ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]resource.Resource, 0)
+	for _, assoc := range resp.LocalGatewayRouteTableVpcAssociations {
+		resources = append(resources, &EC2LocalGatewayRouteTableVPCAssociation{
+			svc:   svc,
+			assoc: assoc,
+		})
+	}
+
+	return resources, nil
+}
+
+type EC2LocalGatewayRouteTableVPCAssociation struct {
+	svc   *ec2.EC2
+	assoc *ec2.LocalGatewayRouteTableVpcAssociation
+}
+
+func (r *EC2LocalGatewayRouteTableVPCAssociation) Remove(_ context.Context) error {
+	_, err := r.svc.DeleteLocalGatewayRouteTableVpcAssociation(
+		&ec2.DeleteLocalGatewayRouteTableVpcAssociationInput{
+			LocalGatewayRouteTableVpcAssociationId: r.assoc.LocalGatewayRouteTableVpcAssociationId,
+		},
+	)
+	return err
+}
+
+func (r *EC2LocalGatewayRouteTableVPCAssociation) Properties() types.Properties {
+	properties := types.NewProperties()
+	for _, tagValue := range r.assoc.Tags {
+		properties.SetTag(tagValue.Key, tagValue.Value)
+	}
+	properties.Set("ID", r.assoc.LocalGatewayRouteTableVpcAssociationId)
+	properties.Set("State", r.assoc.State)
+	properties.Set("VpcID", r.assoc.VpcId)
+	properties.Set("LocalGatewayID", r.assoc.LocalGatewayId)
+	properties.Set("LocalGatewayRouteTableID", r.assoc.LocalGatewayRouteTableId)
+	properties.Set("OwnerID", r.assoc.OwnerId)
+	return properties
+}
+
+func (r *EC2LocalGatewayRouteTableVPCAssociation) String() string {
+	return ptr.ToString(r.assoc.LocalGatewayRouteTableVpcAssociationId)
+}
+

--- a/resources/ec2-local-gateway-route-table-vpc-association.go
+++ b/resources/ec2-local-gateway-route-table-vpc-association.go
@@ -2,10 +2,13 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/gotidy/ptr"
 
-	"github.com/aws/aws-sdk-go/service/ec2" //nolint:staticcheck
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -27,12 +30,12 @@ func init() {
 
 type EC2LocalGatewayRouteTableVPCAssociationLister struct{}
 
-func (l *EC2LocalGatewayRouteTableVPCAssociationLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+func (l *EC2LocalGatewayRouteTableVPCAssociationLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
 
-	svc := ec2.New(opts.Session)
+	svc := ec2.NewFromConfig(*opts.Config)
 
-	resp, err := svc.DescribeLocalGatewayRouteTableVpcAssociations(
+	resp, err := svc.DescribeLocalGatewayRouteTableVpcAssociations(ctx,
 		&ec2.DescribeLocalGatewayRouteTableVpcAssociationsInput{},
 	)
 	if err != nil {
@@ -40,10 +43,17 @@ func (l *EC2LocalGatewayRouteTableVPCAssociationLister) List(_ context.Context, 
 	}
 
 	resources := make([]resource.Resource, 0)
-	for _, assoc := range resp.LocalGatewayRouteTableVpcAssociations {
+	for i := range resp.LocalGatewayRouteTableVpcAssociations {
+		assoc := &resp.LocalGatewayRouteTableVpcAssociations[i]
 		resources = append(resources, &EC2LocalGatewayRouteTableVPCAssociation{
-			svc:   svc,
-			assoc: assoc,
+			svc:                      svc,
+			ID:                       assoc.LocalGatewayRouteTableVpcAssociationId,
+			State:                    assoc.State,
+			VpcID:                    assoc.VpcId,
+			LocalGatewayID:           assoc.LocalGatewayId,
+			LocalGatewayRouteTableID: assoc.LocalGatewayRouteTableId,
+			OwnerID:                  assoc.OwnerId,
+			Tags:                     assoc.Tags,
 		})
 	}
 
@@ -51,34 +61,36 @@ func (l *EC2LocalGatewayRouteTableVPCAssociationLister) List(_ context.Context, 
 }
 
 type EC2LocalGatewayRouteTableVPCAssociation struct {
-	svc   *ec2.EC2
-	assoc *ec2.LocalGatewayRouteTableVpcAssociation
+	svc                      *ec2.Client
+	ID                       *string `property:"name=ID"`
+	State                    *string
+	VpcID                    *string
+	LocalGatewayID           *string
+	LocalGatewayRouteTableID *string
+	OwnerID                  *string
+	Tags                     []ec2types.Tag
 }
 
-func (r *EC2LocalGatewayRouteTableVPCAssociation) Remove(_ context.Context) error {
-	_, err := r.svc.DeleteLocalGatewayRouteTableVpcAssociation(
+func (r *EC2LocalGatewayRouteTableVPCAssociation) Filter() error {
+	if r.OwnerID != nil && strings.HasSuffix(ptr.ToString(r.OwnerID), ".amazonaws.com") {
+		return fmt.Errorf("unable to remove service-managed association (owner: %s)", ptr.ToString(r.OwnerID))
+	}
+	return nil
+}
+
+func (r *EC2LocalGatewayRouteTableVPCAssociation) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteLocalGatewayRouteTableVpcAssociation(ctx,
 		&ec2.DeleteLocalGatewayRouteTableVpcAssociationInput{
-			LocalGatewayRouteTableVpcAssociationId: r.assoc.LocalGatewayRouteTableVpcAssociationId,
+			LocalGatewayRouteTableVpcAssociationId: r.ID,
 		},
 	)
 	return err
 }
 
 func (r *EC2LocalGatewayRouteTableVPCAssociation) Properties() types.Properties {
-	properties := types.NewProperties()
-	for _, tagValue := range r.assoc.Tags {
-		properties.SetTag(tagValue.Key, tagValue.Value)
-	}
-	properties.Set("ID", r.assoc.LocalGatewayRouteTableVpcAssociationId)
-	properties.Set("State", r.assoc.State)
-	properties.Set("VpcID", r.assoc.VpcId)
-	properties.Set("LocalGatewayID", r.assoc.LocalGatewayId)
-	properties.Set("LocalGatewayRouteTableID", r.assoc.LocalGatewayRouteTableId)
-	properties.Set("OwnerID", r.assoc.OwnerId)
-	return properties
+	return types.NewPropertiesFromStruct(r)
 }
 
 func (r *EC2LocalGatewayRouteTableVPCAssociation) String() string {
-	return ptr.ToString(r.assoc.LocalGatewayRouteTableVpcAssociationId)
+	return ptr.ToString(r.ID)
 }
-


### PR DESCRIPTION
## Summary

Adds support for deleting Local Gateway Route Table VPC Associations (`EC2LocalGatewayRouteTableVPCAssociation`).

When AWS Outposts are present in an account, VPCs may have associations to Local Gateway Route Tables. These associations must be removed before the VPC can be deleted. Without this resource, aws-nuke cannot fully clean accounts that have Outposts or Local Gateway configurations, requiring manual intervention prior to running nuke.

## API Calls Used

- List: `DescribeLocalGatewayRouteTableVpcAssociations`
- Delete: `DeleteLocalGatewayRouteTableVpcAssociation`

## Properties Exposed for Filtering

- `ID`, `State`, `VpcID`, `LocalGatewayID`, `LocalGatewayRouteTableID`, `OwnerID`, tags

## Notes

For complete Outposts account cleanup, this resource should be deleted before the VPC. A future enhancement could add `EC2LocalGatewayRouteTableVPCAssociation` to the `DependsOn` list of `EC2VPC` in `ec2-vpc.go`.