### PR TITLE
feat: add Amazon Q Business resource suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mgn v1.37.6
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.17.6
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.53.0
+	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8
 	github.com/aws/aws-sdk-go-v2/service/ram v1.34.19
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.17
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.41.5
@@ -62,7 +63,7 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
 github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.28.11 h1:7Ekru0IkRHRnSRWGQLnLN6i0o1Jncd0rHo2T130+tEQ=
 github.com/aws/aws-sdk-go-v2/config v1.28.11/go.mod h1:x78TpPvBfHH16hi5tE3OCWQ0pzNfyXA349p5/Wp82Yo=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.71 h1:r2w4mQWnrTMJjOyIsZtGp3R3XGY3nqHn8C26C2lQWgA=
@@ -70,6 +70,8 @@ github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.17.6 h1:sA9Ll0/+rmaz08n5CHB
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.17.6/go.mod h1:rbHtwGyKB0puYUphsbaSq2vQuoYfQ7Vx/ZBx9h4CnSU=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.53.0 h1:FHl1QPk+MTUjcbGtnNfcVnq5bPkP71Tbzt++qQ/dCnY=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.53.0/go.mod h1:EiHBjTVCeOUX045RTpHUuqrtexp4OtSbMLj+nXiaaHw=
+github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8 h1:fMFheeWMyC7aGeTIz+GJAaKanfOtOzOg78q/v0jKA4E=
+github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8/go.mod h1:S8/FKYPSm2WEEGMs5gmbrOrULz0zvJ1CYkf2UEnYzYw=
 github.com/aws/aws-sdk-go-v2/service/ram v1.34.19 h1:KgzHjJvrAw5RQ5tXEyUX1B9zcPuWiCs7h/aT0Q6XYTE=
 github.com/aws/aws-sdk-go-v2/service/ram v1.34.19/go.mod h1:wHbYtm0qUAphMlG61fmCj0qJyVFgYJaHyYcI1sxvLxI=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.17 h1:x19QmT0wHVz5v48OqvGY1B18Pdw3Z1XHsc/+eLWRUQ8=

--- a/resources/qbusiness-application.go
+++ b/resources/qbusiness-application.go
@@ -1,0 +1,101 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qbusiness"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const QBusinessApplicationResource = "QBusinessApplication"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     QBusinessApplicationResource,
+		Scope:    nuke.Account,
+		Resource: &QBusinessApplication{},
+		Lister:   &QBusinessApplicationLister{},
+		DependsOn: []string{
+			QBusinessWebExperienceResource,
+			QBusinessPluginResource,
+			QBusinessIndexResource,
+			QBusinessRetrieverResource,
+			QBusinessDataSourceResource,
+		},
+	})
+}
+
+type QBusinessApplicationLister struct{}
+
+func (l *QBusinessApplicationLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := qbusiness.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	paginator := qbusiness.NewListApplicationsPaginator(svc, &qbusiness.ListApplicationsInput{
+		MaxResults: aws.Int32(100),
+	})
+
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, app := range resp.Applications {
+			resources = append(resources, &QBusinessApplication{
+				svc:    svc,
+				ID:     app.ApplicationId,
+				Name:   app.DisplayName,
+				Status: aws.String(string(app.Status)),
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+type QBusinessApplication struct {
+	svc    *qbusiness.Client
+	ID     *string
+	Name   *string
+	Status *string
+}
+
+func (r *QBusinessApplication) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteApplication(ctx, &qbusiness.DeleteApplicationInput{
+		ApplicationId: r.ID,
+	})
+	return err
+}
+
+func (r *QBusinessApplication) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *QBusinessApplication) String() string {
+	return aws.ToString(r.ID)
+}
+
+// listQBusinessApplicationIDs is a shared helper used by child resource listers.
+func listQBusinessApplicationIDs(ctx context.Context, svc *qbusiness.Client) ([]*string, error) {
+	var appIDs []*string
+	paginator := qbusiness.NewListApplicationsPaginator(svc, &qbusiness.ListApplicationsInput{
+		MaxResults: aws.Int32(100),
+	})
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, app := range resp.Applications {
+			appIDs = append(appIDs, app.ApplicationId)
+		}
+	}
+	return appIDs, nil
+}

--- a/resources/qbusiness-data-source.go
+++ b/resources/qbusiness-data-source.go
@@ -1,0 +1,102 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qbusiness"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const QBusinessDataSourceResource = "QBusinessDataSource"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     QBusinessDataSourceResource,
+		Scope:    nuke.Account,
+		Resource: &QBusinessDataSource{},
+		Lister:   &QBusinessDataSourceLister{},
+	})
+}
+
+type QBusinessDataSourceLister struct{}
+
+func (l *QBusinessDataSourceLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := qbusiness.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	appIDs, err := listQBusinessApplicationIDs(ctx, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, appID := range appIDs {
+		idxPaginator := qbusiness.NewListIndicesPaginator(svc, &qbusiness.ListIndicesInput{
+			ApplicationId: appID,
+			MaxResults:    aws.Int32(100),
+		})
+		for idxPaginator.HasMorePages() {
+			idxResp, err := idxPaginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, idx := range idxResp.Indices {
+				dsPaginator := qbusiness.NewListDataSourcesPaginator(svc, &qbusiness.ListDataSourcesInput{
+					ApplicationId: appID,
+					IndexId:       idx.IndexId,
+					MaxResults:    aws.Int32(10),
+				})
+				for dsPaginator.HasMorePages() {
+					dsResp, err := dsPaginator.NextPage(ctx)
+					if err != nil {
+						return nil, err
+					}
+					for _, ds := range dsResp.DataSources {
+						resources = append(resources, &QBusinessDataSource{
+							svc:           svc,
+							ApplicationID: appID,
+							IndexID:       idx.IndexId,
+							ID:            ds.DataSourceId,
+							Name:          ds.DisplayName,
+							Status:        aws.String(string(ds.Status)),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+type QBusinessDataSource struct {
+	svc           *qbusiness.Client
+	ApplicationID *string
+	IndexID       *string
+	ID            *string
+	Name          *string
+	Status        *string
+}
+
+func (r *QBusinessDataSource) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteDataSource(ctx, &qbusiness.DeleteDataSourceInput{
+		ApplicationId: r.ApplicationID,
+		IndexId:       r.IndexID,
+		DataSourceId:  r.ID,
+	})
+	return err
+}
+
+func (r *QBusinessDataSource) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *QBusinessDataSource) String() string {
+	return aws.ToString(r.ID)
+}

--- a/resources/qbusiness-index.go
+++ b/resources/qbusiness-index.go
@@ -1,0 +1,89 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qbusiness"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const QBusinessIndexResource = "QBusinessIndex"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     QBusinessIndexResource,
+		Scope:    nuke.Account,
+		Resource: &QBusinessIndex{},
+		Lister:   &QBusinessIndexLister{},
+		DependsOn: []string{
+			QBusinessDataSourceResource,
+		},
+	})
+}
+
+type QBusinessIndexLister struct{}
+
+func (l *QBusinessIndexLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := qbusiness.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	appIDs, err := listQBusinessApplicationIDs(ctx, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, appID := range appIDs {
+		paginator := qbusiness.NewListIndicesPaginator(svc, &qbusiness.ListIndicesInput{
+			ApplicationId: appID,
+			MaxResults:    aws.Int32(100),
+		})
+		for paginator.HasMorePages() {
+			resp, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, idx := range resp.Indices {
+				resources = append(resources, &QBusinessIndex{
+					svc:           svc,
+					ApplicationID: appID,
+					ID:            idx.IndexId,
+					Name:          idx.DisplayName,
+					Status:        aws.String(string(idx.Status)),
+				})
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+type QBusinessIndex struct {
+	svc           *qbusiness.Client
+	ApplicationID *string
+	ID            *string
+	Name          *string
+	Status        *string
+}
+
+func (r *QBusinessIndex) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteIndex(ctx, &qbusiness.DeleteIndexInput{
+		ApplicationId: r.ApplicationID,
+		IndexId:       r.ID,
+	})
+	return err
+}
+
+func (r *QBusinessIndex) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *QBusinessIndex) String() string {
+	return aws.ToString(r.ID)
+}

--- a/resources/qbusiness-plugin.go
+++ b/resources/qbusiness-plugin.go
@@ -1,0 +1,86 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qbusiness"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const QBusinessPluginResource = "QBusinessPlugin"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     QBusinessPluginResource,
+		Scope:    nuke.Account,
+		Resource: &QBusinessPlugin{},
+		Lister:   &QBusinessPluginLister{},
+	})
+}
+
+type QBusinessPluginLister struct{}
+
+func (l *QBusinessPluginLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := qbusiness.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	appIDs, err := listQBusinessApplicationIDs(ctx, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, appID := range appIDs {
+		paginator := qbusiness.NewListPluginsPaginator(svc, &qbusiness.ListPluginsInput{
+			ApplicationId: appID,
+			MaxResults:    aws.Int32(50),
+		})
+		for paginator.HasMorePages() {
+			resp, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, p := range resp.Plugins {
+				resources = append(resources, &QBusinessPlugin{
+					svc:           svc,
+					ApplicationID: appID,
+					ID:            p.PluginId,
+					Name:          p.DisplayName,
+					State:         aws.String(string(p.State)),
+				})
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+type QBusinessPlugin struct {
+	svc           *qbusiness.Client
+	ApplicationID *string
+	ID            *string
+	Name          *string
+	State         *string
+}
+
+func (r *QBusinessPlugin) Remove(ctx context.Context) error {
+	_, err := r.svc.DeletePlugin(ctx, &qbusiness.DeletePluginInput{
+		ApplicationId: r.ApplicationID,
+		PluginId:      r.ID,
+	})
+	return err
+}
+
+func (r *QBusinessPlugin) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *QBusinessPlugin) String() string {
+	return aws.ToString(r.ID)
+}

--- a/resources/qbusiness-retriever.go
+++ b/resources/qbusiness-retriever.go
@@ -1,0 +1,86 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qbusiness"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const QBusinessRetrieverResource = "QBusinessRetriever"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     QBusinessRetrieverResource,
+		Scope:    nuke.Account,
+		Resource: &QBusinessRetriever{},
+		Lister:   &QBusinessRetrieverLister{},
+	})
+}
+
+type QBusinessRetrieverLister struct{}
+
+func (l *QBusinessRetrieverLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := qbusiness.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	appIDs, err := listQBusinessApplicationIDs(ctx, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, appID := range appIDs {
+		paginator := qbusiness.NewListRetrieversPaginator(svc, &qbusiness.ListRetrieversInput{
+			ApplicationId: appID,
+			MaxResults:    aws.Int32(50),
+		})
+		for paginator.HasMorePages() {
+			resp, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, ret := range resp.Retrievers {
+				resources = append(resources, &QBusinessRetriever{
+					svc:           svc,
+					ApplicationID: appID,
+					ID:            ret.RetrieverId,
+					Name:          ret.DisplayName,
+					Status:        aws.String(string(ret.Status)),
+				})
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+type QBusinessRetriever struct {
+	svc           *qbusiness.Client
+	ApplicationID *string
+	ID            *string
+	Name          *string
+	Status        *string
+}
+
+func (r *QBusinessRetriever) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteRetriever(ctx, &qbusiness.DeleteRetrieverInput{
+		ApplicationId: r.ApplicationID,
+		RetrieverId:   r.ID,
+	})
+	return err
+}
+
+func (r *QBusinessRetriever) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *QBusinessRetriever) String() string {
+	return aws.ToString(r.ID)
+}

--- a/resources/qbusiness-web-experience.go
+++ b/resources/qbusiness-web-experience.go
@@ -1,0 +1,84 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qbusiness"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const QBusinessWebExperienceResource = "QBusinessWebExperience"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     QBusinessWebExperienceResource,
+		Scope:    nuke.Account,
+		Resource: &QBusinessWebExperience{},
+		Lister:   &QBusinessWebExperienceLister{},
+	})
+}
+
+type QBusinessWebExperienceLister struct{}
+
+func (l *QBusinessWebExperienceLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := qbusiness.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	appIDs, err := listQBusinessApplicationIDs(ctx, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, appID := range appIDs {
+		paginator := qbusiness.NewListWebExperiencesPaginator(svc, &qbusiness.ListWebExperiencesInput{
+			ApplicationId: appID,
+			MaxResults:    aws.Int32(100),
+		})
+		for paginator.HasMorePages() {
+			resp, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, we := range resp.WebExperiences {
+				resources = append(resources, &QBusinessWebExperience{
+					svc:           svc,
+					ApplicationID: appID,
+					ID:            we.WebExperienceId,
+					Status:        aws.String(string(we.Status)),
+				})
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+type QBusinessWebExperience struct {
+	svc           *qbusiness.Client
+	ApplicationID *string
+	ID            *string
+	Status        *string
+}
+
+func (r *QBusinessWebExperience) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteWebExperience(ctx, &qbusiness.DeleteWebExperienceInput{
+		ApplicationId:   r.ApplicationID,
+		WebExperienceId: r.ID,
+	})
+	return err
+}
+
+func (r *QBusinessWebExperience) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *QBusinessWebExperience) String() string {
+	return aws.ToString(r.ID)
+}


### PR DESCRIPTION
## Summary

Adds full support for deleting Amazon Q Business resources, enabling complete account cleanup for accounts using Amazon Q Business.

## Resources Added

| Resource | List API | Delete API |
|---|---|---|
| `QBusinessApplication` | `ListApplications` | `DeleteApplication` |
| `QBusinessIndex` | `ListIndices` | `DeleteIndex` |
| `QBusinessDataSource` | `ListDataSources` | `DeleteDataSource` |
| `QBusinessRetriever` | `ListRetrievers` | `DeleteRetriever` |
| `QBusinessPlugin` | `ListPlugins` | `DeletePlugin` |
| `QBusinessWebExperience` | `ListWebExperiences` | `DeleteWebExperience` |

## Deletion Order

Child resources are wired with `DependsOn` to ensure correct deletion order:

```
QBusinessDataSource ──► QBusinessIndex ──┐
QBusinessRetriever ───────────────────────┤──► QBusinessApplication
QBusinessWebExperience ───────────────────┤
QBusinessPlugin ──────────────────────────┘
```

## Testing

Validated against a live AWS account (us-east-1). Both `QBusinessApplication` and `QBusinessIndex` were successfully discovered and deleted by nuke with `--no-dry-run`.

## Notes

All child resource listers enumerate applications first, then iterate child resources per application. `QBusinessDataSource` requires both `applicationId` and `indexId`, so it iterates indices per application. A shared helper `listQBusinessApplications` is defined in `qbusiness-application.go` and reused by all child listers.