### PR TITLE
fix: Add missing tags to the lambda event source mapping resource

### DIFF
--- a/docs/resources/lambda-event-source-mapping.md
+++ b/docs/resources/lambda-event-source-mapping.md
@@ -11,5 +11,26 @@ generated: true
 LambdaEventSourceMapping
 ```
 
+## Properties
 
+
+- `EventSourceArn`: No Description
+- `EventSourceMappingArn`: No Description
+- `FunctionArn`: No Description
+- `State`: No Description
+- `UUID`: No Description
+- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
+	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"]) 
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3files v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/shield v1.34.25
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.3.10
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/textract v1.40.22

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/aws/aws-sdk-go-v2/service/s3tables v1.15.1 h1:3mQxvXAzMRfnc1md8Op2sYF
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.15.1/go.mod h1:F3WPcRjnxxFfS5ljI+H7Tg/SZ/IXP8j8HSh0UWRIFiI=
 github.com/aws/aws-sdk-go-v2/service/shield v1.34.25 h1:mTkHhGBTt/7wd/7dMQwPpoI9xWeuR9HMk87WQSMmRTE=
 github.com/aws/aws-sdk-go-v2/service/shield v1.34.25/go.mod h1:RFFO1hD4EphzolYUUk2YSf4bQwvdW3uYS2VkGbgSnjI=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25 h1:8Bv3TQ1Cob6HLlpUbAnWxeHhAkYScJO9RIHh2WPXaxw=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25/go.mod h1:eDstEbM0OEnBUnNQxIA7j74Jy61cCU1S4EMlCtdMwzs=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.3.10 h1:3e9ZvkZB5NsDellLxPuaCJSeA5Hg7SeHY+Godotzizc=
 github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.3.10/go.mod h1:UKtH07HzEWvg7zZ6R2JixYlmGYa/3i2niz7Lz2zJoeM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.6 h1:rGtWqkQbPk7Bkwuv3NzpE/scwwL9sC1Ul3tn9x83DUI=

--- a/resources/lambda-event-source-mapping.go
+++ b/resources/lambda-event-source-mapping.go
@@ -48,13 +48,25 @@ func (l *LambdaEventSourceMappingLister) List(ctx context.Context, o interface{}
 			return nil, err
 		}
 
-		for _, mapping := range resp.EventSourceMappings {
+		// Use index-based iteration to avoid copying the 344-byte
+		// EventSourceMappingConfiguration struct on each iteration.
+		for i := range resp.EventSourceMappings {
+			mapping := &resp.EventSourceMappings[i]
+			tagsResp, err := svc.ListTags(ctx, &lambda.ListTagsInput{
+				Resource: mapping.EventSourceMappingArn,
+			})
+			if err != nil {
+				return nil, err
+			}
+
 			resources = append(resources, &LambdaEventSourceMapping{
-				svc:            svc,
-				UUID:           mapping.UUID,
-				EventSourceArn: mapping.EventSourceArn,
-				FunctionArn:    mapping.FunctionArn,
-				State:          mapping.State,
+				svc:                   svc,
+				UUID:                  mapping.UUID,
+				EventSourceMappingArn: mapping.EventSourceMappingArn,
+				EventSourceArn:        mapping.EventSourceArn,
+				FunctionArn:           mapping.FunctionArn,
+				State:                 mapping.State,
+				Tags:                  tagsResp.Tags,
 			})
 		}
 	}
@@ -63,11 +75,13 @@ func (l *LambdaEventSourceMappingLister) List(ctx context.Context, o interface{}
 }
 
 type LambdaEventSourceMapping struct {
-	svc            LambdaEventSourceMappingClient
-	UUID           *string
-	EventSourceArn *string
-	FunctionArn    *string
-	State          *string
+	svc                   LambdaEventSourceMappingClient
+	UUID                  *string
+	EventSourceMappingArn *string
+	EventSourceArn        *string
+	FunctionArn           *string
+	State                 *string
+	Tags                  map[string]string
 }
 
 func (r *LambdaEventSourceMapping) Remove(ctx context.Context) error {

--- a/resources/lambda-event-source-mapping.go
+++ b/resources/lambda-event-source-mapping.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/service/lambda" //nolint:staticcheck
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -23,61 +23,65 @@ func init() {
 	})
 }
 
-type LambdaEventSourceMappingLister struct{}
+type LambdaEventSourceMappingLister struct {
+	mockSvc LambdaEventSourceMappingClient
+}
 
-func (l *LambdaEventSourceMappingLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+func (l *LambdaEventSourceMappingLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
 
-	svc := lambda.New(opts.Session)
+	var svc LambdaEventSourceMappingClient
+	if l.mockSvc != nil {
+		svc = l.mockSvc
+	} else {
+		svc = lambda.NewFromConfig(*opts.Config)
+	}
+
 	resources := make([]resource.Resource, 0)
 
 	params := &lambda.ListEventSourceMappingsInput{}
-	for {
-		resp, err := svc.ListEventSourceMappings(params)
+	paginator := lambda.NewListEventSourceMappingsPaginator(svc, params)
+
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, mapping := range resp.EventSourceMappings {
 			resources = append(resources, &LambdaEventSourceMapping{
-				svc:     svc,
-				mapping: mapping,
+				svc:            svc,
+				UUID:           mapping.UUID,
+				EventSourceArn: mapping.EventSourceArn,
+				FunctionArn:    mapping.FunctionArn,
+				State:          mapping.State,
 			})
 		}
-
-		if resp.NextMarker == nil {
-			break
-		}
-
-		params.Marker = resp.NextMarker
 	}
 
 	return resources, nil
 }
 
 type LambdaEventSourceMapping struct {
-	svc     *lambda.Lambda
-	mapping *lambda.EventSourceMappingConfiguration
+	svc            LambdaEventSourceMappingClient
+	UUID           *string
+	EventSourceArn *string
+	FunctionArn    *string
+	State          *string
 }
 
-func (m *LambdaEventSourceMapping) Remove(_ context.Context) error {
-	_, err := m.svc.DeleteEventSourceMapping(&lambda.DeleteEventSourceMappingInput{
-		UUID: m.mapping.UUID,
+func (r *LambdaEventSourceMapping) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteEventSourceMapping(ctx, &lambda.DeleteEventSourceMappingInput{
+		UUID: r.UUID,
 	})
 
 	return err
 }
 
-func (m *LambdaEventSourceMapping) Properties() types.Properties {
-	properties := types.NewProperties()
-	properties.Set("UUID", m.mapping.UUID)
-	properties.Set("EventSourceArn", m.mapping.EventSourceArn)
-	properties.Set("FunctionArn", m.mapping.FunctionArn)
-	properties.Set("State", m.mapping.State)
-
-	return properties
+func (r *LambdaEventSourceMapping) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
 }
 
-func (m *LambdaEventSourceMapping) String() string {
-	return *m.mapping.UUID
+func (r *LambdaEventSourceMapping) String() string {
+	return *r.UUID
 }

--- a/resources/lambda-event-source-mapping_mock_test.go
+++ b/resources/lambda-event-source-mapping_mock_test.go
@@ -1,0 +1,77 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gotidy/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+func Test_Mock_LambdaEventSourceMapping_List(t *testing.T) {
+	mockSvc := new(mockLambdaEventSourceMappingClient)
+	mockSvc.On("ListEventSourceMappings", mock.Anything, mock.Anything).Return(&lambda.ListEventSourceMappingsOutput{
+		EventSourceMappings: []lambdatypes.EventSourceMappingConfiguration{
+			{
+				UUID:           ptr.String("test-uuid"),
+				EventSourceArn: ptr.String("arn:aws:sqs:us-east-1:123456789012:test-queue"),
+				FunctionArn:    ptr.String("arn:aws:lambda:us-east-1:123456789012:function:test-func"),
+				State:          ptr.String("Enabled"),
+			},
+		},
+	}, nil)
+
+	lister := &LambdaEventSourceMappingLister{
+		mockSvc: mockSvc,
+	}
+	opts := &nuke.ListerOpts{Config: &aws.Config{
+		Region: "us-east-1",
+	}}
+
+	resources, err := lister.List(context.TODO(), opts)
+	assert.NoError(t, err)
+	assert.Len(t, resources, 1)
+
+	res := resources[0].(*LambdaEventSourceMapping)
+	assert.Equal(t, "test-uuid", *res.UUID)
+
+	mockSvc.AssertExpectations(t)
+}
+
+func Test_Mock_LambdaEventSourceMapping_Remove(t *testing.T) {
+	mockSvc := new(mockLambdaEventSourceMappingClient)
+	mockSvc.On("DeleteEventSourceMapping", mock.Anything, mock.Anything).Return(&lambda.DeleteEventSourceMappingOutput{}, nil)
+
+	r := &LambdaEventSourceMapping{
+		svc:  mockSvc,
+		UUID: ptr.String("test-uuid"),
+	}
+
+	err := r.Remove(context.TODO())
+	assert.NoError(t, err)
+
+	mockSvc.AssertExpectations(t)
+}
+
+func Test_Mock_LambdaEventSourceMapping_Properties(t *testing.T) {
+	r := &LambdaEventSourceMapping{
+		UUID:           ptr.String("test-uuid"),
+		EventSourceArn: ptr.String("arn:aws:sqs:us-east-1:123456789012:test-queue"),
+		FunctionArn:    ptr.String("arn:aws:lambda:us-east-1:123456789012:function:test-func"),
+		State:          ptr.String("Enabled"),
+	}
+
+	props := r.Properties()
+
+	assert.Equal(t, "test-uuid", props.Get("UUID"))
+	assert.Equal(t, "arn:aws:sqs:us-east-1:123456789012:test-queue", props.Get("EventSourceArn"))
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:test-func", props.Get("FunctionArn"))
+	assert.Equal(t, "Enabled", props.Get("State"))
+}

--- a/resources/lambda-event-source-mapping_mock_test.go
+++ b/resources/lambda-event-source-mapping_mock_test.go
@@ -20,12 +20,16 @@ func Test_Mock_LambdaEventSourceMapping_List(t *testing.T) {
 	mockSvc.On("ListEventSourceMappings", mock.Anything, mock.Anything).Return(&lambda.ListEventSourceMappingsOutput{
 		EventSourceMappings: []lambdatypes.EventSourceMappingConfiguration{
 			{
-				UUID:           ptr.String("test-uuid"),
-				EventSourceArn: ptr.String("arn:aws:sqs:us-east-1:123456789012:test-queue"),
-				FunctionArn:    ptr.String("arn:aws:lambda:us-east-1:123456789012:function:test-func"),
-				State:          ptr.String("Enabled"),
+				UUID:                  ptr.String("test-uuid"),
+				EventSourceMappingArn: ptr.String("arn:aws:lambda:us-east-1:123456789012:event-source-mapping:test-uuid"),
+				EventSourceArn:        ptr.String("arn:aws:sqs:us-east-1:123456789012:test-queue"),
+				FunctionArn:           ptr.String("arn:aws:lambda:us-east-1:123456789012:function:test-func"),
+				State:                 ptr.String("Enabled"),
 			},
 		},
+	}, nil)
+	mockSvc.On("ListTags", mock.Anything, mock.Anything).Return(&lambda.ListTagsOutput{
+		Tags: map[string]string{"test-key": "test-value"},
 	}, nil)
 
 	lister := &LambdaEventSourceMappingLister{
@@ -41,6 +45,7 @@ func Test_Mock_LambdaEventSourceMapping_List(t *testing.T) {
 
 	res := resources[0].(*LambdaEventSourceMapping)
 	assert.Equal(t, "test-uuid", *res.UUID)
+	assert.Equal(t, "test-value", res.Tags["test-key"])
 
 	mockSvc.AssertExpectations(t)
 }
@@ -62,16 +67,20 @@ func Test_Mock_LambdaEventSourceMapping_Remove(t *testing.T) {
 
 func Test_Mock_LambdaEventSourceMapping_Properties(t *testing.T) {
 	r := &LambdaEventSourceMapping{
-		UUID:           ptr.String("test-uuid"),
-		EventSourceArn: ptr.String("arn:aws:sqs:us-east-1:123456789012:test-queue"),
-		FunctionArn:    ptr.String("arn:aws:lambda:us-east-1:123456789012:function:test-func"),
-		State:          ptr.String("Enabled"),
+		UUID:                  ptr.String("test-uuid"),
+		EventSourceMappingArn: ptr.String("arn:aws:lambda:us-east-1:123456789012:event-source-mapping:test-uuid"),
+		EventSourceArn:        ptr.String("arn:aws:sqs:us-east-1:123456789012:test-queue"),
+		FunctionArn:           ptr.String("arn:aws:lambda:us-east-1:123456789012:function:test-func"),
+		State:                 ptr.String("Enabled"),
+		Tags:                  map[string]string{"env": "test"},
 	}
 
 	props := r.Properties()
 
 	assert.Equal(t, "test-uuid", props.Get("UUID"))
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:event-source-mapping:test-uuid", props.Get("EventSourceMappingArn"))
 	assert.Equal(t, "arn:aws:sqs:us-east-1:123456789012:test-queue", props.Get("EventSourceArn"))
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:test-func", props.Get("FunctionArn"))
 	assert.Equal(t, "Enabled", props.Get("State"))
+	assert.Equal(t, "test", props.Get("tag:env"))
 }

--- a/resources/lambda-event-source-mapping_test.go
+++ b/resources/lambda-event-source-mapping_test.go
@@ -164,11 +164,12 @@ func (suite *TestLambdaEventSourceMappingSuite) TearDownSuite() {
 }
 
 func (suite *TestLambdaEventSourceMappingSuite) Test_List() {
-	// Create a mapping scoped to this test
+	// Create a mapping with a tag so we can verify tag retrieval
 	mappingResp, err := suite.lambdaSvc.CreateEventSourceMapping(suite.ctx, &lambda.CreateEventSourceMappingInput{
 		EventSourceArn: aws.String(suite.queueArn),
 		FunctionName:   aws.String(suite.functionName),
 		Enabled:        aws.Bool(false),
+		Tags:           map[string]string{"aws-nuke-test": "true"},
 	})
 	assert.NoError(suite.T(), err)
 
@@ -183,15 +184,18 @@ func (suite *TestLambdaEventSourceMappingSuite) Test_List() {
 	assert.NoError(suite.T(), err)
 	assert.Greater(suite.T(), len(resources), 0)
 
-	found := false
+	var found *LambdaEventSourceMapping
 	for _, r := range resources {
 		mapping := r.(*LambdaEventSourceMapping)
 		if *mapping.UUID == *mappingResp.UUID {
-			found = true
+			found = mapping
 			break
 		}
 	}
-	assert.True(suite.T(), found, "expected to find the created event source mapping in list results")
+	assert.NotNil(suite.T(), found, "expected to find the created event source mapping in list results")
+	if found != nil {
+		assert.Equal(suite.T(), "true", found.Tags["aws-nuke-test"], "expected tag to be present on listed mapping")
+	}
 }
 
 func (suite *TestLambdaEventSourceMappingSuite) Test_Remove() {

--- a/resources/lambda-event-source-mapping_test.go
+++ b/resources/lambda-event-source-mapping_test.go
@@ -1,0 +1,227 @@
+//go:build integration
+
+package resources
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+type TestLambdaEventSourceMappingSuite struct {
+	suite.Suite
+	ctx          context.Context
+	cfg          aws.Config
+	lambdaSvc    *lambda.Client
+	sqsSvc       *sqs.Client
+	iamSvc       *iam.Client
+	functionName string
+	roleName     string
+	queueURL     string
+	queueArn     string
+}
+
+func (suite *TestLambdaEventSourceMappingSuite) SetupSuite() {
+	suite.ctx = context.TODO()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	suite.functionName = fmt.Sprintf("aws-nuke-testing-lambda-%s", suffix)
+	suite.roleName = fmt.Sprintf("aws-nuke-testing-role-%s", suffix)
+
+	cfg, err := config.LoadDefaultConfig(suite.ctx, config.WithRegion("us-east-1"))
+	if err != nil {
+		suite.T().Fatalf("failed to load config: %v", err)
+	}
+	suite.cfg = cfg
+
+	suite.lambdaSvc = lambda.NewFromConfig(cfg)
+	suite.sqsSvc = sqs.NewFromConfig(cfg)
+	suite.iamSvc = iam.NewFromConfig(cfg)
+
+	roleArn := suite.createIAMRole(suffix)
+	suite.createSQSQueue(suffix)
+
+	// IAM roles take a few seconds to propagate before Lambda accepts them
+	time.Sleep(15 * time.Second)
+
+	suite.createLambdaFunction(roleArn)
+}
+
+func (suite *TestLambdaEventSourceMappingSuite) createIAMRole(suffix string) string {
+	roleResp, err := suite.iamSvc.CreateRole(suite.ctx, &iam.CreateRoleInput{
+		RoleName: aws.String(suite.roleName),
+		AssumeRolePolicyDocument: aws.String(`{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "Allow",
+				"Principal": {"Service": "lambda.amazonaws.com"},
+				"Action": "sts:AssumeRole"
+			}]
+		}`),
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to create IAM role: %v", err)
+	}
+
+	_, err = suite.iamSvc.AttachRolePolicy(suite.ctx, &iam.AttachRolePolicyInput{
+		RoleName:  aws.String(suite.roleName),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"),
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to attach execution policy: %v", err)
+	}
+
+	return *roleResp.Role.Arn
+}
+
+func (suite *TestLambdaEventSourceMappingSuite) createSQSQueue(suffix string) {
+	queueResp, err := suite.sqsSvc.CreateQueue(suite.ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(fmt.Sprintf("aws-nuke-testing-sqs-%s", suffix)),
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to create SQS queue: %v", err)
+	}
+	suite.queueURL = *queueResp.QueueUrl
+
+	attrResp, err := suite.sqsSvc.GetQueueAttributes(suite.ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       queueResp.QueueUrl,
+		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameQueueArn},
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to get queue ARN: %v", err)
+	}
+	suite.queueArn = attrResp.Attributes[string(sqstypes.QueueAttributeNameQueueArn)]
+}
+
+func (suite *TestLambdaEventSourceMappingSuite) createLambdaFunction(roleArn string) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	f, err := zw.Create("index.py")
+	if err != nil {
+		suite.T().Fatalf("failed to create zip entry: %v", err)
+	}
+	_, err = f.Write([]byte("def handler(event, context): return {}"))
+	if err != nil {
+		suite.T().Fatalf("failed to write zip content: %v", err)
+	}
+	if err = zw.Close(); err != nil {
+		suite.T().Fatalf("failed to close zip: %v", err)
+	}
+
+	_, err = suite.lambdaSvc.CreateFunction(suite.ctx, &lambda.CreateFunctionInput{
+		FunctionName: aws.String(suite.functionName),
+		Role:         aws.String(roleArn),
+		Runtime:      lambdatypes.RuntimePython314,
+		Handler:      aws.String("index.handler"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: buf.Bytes()},
+	})
+	if err != nil {
+		suite.T().Fatalf("failed to create Lambda function: %v", err)
+	}
+
+	waiter := lambda.NewFunctionActiveV2Waiter(suite.lambdaSvc)
+	if err = waiter.Wait(suite.ctx, &lambda.GetFunctionInput{
+		FunctionName: aws.String(suite.functionName),
+	}, 2*time.Minute); err != nil {
+		suite.T().Fatalf("Lambda function did not become active: %v", err)
+	}
+}
+
+func (suite *TestLambdaEventSourceMappingSuite) TearDownSuite() {
+	// Best-effort cleanup of supporting resources
+	_, _ = suite.lambdaSvc.DeleteFunction(suite.ctx, &lambda.DeleteFunctionInput{
+		FunctionName: aws.String(suite.functionName),
+	})
+
+	_, _ = suite.iamSvc.DetachRolePolicy(suite.ctx, &iam.DetachRolePolicyInput{
+		RoleName:  aws.String(suite.roleName),
+		PolicyArn: aws.String("arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"),
+	})
+
+	_, _ = suite.iamSvc.DeleteRole(suite.ctx, &iam.DeleteRoleInput{
+		RoleName: aws.String(suite.roleName),
+	})
+
+	_, _ = suite.sqsSvc.DeleteQueue(suite.ctx, &sqs.DeleteQueueInput{
+		QueueUrl: aws.String(suite.queueURL),
+	})
+}
+
+func (suite *TestLambdaEventSourceMappingSuite) Test_List() {
+	// Create a mapping scoped to this test
+	mappingResp, err := suite.lambdaSvc.CreateEventSourceMapping(suite.ctx, &lambda.CreateEventSourceMappingInput{
+		EventSourceArn: aws.String(suite.queueArn),
+		FunctionName:   aws.String(suite.functionName),
+		Enabled:        aws.Bool(false),
+	})
+	assert.NoError(suite.T(), err)
+
+	defer func() {
+		_, _ = suite.lambdaSvc.DeleteEventSourceMapping(suite.ctx, &lambda.DeleteEventSourceMappingInput{
+			UUID: mappingResp.UUID,
+		})
+	}()
+
+	lister := &LambdaEventSourceMappingLister{}
+	resources, err := lister.List(suite.ctx, &nuke.ListerOpts{Config: &suite.cfg})
+	assert.NoError(suite.T(), err)
+	assert.Greater(suite.T(), len(resources), 0)
+
+	found := false
+	for _, r := range resources {
+		mapping := r.(*LambdaEventSourceMapping)
+		if *mapping.UUID == *mappingResp.UUID {
+			found = true
+			break
+		}
+	}
+	assert.True(suite.T(), found, "expected to find the created event source mapping in list results")
+}
+
+func (suite *TestLambdaEventSourceMappingSuite) Test_Remove() {
+	// Create a mapping to delete
+	mappingResp, err := suite.lambdaSvc.CreateEventSourceMapping(suite.ctx, &lambda.CreateEventSourceMappingInput{
+		EventSourceArn: aws.String(suite.queueArn),
+		FunctionName:   aws.String(suite.functionName),
+		Enabled:        aws.Bool(false),
+	})
+	assert.NoError(suite.T(), err)
+
+	r := &LambdaEventSourceMapping{
+		svc:  suite.lambdaSvc,
+		UUID: mappingResp.UUID,
+	}
+
+	err = r.Remove(suite.ctx)
+	assert.NoError(suite.T(), err)
+
+	// Verify deletion: the mapping should no longer be found
+	out, err := suite.lambdaSvc.ListEventSourceMappings(suite.ctx, &lambda.ListEventSourceMappingsInput{
+		EventSourceArn: aws.String(suite.queueArn),
+		FunctionName:   aws.String(suite.functionName),
+	})
+	assert.NoError(suite.T(), err)
+	for _, m := range out.EventSourceMappings {
+		assert.NotEqual(suite.T(), *mappingResp.UUID, *m.UUID)
+	}
+}
+
+func TestLambdaEventSourceMappingIntegration(t *testing.T) {
+	suite.Run(t, new(TestLambdaEventSourceMappingSuite))
+}

--- a/resources/lambda-event-source-mapping_test.go
+++ b/resources/lambda-event-source-mapping_test.go
@@ -6,6 +6,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -56,10 +57,6 @@ func (suite *TestLambdaEventSourceMappingSuite) SetupSuite() {
 
 	roleArn := suite.createIAMRole(suffix)
 	suite.createSQSQueue(suffix)
-
-	// IAM roles take a few seconds to propagate before Lambda accepts them
-	time.Sleep(15 * time.Second)
-
 	suite.createLambdaFunction(roleArn)
 }
 
@@ -124,15 +121,32 @@ func (suite *TestLambdaEventSourceMappingSuite) createLambdaFunction(roleArn str
 		suite.T().Fatalf("failed to close zip: %v", err)
 	}
 
-	_, err = suite.lambdaSvc.CreateFunction(suite.ctx, &lambda.CreateFunctionInput{
+	input := &lambda.CreateFunctionInput{
 		FunctionName: aws.String(suite.functionName),
 		Role:         aws.String(roleArn),
 		Runtime:      lambdatypes.RuntimePython314,
 		Handler:      aws.String("index.handler"),
 		Code:         &lambdatypes.FunctionCode{ZipFile: buf.Bytes()},
-	})
-	if err != nil {
-		suite.T().Fatalf("failed to create Lambda function: %v", err)
+	}
+
+	// Retry CreateFunction with backoff until the IAM role propagates.
+	deadline := time.Now().Add(2 * time.Minute)
+	delay := 2 * time.Second
+	for {
+		_, err = suite.lambdaSvc.CreateFunction(suite.ctx, input)
+		if err == nil {
+			break
+		}
+		// Lambda returns InvalidParameterValueException when the IAM role has not
+		// yet propagated globally; retry with backoff until it does.
+		var invalidParam *lambdatypes.InvalidParameterValueException
+		if !errors.As(err, &invalidParam) || time.Now().After(deadline) {
+			suite.T().Fatalf("failed to create Lambda function: %v", err)
+		}
+		time.Sleep(delay)
+		if delay < 30*time.Second {
+			delay *= 2
+		}
 	}
 
 	waiter := lambda.NewFunctionActiveV2Waiter(suite.lambdaSvc)

--- a/resources/lambda.go
+++ b/resources/lambda.go
@@ -1,0 +1,14 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+)
+
+type LambdaEventSourceMappingClient interface {
+	ListEventSourceMappings(ctx context.Context, params *lambda.ListEventSourceMappingsInput,
+		optFns ...func(*lambda.Options)) (*lambda.ListEventSourceMappingsOutput, error)
+	DeleteEventSourceMapping(ctx context.Context, params *lambda.DeleteEventSourceMappingInput,
+		optFns ...func(*lambda.Options)) (*lambda.DeleteEventSourceMappingOutput, error)
+}

--- a/resources/lambda.go
+++ b/resources/lambda.go
@@ -9,6 +9,8 @@ import (
 type LambdaEventSourceMappingClient interface {
 	ListEventSourceMappings(ctx context.Context, params *lambda.ListEventSourceMappingsInput,
 		optFns ...func(*lambda.Options)) (*lambda.ListEventSourceMappingsOutput, error)
+	ListTags(ctx context.Context, params *lambda.ListTagsInput,
+		optFns ...func(*lambda.Options)) (*lambda.ListTagsOutput, error)
 	DeleteEventSourceMapping(ctx context.Context, params *lambda.DeleteEventSourceMappingInput,
 		optFns ...func(*lambda.Options)) (*lambda.DeleteEventSourceMappingOutput, error)
 }

--- a/resources/lambda_test.go
+++ b/resources/lambda_test.go
@@ -18,6 +18,12 @@ func (m *mockLambdaEventSourceMappingClient) ListEventSourceMappings(ctx context
 	return args.Get(0).(*lambda.ListEventSourceMappingsOutput), args.Error(1)
 }
 
+func (m *mockLambdaEventSourceMappingClient) ListTags(ctx context.Context, params *lambda.ListTagsInput,
+	_ ...func(*lambda.Options)) (*lambda.ListTagsOutput, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*lambda.ListTagsOutput), args.Error(1)
+}
+
 func (m *mockLambdaEventSourceMappingClient) DeleteEventSourceMapping(ctx context.Context, params *lambda.DeleteEventSourceMappingInput,
 	_ ...func(*lambda.Options)) (*lambda.DeleteEventSourceMappingOutput, error) {
 	args := m.Called(ctx, params)

--- a/resources/lambda_test.go
+++ b/resources/lambda_test.go
@@ -1,0 +1,25 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+)
+
+type mockLambdaEventSourceMappingClient struct {
+	mock.Mock
+}
+
+func (m *mockLambdaEventSourceMappingClient) ListEventSourceMappings(ctx context.Context, params *lambda.ListEventSourceMappingsInput,
+	_ ...func(*lambda.Options)) (*lambda.ListEventSourceMappingsOutput, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*lambda.ListEventSourceMappingsOutput), args.Error(1)
+}
+
+func (m *mockLambdaEventSourceMappingClient) DeleteEventSourceMapping(ctx context.Context, params *lambda.DeleteEventSourceMappingInput,
+	_ ...func(*lambda.Options)) (*lambda.DeleteEventSourceMappingOutput, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*lambda.DeleteEventSourceMappingOutput), args.Error(1)
+}


### PR DESCRIPTION
This pull request addresses #912 and also refactors the `LambdaEventSourceMapping` resource to use the AWS SDK v2, and adds both unit and integration tests. It also updates documentation to reflect the new resource properties and usage.

**Refactor to AWS SDK v2 and Improved Testability:**

- Migrated the `resources/lambda-event-source-mapping.go` implementation from AWS SDK v1 to v2, updating client construction, method calls, and pagination logic. Introduced the `LambdaEventSourceMappingClient` interface for dependency injection and easier mocking in tests. The resource struct now stores individual fields instead of the SDK struct, and tag retrieval is integrated. [[1]](diffhunk://#diff-e0816ad881ea301a005ce9f54a1a36de9da5dc749a21d8b47d22498a87a4d5f5L6-R6) [[2]](diffhunk://#diff-e0816ad881ea301a005ce9f54a1a36de9da5dc749a21d8b47d22498a87a4d5f5L26-R100) [[3]](diffhunk://#diff-f9f61aac2278812c41c51ec3390d53d9fca032895b660269063d9976127190e2R1-R16)
- Added a mock implementation of `LambdaEventSourceMappingClient` in `resources/lambda_test.go` to facilitate unit testing.

**Testing Improvements:**

- Added comprehensive unit tests for listing, removing, and property retrieval of `LambdaEventSourceMapping` in `resources/lambda-event-source-mapping_mock_test.go`, using the new mock client.
- Introduced an integration test suite in `resources/lambda-event-source-mapping_test.go` to verify end-to-end behavior of listing and removing Lambda event source mappings, including setup and teardown of real AWS resources.

**Documentation and Dependency Updates:**

- Updated the generated documentation (`docs/resources/lambda-event-source-mapping.md`) to document all properties of the `LambdaEventSourceMapping` resource and explain how to use them in filters.
- Added the `github.com/aws/aws-sdk-go-v2/service/sqs` dependency in `go.mod` to support integration tests.