### PR TITLE
fix(eks): delete cluster capabilities before removing cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.239.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.54.6
 	github.com/aws/aws-sdk-go-v2/service/efs v1.35.4
-	github.com/aws/aws-sdk-go-v2/service/eks v1.74.10
+	github.com/aws/aws-sdk-go-v2/service/eks v1.76.4
 	github.com/aws/aws-sdk-go-v2/service/iam v1.38.10
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.44.12
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.46.6

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.54.6 h1:TE4XBXeHvTTnD4rISqqMET4TwE7S
 github.com/aws/aws-sdk-go-v2/service/ecs v1.54.6/go.mod h1:wAtdeFanDuF9Re/ge4DRDaYe3Wy1OGrU7jG042UcuI4=
 github.com/aws/aws-sdk-go-v2/service/efs v1.35.4 h1:QJHwC9X5TxJJGdesIJP65gAsu0gXCGs0nF2/wBe4aAA=
 github.com/aws/aws-sdk-go-v2/service/efs v1.35.4/go.mod h1:XT6hcgC1HV33EBGPWdXnbgyeqND4k43qX3argLyEZM8=
-github.com/aws/aws-sdk-go-v2/service/eks v1.74.10 h1:bkpRyAmbBYuMKx4ZfmVLRdTwewAXGy1S0LrvH1BFz2M=
-github.com/aws/aws-sdk-go-v2/service/eks v1.74.10/go.mod h1:lrJRZkSj6nIXH/SN3gbGQp4i4AtNyha0wT7VgYZ3KDw=
+github.com/aws/aws-sdk-go-v2/service/eks v1.76.4 h1:5f9jIMcEd0wvRpEoo925Ltfw/2Yalcf+amFm3e1tRd8=
+github.com/aws/aws-sdk-go-v2/service/eks v1.76.4/go.mod h1:Qg678m+87sCuJhcsZojenz8mblYG+Tq86V4m3hjVz0s=
 github.com/aws/aws-sdk-go-v2/service/iam v1.38.10 h1:u/MwkFwRkKRDvy7D76/khJTk8HMp4mC5sZKErU53jos=
 github.com/aws/aws-sdk-go-v2/service/iam v1.38.10/go.mod h1:Gid0WEVky3EWbkeXiS67kHhbiK+q3/wO/hvPh7plR0c=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.44.12 h1:KC35deDW2vbbXPW14nUGgpf1lv3Qdg1wHhD9a1c2WDY=

--- a/resources/eks-clusters.go
+++ b/resources/eks-clusters.go
@@ -2,11 +2,12 @@ package resources
 
 import (
 	"context"
-
+	"errors"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/gotidy/ptr"
 
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -87,11 +88,48 @@ func (r *EKSCluster) Remove(ctx context.Context) error {
 			return err
 		}
 	}
+
+	if err := r.removeCapabilities(ctx); err != nil {
+		return err
+	}
+
 	_, err := r.svc.DeleteCluster(ctx, &eks.DeleteClusterInput{
 		Name: r.Name,
 	})
 
 	return err
+}
+
+func (r *EKSCluster) removeCapabilities(ctx context.Context) error {
+	params := &eks.ListCapabilitiesInput{
+		ClusterName: r.Name,
+		MaxResults:  aws.Int32(100),
+	}
+
+	paginator := eks.NewListCapabilitiesPaginator(r.svc, params)
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, capability := range resp.Capabilities {
+			_, err := r.svc.DeleteCapability(ctx, &eks.DeleteCapabilityInput{
+				ClusterName:    r.Name,
+				CapabilityName: capability.CapabilityName,
+			})
+			if err != nil {
+				var notFound *ekstypes.ResourceNotFoundException
+				if errors.As(err, &notFound) {
+					continue
+				}
+
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *EKSCluster) Properties() types.Properties {

--- a/resources/eks-clusters_mock_test.go
+++ b/resources/eks-clusters_mock_test.go
@@ -1,0 +1,23 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/gotidy/ptr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEKSClusterProperties(t *testing.T) {
+	resource := &EKSCluster{
+		Name: ptr.String("test-cluster"),
+		Tags: map[string]string{
+			"Environment": "test",
+		},
+	}
+
+	properties := resource.Properties()
+
+	assert.Equal(t, "test-cluster", properties.Get("Name"))
+	assert.Equal(t, "test", properties.Get("tag:Environment"))
+	assert.Equal(t, "test-cluster", resource.String())
+}


### PR DESCRIPTION
## Summary
- Delete EKS cluster capabilities before calling DeleteCluster
- Fixes ResourceInUseException: Cluster has capabilities attached
- Bump EKS SDK to v1.76.4 for ListCapabilities/DeleteCapability support

## Test plan
- [ ] go test ./resources/ -run TestEKSCluster
- [ ] Re-run aws-nuke against cluster pg-backup-central-k8s