### PR TITLE
feat: add VPC Lattice resource support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/textract v1.40.22
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5
+	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.22.2
 	github.com/aws/smithy-go v1.27.2
 	github.com/ekristen/libnuke v1.3.0
 	github.com/fatih/color v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6 h1:Cjn8vN7HcVipJ
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6/go.mod h1:obaEZourm+uDHiBOTkxJ1y/RF1WU8GtywWBee2hxm6k=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5 h1:3CgAcyZciL7KG/8LCEWWoMJfZvgZV2xUzjtNGDlaBVQ=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5/go.mod h1:NJBUE6GjnjqSvexXpU0pj/2w+VEhRk5XPL5rRZpj7bI=
+github.com/aws/aws-sdk-go-v2/service/vpclattice v1.22.2 h1:q9xVCezxBqFAv/sJakd63MZ564MxOY8CDfWuiih9awM=
+github.com/aws/aws-sdk-go-v2/service/vpclattice v1.22.2/go.mod h1:iMZnTuSYmfTgpqnzEni1JqeO0Ar/ZItPumptLBMb8/A=
 github.com/aws/smithy-go v1.27.2 h1:y9NPmSE6am6LjEFPfqHqG/jJk7AauQvhCJONKh7kpzk=
 github.com/aws/smithy-go v1.27.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=

--- a/resources/vpclattice-resource-configuration.go
+++ b/resources/vpclattice-resource-configuration.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	vpclatticeTypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
@@ -45,6 +46,13 @@ func (l *VPCLatticeResourceConfigurationLister) List(ctx context.Context, o inte
 		}
 
 		for i := range resp.Items {
+			tagResp, err := svc.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: resp.Items[i].Arn,
+			})
+			if err != nil {
+				return nil, err
+			}
+
 			resources = append(resources, &VPCLatticeResourceConfiguration{
 				svc:           svc,
 				ID:            resp.Items[i].Id,
@@ -53,6 +61,8 @@ func (l *VPCLatticeResourceConfigurationLister) List(ctx context.Context, o inte
 				Status:        string(resp.Items[i].Status),
 				Type:          string(resp.Items[i].Type),
 				AmazonManaged: resp.Items[i].AmazonManaged,
+				CreatedAt:     resp.Items[i].CreatedAt,
+				Tags:          tagResp.Tags,
 			})
 		}
 	}
@@ -68,6 +78,8 @@ type VPCLatticeResourceConfiguration struct {
 	Status        string
 	Type          string
 	AmazonManaged *bool
+	CreatedAt     *time.Time
+	Tags          map[string]string
 }
 
 func (r *VPCLatticeResourceConfiguration) Filter() error {

--- a/resources/vpclattice-resource-configuration.go
+++ b/resources/vpclattice-resource-configuration.go
@@ -1,0 +1,99 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	vpclatticeTypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const VPCLatticeResourceConfigurationResource = "VPCLatticeResourceConfiguration"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     VPCLatticeResourceConfigurationResource,
+		Scope:    nuke.Account,
+		Resource: &VPCLatticeResourceConfiguration{},
+		Lister:   &VPCLatticeResourceConfigurationLister{},
+		DependsOn: []string{
+			"VPCLatticeServiceNetworkResourceAssociation",
+		},
+	})
+}
+
+type VPCLatticeResourceConfigurationLister struct{}
+
+func (l *VPCLatticeResourceConfigurationLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := vpclattice.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	params := &vpclattice.ListResourceConfigurationsInput{}
+	paginator := vpclattice.NewListResourceConfigurationsPaginator(svc, params)
+
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range resp.Items {
+			resources = append(resources, &VPCLatticeResourceConfiguration{
+				svc:           svc,
+				ID:            resp.Items[i].Id,
+				Name:          resp.Items[i].Name,
+				ARN:           resp.Items[i].Arn,
+				Status:        string(resp.Items[i].Status),
+				Type:          string(resp.Items[i].Type),
+				AmazonManaged: resp.Items[i].AmazonManaged,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+type VPCLatticeResourceConfiguration struct {
+	svc           *vpclattice.Client
+	ID            *string
+	Name          *string
+	ARN           *string
+	Status        string
+	Type          string
+	AmazonManaged *bool
+}
+
+func (r *VPCLatticeResourceConfiguration) Filter() error {
+	if r.AmazonManaged != nil && *r.AmazonManaged {
+		return fmt.Errorf("cannot delete Amazon managed resource")
+	}
+	switch vpclatticeTypes.ResourceConfigurationStatus(r.Status) {
+	case vpclatticeTypes.ResourceConfigurationStatusDeleteInProgress,
+		vpclatticeTypes.ResourceConfigurationStatusCreateInProgress,
+		vpclatticeTypes.ResourceConfigurationStatusUpdateInProgress:
+		return fmt.Errorf("resource configuration is in %s state", r.Status)
+	}
+	return nil
+}
+
+func (r *VPCLatticeResourceConfiguration) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteResourceConfiguration(ctx, &vpclattice.DeleteResourceConfigurationInput{
+		ResourceConfigurationIdentifier: r.ID,
+	})
+	return err
+}
+
+func (r *VPCLatticeResourceConfiguration) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *VPCLatticeResourceConfiguration) String() string {
+	return *r.Name
+}

--- a/resources/vpclattice-resource-gateway.go
+++ b/resources/vpclattice-resource-gateway.go
@@ -1,0 +1,94 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	vpclatticeTypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const VPCLatticeResourceGatewayResource = "VPCLatticeResourceGateway"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     VPCLatticeResourceGatewayResource,
+		Scope:    nuke.Account,
+		Resource: &VPCLatticeResourceGateway{},
+		Lister:   &VPCLatticeResourceGatewayLister{},
+		DependsOn: []string{
+			"VPCLatticeResourceConfiguration",
+		},
+	})
+}
+
+type VPCLatticeResourceGatewayLister struct{}
+
+func (l *VPCLatticeResourceGatewayLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := vpclattice.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	params := &vpclattice.ListResourceGatewaysInput{}
+	paginator := vpclattice.NewListResourceGatewaysPaginator(svc, params)
+
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range resp.Items {
+			resources = append(resources, &VPCLatticeResourceGateway{
+				svc:           svc,
+				ID:            resp.Items[i].Id,
+				Name:          resp.Items[i].Name,
+				ARN:           resp.Items[i].Arn,
+				Status:        string(resp.Items[i].Status),
+				IPAddressType: string(resp.Items[i].IpAddressType),
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+type VPCLatticeResourceGateway struct {
+	svc           *vpclattice.Client
+	ID            *string
+	Name          *string
+	ARN           *string
+	Status        string
+	IPAddressType string
+}
+
+func (r *VPCLatticeResourceGateway) Filter() error {
+	switch vpclatticeTypes.ResourceGatewayStatus(r.Status) {
+	case vpclatticeTypes.ResourceGatewayStatusDeleteInProgress,
+		vpclatticeTypes.ResourceGatewayStatusCreateInProgress,
+		vpclatticeTypes.ResourceGatewayStatusUpdateInProgress:
+		return fmt.Errorf("resource gateway is in %s state", r.Status)
+	}
+	return nil
+}
+
+func (r *VPCLatticeResourceGateway) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteResourceGateway(ctx, &vpclattice.DeleteResourceGatewayInput{
+		ResourceGatewayIdentifier: r.ID,
+	})
+	return err
+}
+
+func (r *VPCLatticeResourceGateway) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *VPCLatticeResourceGateway) String() string {
+	return *r.Name
+}

--- a/resources/vpclattice-resource-gateway.go
+++ b/resources/vpclattice-resource-gateway.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	vpclatticeTypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
@@ -45,6 +46,13 @@ func (l *VPCLatticeResourceGatewayLister) List(ctx context.Context, o interface{
 		}
 
 		for i := range resp.Items {
+			tagResp, err := svc.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: resp.Items[i].Arn,
+			})
+			if err != nil {
+				return nil, err
+			}
+
 			resources = append(resources, &VPCLatticeResourceGateway{
 				svc:           svc,
 				ID:            resp.Items[i].Id,
@@ -52,6 +60,8 @@ func (l *VPCLatticeResourceGatewayLister) List(ctx context.Context, o interface{
 				ARN:           resp.Items[i].Arn,
 				Status:        string(resp.Items[i].Status),
 				IPAddressType: string(resp.Items[i].IpAddressType),
+				CreatedAt:     resp.Items[i].CreatedAt,
+				Tags:          tagResp.Tags,
 			})
 		}
 	}
@@ -66,6 +76,8 @@ type VPCLatticeResourceGateway struct {
 	ARN           *string
 	Status        string
 	IPAddressType string
+	CreatedAt     *time.Time
+	Tags          map[string]string
 }
 
 func (r *VPCLatticeResourceGateway) Filter() error {

--- a/resources/vpclattice-service-network-resource-association.go
+++ b/resources/vpclattice-service-network-resource-association.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	vpclatticeTypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
@@ -42,6 +43,13 @@ func (l *VPCLatticeServiceNetworkResourceAssociationLister) List(ctx context.Con
 		}
 
 		for i := range resp.Items {
+			tagResp, err := svc.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: resp.Items[i].Arn,
+			})
+			if err != nil {
+				return nil, err
+			}
+
 			resources = append(resources, &VPCLatticeServiceNetworkResourceAssociation{
 				svc:                       svc,
 				ID:                        resp.Items[i].Id,
@@ -50,6 +58,8 @@ func (l *VPCLatticeServiceNetworkResourceAssociationLister) List(ctx context.Con
 				ServiceNetworkName:        resp.Items[i].ServiceNetworkName,
 				ResourceConfigurationName: resp.Items[i].ResourceConfigurationName,
 				IsManagedAssociation:      resp.Items[i].IsManagedAssociation,
+				CreatedAt:                 resp.Items[i].CreatedAt,
+				Tags:                      tagResp.Tags,
 			})
 		}
 	}
@@ -65,6 +75,8 @@ type VPCLatticeServiceNetworkResourceAssociation struct {
 	ServiceNetworkName        *string
 	ResourceConfigurationName *string
 	IsManagedAssociation      *bool
+	CreatedAt                 *time.Time
+	Tags                      map[string]string
 }
 
 func (r *VPCLatticeServiceNetworkResourceAssociation) Filter() error {

--- a/resources/vpclattice-service-network-resource-association.go
+++ b/resources/vpclattice-service-network-resource-association.go
@@ -1,0 +1,95 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	vpclatticeTypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const VPCLatticeServiceNetworkResourceAssociationResource = "VPCLatticeServiceNetworkResourceAssociation"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     VPCLatticeServiceNetworkResourceAssociationResource,
+		Scope:    nuke.Account,
+		Resource: &VPCLatticeServiceNetworkResourceAssociation{},
+		Lister:   &VPCLatticeServiceNetworkResourceAssociationLister{},
+	})
+}
+
+type VPCLatticeServiceNetworkResourceAssociationLister struct{}
+
+func (l *VPCLatticeServiceNetworkResourceAssociationLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := vpclattice.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	params := &vpclattice.ListServiceNetworkResourceAssociationsInput{}
+	paginator := vpclattice.NewListServiceNetworkResourceAssociationsPaginator(svc, params)
+
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range resp.Items {
+			resources = append(resources, &VPCLatticeServiceNetworkResourceAssociation{
+				svc:                       svc,
+				ID:                        resp.Items[i].Id,
+				ARN:                       resp.Items[i].Arn,
+				Status:                    string(resp.Items[i].Status),
+				ServiceNetworkName:        resp.Items[i].ServiceNetworkName,
+				ResourceConfigurationName: resp.Items[i].ResourceConfigurationName,
+				IsManagedAssociation:      resp.Items[i].IsManagedAssociation,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+type VPCLatticeServiceNetworkResourceAssociation struct {
+	svc                       *vpclattice.Client
+	ID                        *string
+	ARN                       *string
+	Status                    string
+	ServiceNetworkName        *string
+	ResourceConfigurationName *string
+	IsManagedAssociation      *bool
+}
+
+func (r *VPCLatticeServiceNetworkResourceAssociation) Filter() error {
+	if r.IsManagedAssociation != nil && *r.IsManagedAssociation {
+		return fmt.Errorf("cannot delete managed association")
+	}
+	switch vpclatticeTypes.ServiceNetworkResourceAssociationStatus(r.Status) {
+	case vpclatticeTypes.ServiceNetworkResourceAssociationStatusDeleteInProgress,
+		vpclatticeTypes.ServiceNetworkResourceAssociationStatusCreateInProgress:
+		return fmt.Errorf("service network resource association is in %s state", r.Status)
+	}
+	return nil
+}
+
+func (r *VPCLatticeServiceNetworkResourceAssociation) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteServiceNetworkResourceAssociation(ctx, &vpclattice.DeleteServiceNetworkResourceAssociationInput{
+		ServiceNetworkResourceAssociationIdentifier: r.ID,
+	})
+	return err
+}
+
+func (r *VPCLatticeServiceNetworkResourceAssociation) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *VPCLatticeServiceNetworkResourceAssociation) String() string {
+	return *r.ID
+}


### PR DESCRIPTION
## Summary

Add support for three VPC Lattice resource types:

- `VPCLatticeResourceGateway`
- `VPCLatticeResourceConfiguration`
- `VPCLatticeServiceNetworkResourceAssociation`

## Details

- Pagination support using SDK v2 built-in paginators
- Filter out resources in transitional states (DELETE_IN_PROGRESS, CREATE_IN_PROGRESS, UPDATE_IN_PROGRESS)
- Filter out AWS-managed resources (amazonManaged, isManagedAssociation)
- Deletion ordering via DependsOn: Association → Configuration → Gateway

Closes #518