### PR TITLE
fix(awsutil): let SkipRegionalForGlobalService honor explicit aws-global clients

### DIFF
--- a/pkg/awsutil/config.go
+++ b/pkg/awsutil/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
@@ -218,6 +219,12 @@ func (SkipRegionalForGlobalService) HandleInitialize(
 	service := middleware.GetServiceID(ctx)
 
 	if IsGlobalService(service) {
+		// Allow callers that explicitly built the client for aws-global —
+		// the sanctioned pattern for code that needs a global service from
+		// a regional context (e.g. CreateRoleToDeleteStack recovery).
+		if awsmiddleware.GetRegion(ctx) == "aws-global" {
+			return next.HandleInitialize(ctx, in)
+		}
 		return out, md, liberrors.ErrSkipRequest(
 			fmt.Sprintf("service '%s' is global, but the session is not", service))
 	}

--- a/pkg/awsutil/config.go
+++ b/pkg/awsutil/config.go
@@ -205,6 +205,14 @@ func (SkipGlobal) HandleInitialize(
 // when operating in a non-global region context. This ensures global
 // services like CloudFront and IAM are only processed once in the
 // "global" pseudo-region rather than in every regional scan.
+//
+// Resources that need a global-service client from a regional scanner
+// (e.g. CloudFormationStack.CreateRoleToDeleteStack recovery) should
+// build the client with Region = "aws-global" to bypass this filter:
+//
+//	iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
+//	    o.Region = "aws-global"
+//	})
 type SkipRegionalForGlobalService struct{}
 
 func (SkipRegionalForGlobalService) ID() string {

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	"github.com/aws/smithy-go/middleware"
 
 	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -61,17 +60,12 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 	opts := o.(*nuke.ListerOpts)
 
 	svc := cloudformation.New(opts.Session)
-	// IAM is a global service: pin to aws-global and strip the
-	// SkipRegionalForGlobalService middleware that NewConfig adds to every
-	// regional config (awsutil/config.go:213). Without this, CreateRole
-	// (used by CreateRoleToDeleteStack to rebuild a stack's missing RoleARN)
-	// is refused with "service 'IAM' is global, but the session is not".
+	// IAM is a global service: pin the client to aws-global so the
+	// SkipRegionalForGlobalService middleware lets it through. Needed for
+	// CreateRoleToDeleteStack's role-recovery path, which must call IAM
+	// from this regional stack scanner.
 	iamSvc := iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
 		o.Region = "aws-global"
-		o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
-			_, _ = stack.Initialize.Remove("aws-nuke::skipRegionalForGlobalService")
-			return nil
-		})
 	})
 	stsSvc := sts.New(opts.Session)
 

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -60,6 +60,7 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 	opts := o.(*nuke.ListerOpts)
 
 	svc := cloudformation.New(opts.Session)
+	// Pinned to aws-global; see awsutil.SkipRegionalForGlobalService.
 	iamSvc := iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
 		o.Region = "aws-global"
 	})

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/smithy-go/middleware"
 
 	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	"github.com/ekristen/libnuke/pkg/registry"
@@ -60,7 +61,18 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 	opts := o.(*nuke.ListerOpts)
 
 	svc := cloudformation.New(opts.Session)
-	iamSvc := iam.NewFromConfig(*opts.Config)
+	// IAM is a global service: pin to aws-global and strip the
+	// SkipRegionalForGlobalService middleware that NewConfig adds to every
+	// regional config (awsutil/config.go:213). Without this, CreateRole
+	// (used by CreateRoleToDeleteStack to rebuild a stack's missing RoleARN)
+	// is refused with "service 'IAM' is global, but the session is not".
+	iamSvc := iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
+		o.Region = "aws-global"
+		o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
+			_, _ = stack.Initialize.Remove("aws-nuke::skipRegionalForGlobalService")
+			return nil
+		})
+	})
 	stsSvc := sts.New(opts.Session)
 
 	params := &cloudformation.DescribeStacksInput{}

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -60,10 +60,6 @@ func (l *CloudFormationStackLister) List(_ context.Context, o interface{}) ([]re
 	opts := o.(*nuke.ListerOpts)
 
 	svc := cloudformation.New(opts.Session)
-	// IAM is a global service: pin the client to aws-global so the
-	// SkipRegionalForGlobalService middleware lets it through. Needed for
-	// CreateRoleToDeleteStack's role-recovery path, which must call IAM
-	// from this regional stack scanner.
 	iamSvc := iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
 		o.Region = "aws-global"
 	})

--- a/resources/ssmquicksetup-configuration-manager.go
+++ b/resources/ssmquicksetup-configuration-manager.go
@@ -51,6 +51,7 @@ func (l *SSMQuickSetupConfigurationManagerLister) List(ctx context.Context, o in
 	for _, p := range res.ConfigurationManagersList {
 		resources = append(resources, &SSMQuickSetupConfigurationManager{
 			svc: svc,
+			// Pinned to aws-global; see awsutil.SkipRegionalForGlobalService.
 			iamSvc: iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
 				o.Region = "aws-global"
 			}),

--- a/resources/ssmquicksetup-configuration-manager.go
+++ b/resources/ssmquicksetup-configuration-manager.go
@@ -51,9 +51,6 @@ func (l *SSMQuickSetupConfigurationManagerLister) List(ctx context.Context, o in
 	for _, p := range res.ConfigurationManagersList {
 		resources = append(resources, &SSMQuickSetupConfigurationManager{
 			svc: svc,
-			// IAM is a global service: pin the client to aws-global so the
-			// SkipRegionalForGlobalService middleware lets it through.
-			// Needed for CreateRoleToDelete's role-recovery path.
 			iamSvc: iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
 				o.Region = "aws-global"
 			}),

--- a/resources/ssmquicksetup-configuration-manager.go
+++ b/resources/ssmquicksetup-configuration-manager.go
@@ -50,8 +50,13 @@ func (l *SSMQuickSetupConfigurationManagerLister) List(ctx context.Context, o in
 
 	for _, p := range res.ConfigurationManagersList {
 		resources = append(resources, &SSMQuickSetupConfigurationManager{
-			svc:          svc,
-			iamSvc:       iam.NewFromConfig(*opts.Config),
+			svc: svc,
+			// IAM is a global service: pin the client to aws-global so the
+			// SkipRegionalForGlobalService middleware lets it through.
+			// Needed for CreateRoleToDelete's role-recovery path.
+			iamSvc: iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
+				o.Region = "aws-global"
+			}),
 			stsSvc:       sts.NewFromConfig(*opts.Config),
 			ARN:          p.ManagerArn,
 			Name:         p.Name,


### PR DESCRIPTION
`CreateRoleToDeleteStack` (CloudFormationStack) and `CreateRoleToDelete` (SSMQuickSetupConfigurationManager) both build an IAM client from the regional `opts.Config` and call `iam.CreateRole` to recreate a missing role. The `SkipRegionalForGlobalService` middleware that `NewConfig` attaches to every regional config refuses these calls:

```
operation error IAM: CreateRole, service 'IAM' is global, but the session is not
```

Move the workaround into the middleware itself: clients explicitly built with `Region = "aws-global"` pass through. Accidental misuse (no region override) is still blocked with the original error.

Resources that legitimately need IAM from a regional scanner can now just set `o.Region = "aws-global"` on the client.