### PR TITLE
fix(bedrock-inference-profile): skip tag lookup for system-defined profiles

### DIFF
--- a/resources/bedrock-inference-profiles.go
+++ b/resources/bedrock-inference-profiles.go
@@ -18,6 +18,17 @@ import (
 
 const BedrockInferenceProfileResource = "BedrockInferenceProfile"
 
+// BedrockInferenceProfileClient is the interface for the bedrock operations used by the inference
+// profile lister and resource. It exists so the List and Remove paths can be exercised with a mock.
+type BedrockInferenceProfileClient interface {
+	ListInferenceProfiles(ctx context.Context, params *bedrock.ListInferenceProfilesInput,
+		optFns ...func(*bedrock.Options)) (*bedrock.ListInferenceProfilesOutput, error)
+	ListTagsForResource(ctx context.Context, params *bedrock.ListTagsForResourceInput,
+		optFns ...func(*bedrock.Options)) (*bedrock.ListTagsForResourceOutput, error)
+	DeleteInferenceProfile(ctx context.Context, params *bedrock.DeleteInferenceProfileInput,
+		optFns ...func(*bedrock.Options)) (*bedrock.DeleteInferenceProfileOutput, error)
+}
+
 func init() {
 	registry.Register(&registry.Registration{
 		Name:     BedrockInferenceProfileResource,
@@ -27,11 +38,20 @@ func init() {
 	})
 }
 
-type BedrockInferenceProfileLister struct{}
+type BedrockInferenceProfileLister struct {
+	mockSvc BedrockInferenceProfileClient
+}
 
 func (l *BedrockInferenceProfileLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
-	svc := bedrock.NewFromConfig(*opts.Config)
+
+	var svc BedrockInferenceProfileClient
+	if l.mockSvc != nil {
+		svc = l.mockSvc
+	} else {
+		svc = bedrock.NewFromConfig(*opts.Config)
+	}
+
 	var resources []resource.Resource
 
 	params := &bedrock.ListInferenceProfilesInput{
@@ -48,12 +68,15 @@ func (l *BedrockInferenceProfileLister) List(ctx context.Context, o interface{})
 
 		for _, profile := range resp.InferenceProfileSummaries {
 			var tags map[string]string
-			if profile.InferenceProfileArn != nil {
+			// Only application inference profiles support tagging. System-defined
+			// (cross-Region) profiles reject ListTagsForResource, so skip them to
+			// avoid noisy warnings for resources that are filtered out anyway.
+			if profile.Type == bedrocktypes.InferenceProfileTypeApplication && profile.InferenceProfileArn != nil {
 				tagsResp, err := svc.ListTagsForResource(ctx, &bedrock.ListTagsForResourceInput{
 					ResourceARN: profile.InferenceProfileArn,
 				})
 				if err != nil {
-					opts.Logger.Warnf("unable to fetch tags for inference profile: %s", *profile.InferenceProfileArn)
+					opts.Logger.WithError(err).Warnf("unable to fetch tags for inference profile: %s", *profile.InferenceProfileArn)
 				} else {
 					tags = make(map[string]string)
 					for _, tag := range tagsResp.Tags {
@@ -81,7 +104,7 @@ func (l *BedrockInferenceProfileLister) List(ctx context.Context, o interface{})
 }
 
 type BedrockInferenceProfile struct {
-	svc         *bedrock.Client
+	svc         BedrockInferenceProfileClient
 	ID          *string
 	Name        *string
 	ARN         *string

--- a/resources/bedrock-inference-profiles_mock_test.go
+++ b/resources/bedrock-inference-profiles_mock_test.go
@@ -1,14 +1,39 @@
 package resources
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/gotidy/ptr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 )
+
+type mockBedrockInferenceProfileClient struct {
+	mock.Mock
+}
+
+func (m *mockBedrockInferenceProfileClient) ListInferenceProfiles(ctx context.Context,
+	params *bedrock.ListInferenceProfilesInput, _ ...func(*bedrock.Options)) (*bedrock.ListInferenceProfilesOutput, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*bedrock.ListInferenceProfilesOutput), args.Error(1)
+}
+
+func (m *mockBedrockInferenceProfileClient) ListTagsForResource(ctx context.Context,
+	params *bedrock.ListTagsForResourceInput, _ ...func(*bedrock.Options)) (*bedrock.ListTagsForResourceOutput, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*bedrock.ListTagsForResourceOutput), args.Error(1)
+}
+
+func (m *mockBedrockInferenceProfileClient) DeleteInferenceProfile(ctx context.Context,
+	params *bedrock.DeleteInferenceProfileInput, _ ...func(*bedrock.Options)) (*bedrock.DeleteInferenceProfileOutput, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*bedrock.DeleteInferenceProfileOutput), args.Error(1)
+}
 
 func Test_BedrockInferenceProfile_Properties(t *testing.T) {
 	a := assert.New(t)
@@ -77,4 +102,74 @@ func Test_BedrockInferenceProfile_Filter_Application(t *testing.T) {
 
 	err := resource.Filter()
 	a.Nil(err)
+}
+
+// Test_Mock_BedrockInferenceProfile_List_SystemDefined verifies that the lister does not attempt to
+// fetch tags for system-defined inference profiles, which do not support tagging. If ListTagsForResource
+// were called, the mock would panic because no expectation is registered for it.
+func Test_Mock_BedrockInferenceProfile_List_SystemDefined(t *testing.T) {
+	a := assert.New(t)
+
+	mockSvc := new(mockBedrockInferenceProfileClient)
+
+	arn := "arn:aws:bedrock:us-east-2:123456789012:inference-profile/us.anthropic.claude-sonnet-5"
+	mockSvc.On("ListInferenceProfiles", mock.Anything, mock.Anything).Return(&bedrock.ListInferenceProfilesOutput{
+		InferenceProfileSummaries: []bedrocktypes.InferenceProfileSummary{
+			{
+				InferenceProfileId:   ptr.String("us.anthropic.claude-sonnet-5"),
+				InferenceProfileName: ptr.String("Claude Sonnet 5"),
+				InferenceProfileArn:  ptr.String(arn),
+				Type:                 bedrocktypes.InferenceProfileTypeSystemDefined,
+			},
+		},
+	}, nil)
+
+	lister := BedrockInferenceProfileLister{mockSvc: mockSvc}
+
+	resources, err := lister.List(context.TODO(), testListerOpts)
+	a.Nil(err)
+	a.Len(resources, 1)
+
+	profile := resources[0].(*BedrockInferenceProfile)
+	a.Nil(profile.Tags)
+	mockSvc.AssertNotCalled(t, "ListTagsForResource", mock.Anything, mock.Anything)
+	mockSvc.AssertExpectations(t)
+}
+
+// Test_Mock_BedrockInferenceProfile_List_Application verifies that the lister fetches and maps tags
+// for application (user-created) inference profiles, which do support tagging.
+func Test_Mock_BedrockInferenceProfile_List_Application(t *testing.T) {
+	a := assert.New(t)
+
+	mockSvc := new(mockBedrockInferenceProfileClient)
+
+	arn := "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/abc123"
+	mockSvc.On("ListInferenceProfiles", mock.Anything, mock.Anything).Return(&bedrock.ListInferenceProfilesOutput{
+		InferenceProfileSummaries: []bedrocktypes.InferenceProfileSummary{
+			{
+				InferenceProfileId:   ptr.String("abc123"),
+				InferenceProfileName: ptr.String("my-app-profile"),
+				InferenceProfileArn:  ptr.String(arn),
+				Type:                 bedrocktypes.InferenceProfileTypeApplication,
+			},
+		},
+	}, nil)
+
+	mockSvc.On("ListTagsForResource", mock.Anything, &bedrock.ListTagsForResourceInput{
+		ResourceARN: ptr.String(arn),
+	}).Return(&bedrock.ListTagsForResourceOutput{
+		Tags: []bedrocktypes.Tag{
+			{Key: ptr.String("Environment"), Value: ptr.String("test")},
+		},
+	}, nil)
+
+	lister := BedrockInferenceProfileLister{mockSvc: mockSvc}
+
+	resources, err := lister.List(context.TODO(), testListerOpts)
+	a.Nil(err)
+	a.Len(resources, 1)
+
+	profile := resources[0].(*BedrockInferenceProfile)
+	a.Equal("test", profile.Tags["Environment"])
+	mockSvc.AssertExpectations(t)
 }


### PR DESCRIPTION
System-defined (cross-Region) inference profiles do not support tagging, so ListTagsForResource was failing for every one of them and emitting a warning, even though they are filtered out at removal time anyway. Only fetch tags for application (user-created) profiles, and include the underlying error in the warning when a real tag lookup does fail.

Adds an injectable client interface and mock-backed lister tests covering both the system-defined skip path and the application tag path.