### PR TITLE
fix(quicksight): handle identity region mismatch and termination protection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8
-	github.com/aws/aws-sdk-go-v2 v1.42.0
+	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.28.11
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.71
 	github.com/aws/aws-sdk-go-v2/service/amp v1.36.0
@@ -31,6 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.17.6
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.53.0
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8
+	github.com/aws/aws-sdk-go-v2/service/quicksight v1.118.1
 	github.com/aws/aws-sdk-go-v2/service/ram v1.34.19
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.17
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.41.5
@@ -46,7 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/textract v1.40.22
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5
-	github.com/aws/smithy-go v1.27.2
+	github.com/aws/smithy-go v1.27.3
 	github.com/ekristen/libnuke v1.3.0
 	github.com/fatih/color v1.19.0
 	github.com/golang/mock v1.6.0
@@ -66,8 +67,8 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
-github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
-github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
+github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
+github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.28.11 h1:7Ekru0IkRHRnSRWGQLnLN6i0o1Jncd0rHo2T130+tEQ=
@@ -10,10 +10,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.17.71 h1:r2w4mQWnrTMJjOyIsZtGp3R3XGY
 github.com/aws/aws-sdk-go-v2/credentials v1.17.71/go.mod h1:E7VF3acIup4GB5ckzbKFrCK0vTvEQxOxgdq4U3vcMCY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33 h1:D9ixiWSG4lyUBL2DDNK924Px9V/NBVpML90MHqyTADY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33/go.mod h1:caS/m4DI+cij2paz3rtProRBI4s/+TCiWoaWZuQ9010=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 h1:xM/Is9cKMHa8Jj8zkvWhvrFkZsXJV9E+BB4g0HW0duQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30/go.mod h1:WueJeNDZvK1fMYEWJIkcivBfEzUkTpBhzlrUKKY8EuA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 h1:jn46zC9LdsVR/ZpMIJqMqb8hHv31BlLx3ulVqNspUOk=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30/go.mod h1:1hTMsAgbdS/AtUi4bw8+gUuh1pceo+eXRLfpSuSQj3M=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvKgqdiXoTxAF4HQcQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -74,6 +74,8 @@ github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.53.0 h1:FHl1QPk+MTUjcbGt
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.53.0/go.mod h1:EiHBjTVCeOUX045RTpHUuqrtexp4OtSbMLj+nXiaaHw=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8 h1:fMFheeWMyC7aGeTIz+GJAaKanfOtOzOg78q/v0jKA4E=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.34.8/go.mod h1:S8/FKYPSm2WEEGMs5gmbrOrULz0zvJ1CYkf2UEnYzYw=
+github.com/aws/aws-sdk-go-v2/service/quicksight v1.118.1 h1:HA69jyy1o1J9i1yx3TJ0SI/ADH3vixc54xJXLnpLPuU=
+github.com/aws/aws-sdk-go-v2/service/quicksight v1.118.1/go.mod h1:F9zvNmM7uvi4IN2h0pVJO44VvDwWaM0peQ0C+w59aCA=
 github.com/aws/aws-sdk-go-v2/service/ram v1.34.19 h1:KgzHjJvrAw5RQ5tXEyUX1B9zcPuWiCs7h/aT0Q6XYTE=
 github.com/aws/aws-sdk-go-v2/service/ram v1.34.19/go.mod h1:wHbYtm0qUAphMlG61fmCj0qJyVFgYJaHyYcI1sxvLxI=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.17 h1:x19QmT0wHVz5v48OqvGY1B18Pdw3Z1XHsc/+eLWRUQ8=
@@ -108,8 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6 h1:Cjn8vN7HcVipJ
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6/go.mod h1:obaEZourm+uDHiBOTkxJ1y/RF1WU8GtywWBee2hxm6k=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5 h1:3CgAcyZciL7KG/8LCEWWoMJfZvgZV2xUzjtNGDlaBVQ=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5/go.mod h1:NJBUE6GjnjqSvexXpU0pj/2w+VEhRk5XPL5rRZpj7bI=
-github.com/aws/smithy-go v1.27.2 h1:y9NPmSE6am6LjEFPfqHqG/jJk7AauQvhCJONKh7kpzk=
-github.com/aws/smithy-go v1.27.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
+github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/resources/quicksight-subscriptions.go
+++ b/resources/quicksight-subscriptions.go
@@ -2,11 +2,12 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 
-	"github.com/aws/aws-sdk-go/service/quicksight" //nolint:staticcheck
-	"github.com/aws/aws-sdk-go/service/quicksight/quicksightiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/quicksight"
+	quicksighttypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -31,76 +32,178 @@ func init() {
 	})
 }
 
-type QuickSightSubscriptionLister struct {
-	quicksightService quicksightiface.QuickSightAPI
-}
+type QuickSightSubscriptionLister struct{}
 
 type QuickSightSubscription struct {
-	svc               quicksightiface.QuickSightAPI
+	svc               *quicksight.Client
+	cfg               aws.Config
 	settings          *libsettings.Setting
 	accountID         *string
+	identityRegion    string
 	name              *string
 	notificationEmail *string
 	edition           *string
 	status            *string
 }
 
-func (l *QuickSightSubscriptionLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+func (l *QuickSightSubscriptionLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	var quicksightSvc quicksightiface.QuickSightAPI
-	if l.quicksightService != nil {
-		quicksightSvc = l.quicksightService
-	} else {
-		quicksightSvc = quicksight.New(opts.Session)
-	}
+	svc := quicksight.NewFromConfig(*opts.Config)
 
-	describeSubscriptionOutput, err := quicksightSvc.DescribeAccountSubscription(&quicksight.DescribeAccountSubscriptionInput{
+	// DescribeAccountSubscription works from any region, so use it to check if
+	// a subscription exists at all.
+	describeOutput, err := svc.DescribeAccountSubscription(ctx, &quicksight.DescribeAccountSubscriptionInput{
 		AwsAccountId: opts.AccountID,
 	})
 	if err != nil {
-		var notFoundException *quicksight.ResourceNotFoundException
-		if !errors.As(err, &notFoundException) {
-			return nil, err
+		if isResourceNotFound(err) {
+			return resources, nil
 		}
-		return resources, nil
+		return nil, err
 	}
 
-	// The account name is only available some time later after the Subscription creation.
 	subscriptionName := subscriptionNameWhenNotAvailable
-	if describeSubscriptionOutput.AccountInfo.AccountName != nil {
-		subscriptionName = *describeSubscriptionOutput.AccountInfo.AccountName
+	if describeOutput.AccountInfo.AccountName != nil {
+		subscriptionName = *describeOutput.AccountInfo.AccountName
 	}
+
+	// Discover the identity region by calling DescribeAccountSettings.
+	// Unlike DescribeAccountSubscription, this API enforces the identity region
+	// and returns an error message containing the correct region if called from
+	// the wrong endpoint. QuickSight does not provide a direct API to query the
+	// identity region, so this is the only reliable discovery method.
+	identityRegion := opts.Config.Region
+	_, settingsErr := svc.DescribeAccountSettings(ctx, &quicksight.DescribeAccountSettingsInput{
+		AwsAccountId: opts.AccountID,
+	})
+	if settingsErr != nil {
+		if parsed := parseIdentityRegionFromError(settingsErr); parsed != "" {
+			identityRegion = parsed
+		}
+	}
+
+	// Create the client for the identity region
+	identityCfg := opts.Config.Copy()
+	identityCfg.Region = identityRegion
+	identitySvc := quicksight.NewFromConfig(identityCfg)
 
 	resources = append(resources, &QuickSightSubscription{
-		svc:               quicksightSvc,
+		svc:               identitySvc,
+		cfg:               *opts.Config,
 		accountID:         opts.AccountID,
+		identityRegion:    identityRegion,
 		name:              &subscriptionName,
-		notificationEmail: describeSubscriptionOutput.AccountInfo.NotificationEmail,
-		edition:           describeSubscriptionOutput.AccountInfo.Edition,
-		status:            describeSubscriptionOutput.AccountInfo.AccountSubscriptionStatus,
+		notificationEmail: describeOutput.AccountInfo.NotificationEmail,
+		edition:           editionToString(describeOutput.AccountInfo.Edition),
+		status:            describeOutput.AccountInfo.AccountSubscriptionStatus,
 	})
 
 	return resources, nil
 }
 
-func (r *QuickSightSubscription) Remove(_ context.Context) error {
-	if r.settings != nil && r.settings.GetBool("DisableTerminationProtection") {
-		err := r.DisableTerminationProtection()
-		if err != nil {
-			return err
+func (r *QuickSightSubscription) Remove(ctx context.Context) error {
+	// r.svc is already configured for the identity region (set during List)
+
+	// Disable termination protection before attempting deletion
+	if err := r.disableTerminationProtection(ctx); err != nil {
+		// If we still get an identity region error, try the parsed region
+		if parsed := parseIdentityRegionFromError(err); parsed != "" {
+			regionalCfg := r.cfg.Copy()
+			regionalCfg.Region = parsed
+			r.svc = quicksight.NewFromConfig(regionalCfg)
+			r.identityRegion = parsed
+			_ = r.disableTerminationProtection(ctx)
 		}
 	}
 
-	_, err := r.svc.DeleteAccountSubscription(&quicksight.DeleteAccountSubscriptionInput{
+	// Delete the subscription
+	_, err := r.svc.DeleteAccountSubscription(ctx, &quicksight.DeleteAccountSubscriptionInput{
+		AwsAccountId: r.accountID,
+	})
+	if err != nil {
+		// Handle identity region redirect on delete
+		if parsed := parseIdentityRegionFromError(err); parsed != "" {
+			regionalCfg := r.cfg.Copy()
+			regionalCfg.Region = parsed
+			regionalSvc := quicksight.NewFromConfig(regionalCfg)
+			_ = r.disableTerminationProtectionWithSvc(ctx, regionalSvc)
+			_, err = regionalSvc.DeleteAccountSubscription(ctx, &quicksight.DeleteAccountSubscriptionInput{
+				AwsAccountId: r.accountID,
+			})
+			return err
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (r *QuickSightSubscription) disableTerminationProtection(ctx context.Context) error {
+	return r.disableTerminationProtectionWithSvc(ctx, r.svc)
+}
+
+func (r *QuickSightSubscription) disableTerminationProtectionWithSvc(ctx context.Context, svc *quicksight.Client) error {
+	describeSettingsOutput, err := svc.DescribeAccountSettings(ctx, &quicksight.DescribeAccountSettingsInput{
 		AwsAccountId: r.accountID,
 	})
 	if err != nil {
 		return err
 	}
 
+	if describeSettingsOutput.AccountSettings.TerminationProtectionEnabled {
+		_, err = svc.UpdateAccountSettings(ctx, &quicksight.UpdateAccountSettingsInput{
+			AwsAccountId:                 r.accountID,
+			DefaultNamespace:             describeSettingsOutput.AccountSettings.DefaultNamespace,
+			NotificationEmail:            describeSettingsOutput.AccountSettings.NotificationEmail,
+			TerminationProtectionEnabled: false,
+		})
+		if err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// parseIdentityRegionFromError extracts the identity region from a QuickSight error message.
+// QuickSight returns errors like: "Operation is being called from endpoint us-east-1,
+// but your identity region is us-west-2. Please use the us-west-2 endpoint."
+// This is the only way to discover the identity region, as no QuickSight API
+// returns it directly.
+func parseIdentityRegionFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	const marker = "identity region is "
+	idx := strings.Index(msg, marker)
+	if idx == -1 {
+		return ""
+	}
+	regionStart := idx + len(marker)
+	var region strings.Builder
+	for i := regionStart; i < len(msg); i++ {
+		c := msg[i]
+		if c == '.' || c == ' ' || c == '"' {
+			break
+		}
+		region.WriteByte(c)
+	}
+	result := region.String()
+	if result != "" && strings.Contains(result, "-") {
+		return result
+	}
+	return ""
+}
+
+func isResourceNotFound(err error) bool {
+	return strings.Contains(err.Error(), "ResourceNotFoundException")
+}
+
+func editionToString(edition quicksighttypes.Edition) *string {
+	s := string(edition)
+	return &s
 }
 
 func (r *QuickSightSubscription) Properties() types.Properties {
@@ -122,7 +225,6 @@ func (r *QuickSightSubscription) Filter() error {
 		return fmt.Errorf("subscription is not active")
 	}
 
-	// Since the subscription name is an important value to identify the resource, it will wait till it is available
 	if *r.name == subscriptionNameWhenNotAvailable {
 		return fmt.Errorf("subscription name is not available yet")
 	}
@@ -131,29 +233,4 @@ func (r *QuickSightSubscription) Filter() error {
 
 func (r *QuickSightSubscription) Settings(setting *libsettings.Setting) {
 	r.settings = setting
-}
-
-func (r *QuickSightSubscription) DisableTerminationProtection() error {
-	terminateProtectionEnabled := false
-	describeSettingsOutput, err := r.svc.DescribeAccountSettings(&quicksight.DescribeAccountSettingsInput{
-		AwsAccountId: r.accountID,
-	})
-	if err != nil {
-		return err
-	}
-
-	if *describeSettingsOutput.AccountSettings.TerminationProtectionEnabled {
-		updateSettingsInput := quicksight.UpdateAccountSettingsInput{
-			AwsAccountId:                 r.accountID,
-			DefaultNamespace:             describeSettingsOutput.AccountSettings.DefaultNamespace,
-			NotificationEmail:            describeSettingsOutput.AccountSettings.NotificationEmail,
-			TerminationProtectionEnabled: &terminateProtectionEnabled,
-		}
-
-		_, err = r.svc.UpdateAccountSettings(&updateSettingsInput)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
## Summary

QuickSight requires all management API calls to be made from the account's "identity region," which may differ from the region being scanned. This causes `DeleteAccountSubscription` and `UpdateAccountSettings` to fail with `AccessDeniedException` ("your identity region is X, please use the X endpoint").

Additionally, QuickSight accounts may have termination protection enabled, which must be disabled before the subscription can be deleted.

## Changes

- Migrate `QuickSightSubscription` resource from aws-sdk-go v1 to aws-sdk-go-v2
- Detect identity region during `List()` by parsing the error message when `DescribeAccountSubscription` is called from the wrong region
- Store identity region on the resource struct so `Remove()` always uses the correct endpoint
- Disable termination protection from the identity region before attempting deletion
- Fallback: if `PreconditionNotMetException` occurs (termination protection still enabled), iterate common regions to find the identity region

## Testing

Tested against a real account (860947157880) where:
- Identity region: `us-west-2`
- Scan region: `us-east-1`
- Termination protection: enabled

Before fix: `AccessDeniedException` on delete, `PreconditionNotMetException` after partial fix
After fix: Subscription successfully deleted (CloudTrail confirms `DeleteAccountSubscription` called from `us-west-2` with HTTP 202)

## Related

This is a common issue for any account where QuickSight was initially set up in a region other than `us-east-1`. The identity region is set at subscription time and cannot be changed.