### PR TITLE
feat(ssm): add association filter properties

### DIFF
--- a/docs/resources/ssm-association.md
+++ b/docs/resources/ssm-association.md
@@ -11,5 +11,26 @@ generated: true
 SSMAssociation
 ```
 
+## Properties
 
 
+- `AssociationId`: The ID of the SSM association
+- `AssociationName`: The optional name of the SSM association
+- `DocumentName`: The name of the SSM document applied by the association
+- `InstanceId`: The managed node ID for a legacy association
+- `TargetMaps`: The association target maps in key=value form
+- `Targets`: The association targets in key=value form
+- `tag:<key>:`: This resource has tags with property `Tags`. These are key/value pairs that are
+	added as their own property with the prefix of `tag:` (e.g. [tag:example: "value"])
+
+!!! note - Using Properties
+    Properties are what [Filters](../config-filtering.md) are written against in your configuration. You use the property
+    names to write filters for what you want to **keep** and omit from the nuke process.
+
+### String Property
+
+The string representation of a resource is generally the value of the Name, ID or ARN field of the resource. Not all
+resources support properties. To write a filter against the string representation, simply omit the `property` field in
+the filter.
+
+The string value is always what is used in the output of the log format when a resource is identified.

--- a/resources/ssm-associations.go
+++ b/resources/ssm-associations.go
@@ -2,12 +2,18 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"         //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/ssm" //nolint:staticcheck
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
 
 	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
 )
@@ -23,12 +29,26 @@ func init() {
 	})
 }
 
-type SSMAssociationLister struct{}
+type ssmAssociationAPI interface {
+	DeleteAssociation(*ssm.DeleteAssociationInput) (*ssm.DeleteAssociationOutput, error)
+	ListAssociations(*ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error)
+	ListTagsForResource(*ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error)
+}
+
+type SSMAssociationLister struct {
+	mockSvc ssmAssociationAPI
+}
 
 func (l *SSMAssociationLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
 
-	svc := ssm.New(opts.Session)
+	var svc ssmAssociationAPI
+	if l.mockSvc != nil {
+		svc = l.mockSvc
+	} else {
+		svc = ssm.New(opts.Session)
+	}
+
 	resources := make([]resource.Resource, 0)
 
 	params := &ssm.ListAssociationsInput{
@@ -42,10 +62,32 @@ func (l *SSMAssociationLister) List(_ context.Context, o interface{}) ([]resourc
 		}
 
 		for _, association := range output.Associations {
+			var tags []*ssm.Tag
+			if association.AssociationId != nil {
+				tagOutput, err := svc.ListTagsForResource(&ssm.ListTagsForResourceInput{
+					ResourceId:   association.AssociationId,
+					ResourceType: aws.String(ssm.ResourceTypeForTaggingAssociation),
+				})
+				if err != nil {
+					logrus.WithError(err).
+						WithField("association_id", aws.StringValue(association.AssociationId)).
+						Warn("unable to list tags for SSM association, skipping to avoid incorrect filtering")
+					continue
+				}
+				if tagOutput != nil {
+					tags = tagOutput.TagList
+				}
+			}
+
 			resources = append(resources, &SSMAssociation{
-				svc:           svc,
-				associationID: association.AssociationId,
-				instanceID:    association.InstanceId,
+				svc:             svc,
+				AssociationID:   association.AssociationId,
+				AssociationName: association.AssociationName,
+				DocumentName:    association.Name,
+				InstanceID:      association.InstanceId,
+				Targets:         association.Targets,
+				TargetMaps:      association.TargetMaps,
+				Tags:            tags,
 			})
 		}
 
@@ -60,19 +102,114 @@ func (l *SSMAssociationLister) List(_ context.Context, o interface{}) ([]resourc
 }
 
 type SSMAssociation struct {
-	svc           *ssm.SSM
-	associationID *string
-	instanceID    *string
+	svc ssmAssociationAPI
+
+	AssociationID   *string                `property:"name=AssociationId" description:"The ID of the SSM association"`
+	AssociationName *string                `description:"The optional name of the SSM association"`
+	DocumentName    *string                `description:"The name of the SSM document applied by the association"`
+	InstanceID      *string                `property:"name=InstanceId" description:"The managed node ID for a legacy association"`
+	Targets         []*ssm.Target          `description:"The association targets in key=value form"`
+	TargetMaps      []map[string][]*string `description:"The association target maps in key=value form"`
+	Tags            []*ssm.Tag             `description:"The tags associated with the association"`
 }
 
 func (f *SSMAssociation) Remove(_ context.Context) error {
 	_, err := f.svc.DeleteAssociation(&ssm.DeleteAssociationInput{
-		AssociationId: f.associationID,
+		AssociationId: f.AssociationID,
 	})
 
 	return err
 }
 
+func (f *SSMAssociation) Properties() types.Properties {
+	properties := types.NewPropertiesFromStruct(f)
+
+	targetInstanceIDs := setAssociationTargetProperties(
+		properties,
+		"Targets",
+		"Target",
+		associationTargetValues(f.Targets),
+	)
+	targetInstanceIDs = append(targetInstanceIDs, setAssociationTargetProperties(
+		properties,
+		"TargetMaps",
+		"TargetMap",
+		associationTargetMapValues(f.TargetMaps),
+	)...)
+	if len(targetInstanceIDs) != 0 {
+		properties.Set("TargetInstanceIds", strings.Join(targetInstanceIDs, ","))
+	}
+
+	return properties
+}
+
+func associationTargetValues(targets []*ssm.Target) map[string][]string {
+	targetValues := make(map[string][]string)
+	for _, target := range targets {
+		if target == nil || target.Key == nil {
+			continue
+		}
+
+		key := strings.TrimSpace(aws.StringValue(target.Key))
+		if key == "" {
+			continue
+		}
+
+		for _, value := range target.Values {
+			if value != nil {
+				targetValues[key] = append(targetValues[key], aws.StringValue(value))
+			}
+		}
+	}
+
+	return targetValues
+}
+
+func associationTargetMapValues(targetMaps []map[string][]*string) map[string][]string {
+	targetValues := make(map[string][]string)
+	for _, targetMap := range targetMaps {
+		for key, values := range targetMap {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+
+			for _, value := range values {
+				if value != nil {
+					targetValues[key] = append(targetValues[key], aws.StringValue(value))
+				}
+			}
+		}
+	}
+
+	return targetValues
+}
+
+func setAssociationTargetProperties(
+	properties types.Properties,
+	aggregateProperty string,
+	propertyPrefix string,
+	targetValues map[string][]string,
+) []string {
+	targetKeys := make([]string, 0, len(targetValues))
+	for key := range targetValues {
+		targetKeys = append(targetKeys, key)
+	}
+	sort.Strings(targetKeys)
+
+	targets := make([]string, 0, len(targetKeys))
+	for _, key := range targetKeys {
+		values := strings.Join(targetValues[key], ",")
+		properties.SetWithPrefix(propertyPrefix, key, values)
+		targets = append(targets, fmt.Sprintf("%s=%s", key, values))
+	}
+	if len(targets) != 0 {
+		properties.Set(aggregateProperty, strings.Join(targets, ";"))
+	}
+
+	return targetValues["InstanceIds"]
+}
+
 func (f *SSMAssociation) String() string {
-	return *f.associationID
+	return aws.StringValue(f.AssociationID)
 }

--- a/resources/ssm-associations_mock_test.go
+++ b/resources/ssm-associations_mock_test.go
@@ -1,0 +1,324 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gotidy/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/aws-sdk-go/service/ssm" //nolint:staticcheck
+)
+
+type mockSSMAssociationService struct {
+	deleteAssociation   func(*ssm.DeleteAssociationInput) (*ssm.DeleteAssociationOutput, error)
+	listAssociations    func(*ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error)
+	listTagsForResource func(*ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error)
+}
+
+func (m *mockSSMAssociationService) DeleteAssociation(
+	input *ssm.DeleteAssociationInput,
+) (*ssm.DeleteAssociationOutput, error) {
+	return m.deleteAssociation(input)
+}
+
+func (m *mockSSMAssociationService) ListAssociations(
+	input *ssm.ListAssociationsInput,
+) (*ssm.ListAssociationsOutput, error) {
+	return m.listAssociations(input)
+}
+
+func (m *mockSSMAssociationService) ListTagsForResource(
+	input *ssm.ListTagsForResourceInput,
+) (*ssm.ListTagsForResourceOutput, error) {
+	return m.listTagsForResource(input)
+}
+
+func Test_Mock_SSMAssociation_ListAndProperties(t *testing.T) {
+	tagCalls := 0
+	mockSvc := &mockSSMAssociationService{
+		listAssociations: func(input *ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error) {
+			require.NotNil(t, input.MaxResults)
+			assert.Equal(t, int64(50), *input.MaxResults)
+			return &ssm.ListAssociationsOutput{
+				Associations: []*ssm.Association{
+					{
+						AssociationId:   ptr.String("association-1"),
+						AssociationName: ptr.String("install-agent"),
+						InstanceId:      ptr.String("i-0123456789abcdef0"),
+						Name:            ptr.String("AWS-RunShellScript"),
+						Targets: []*ssm.Target{
+							{
+								Key: ptr.String("InstanceIds"),
+								Values: []*string{
+									ptr.String("i-0123456789abcdef0"),
+									ptr.String("i-0fedcba9876543210"),
+								},
+							},
+							{
+								Key:    ptr.String("tag:Environment"),
+								Values: []*string{ptr.String("production")},
+							},
+						},
+					},
+					{
+						AssociationId: ptr.String("association-2"),
+						Name:          ptr.String("AWS-UpdateSSMAgent"),
+					},
+				},
+			}, nil
+		},
+		listTagsForResource: func(input *ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
+			tagCalls++
+			assert.Equal(t, ssm.ResourceTypeForTaggingAssociation, ptr.ToString(input.ResourceType))
+
+			if ptr.ToString(input.ResourceId) == "association-1" {
+				return &ssm.ListTagsForResourceOutput{
+					TagList: []*ssm.Tag{
+						{
+							Key:   ptr.String("Environment"),
+							Value: ptr.String("production"),
+						},
+					},
+				}, nil
+			}
+
+			return &ssm.ListTagsForResourceOutput{}, nil
+		},
+	}
+
+	lister := &SSMAssociationLister{mockSvc: mockSvc}
+	resources, err := lister.List(context.TODO(), testListerOpts)
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	assert.Equal(t, 2, tagCalls)
+
+	first := resources[0].(*SSMAssociation)
+	properties := first.Properties()
+	assert.Equal(t, "association-1", properties.Get("AssociationId"))
+	assert.Equal(t, "install-agent", properties.Get("AssociationName"))
+	assert.Equal(t, "AWS-RunShellScript", properties.Get("DocumentName"))
+	assert.Equal(t, "i-0123456789abcdef0", properties.Get("InstanceId"))
+	assert.Equal(
+		t,
+		"i-0123456789abcdef0,i-0fedcba9876543210",
+		properties.Get("Target:InstanceIds"),
+	)
+	assert.Equal(
+		t,
+		"i-0123456789abcdef0,i-0fedcba9876543210",
+		properties.Get("TargetInstanceIds"),
+	)
+	assert.Equal(
+		t,
+		"InstanceIds=i-0123456789abcdef0,i-0fedcba9876543210;tag:Environment=production",
+		properties.Get("Targets"),
+	)
+	assert.Equal(t, "production", properties.Get("tag:Environment"))
+	assert.Equal(t, "association-1", first.String())
+
+	second := resources[1].(*SSMAssociation)
+	assert.Equal(t, "", second.Properties().Get("AssociationName"))
+	assert.Equal(t, "", second.Properties().Get("tag:Environment"))
+}
+
+func Test_Mock_SSMAssociation_List_TagErrorSkipsAssociation(t *testing.T) {
+	expectedErr := errors.New("unable to list association tags")
+	mockSvc := &mockSSMAssociationService{
+		listAssociations: func(*ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error) {
+			return &ssm.ListAssociationsOutput{
+				Associations: []*ssm.Association{
+					{AssociationId: ptr.String("association-1")},
+					{
+						AssociationId:   ptr.String("association-2"),
+						AssociationName: ptr.String("retained-association"),
+					},
+				},
+			}, nil
+		},
+		listTagsForResource: func(input *ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
+			if ptr.ToString(input.ResourceId) == "association-1" {
+				return nil, expectedErr
+			}
+
+			return &ssm.ListTagsForResourceOutput{
+				TagList: []*ssm.Tag{
+					{Key: ptr.String("Environment"), Value: ptr.String("test")},
+				},
+			}, nil
+		},
+	}
+
+	lister := &SSMAssociationLister{mockSvc: mockSvc}
+	resources, err := lister.List(context.TODO(), testListerOpts)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	association := resources[0].(*SSMAssociation)
+	assert.Equal(t, "association-2", association.String())
+	assert.Equal(t, "retained-association", association.Properties().Get("AssociationName"))
+	assert.Equal(t, "test", association.Properties().Get("tag:Environment"))
+}
+
+func Test_Mock_SSMAssociation_Properties_NilSafe(t *testing.T) {
+	association := &SSMAssociation{
+		AssociationID: ptr.String("association-1"),
+		Targets: []*ssm.Target{
+			nil,
+			{},
+			{Key: ptr.String("InstanceIds"), Values: []*string{nil}},
+		},
+		TargetMaps: []map[string][]*string{
+			nil,
+			{"": {nil}},
+		},
+		Tags: []*ssm.Tag{nil, {}},
+	}
+
+	assert.NotPanics(t, func() {
+		properties := association.Properties()
+		assert.Equal(t, "association-1", properties.Get("AssociationId"))
+		assert.Equal(t, "", properties.Get("AssociationName"))
+		assert.Equal(t, "", properties.Get("DocumentName"))
+		assert.Equal(t, "", properties.Get("tag:"))
+	})
+}
+
+func Test_Mock_SSMAssociation_Properties_TargetMaps(t *testing.T) {
+	association := &SSMAssociation{
+		TargetMaps: []map[string][]*string{
+			{
+				"InstanceIds": {ptr.String("i-0123456789abcdef0")},
+				"Operation":   {ptr.String("Install")},
+			},
+			{
+				"InstanceIds": {ptr.String("i-0fedcba9876543210"), nil},
+				"":            {ptr.String("ignored")},
+			},
+		},
+	}
+
+	properties := association.Properties()
+	assert.Equal(
+		t,
+		"i-0123456789abcdef0,i-0fedcba9876543210",
+		properties.Get("TargetMap:InstanceIds"),
+	)
+	assert.Equal(t, "Install", properties.Get("TargetMap:Operation"))
+	assert.Equal(
+		t,
+		"InstanceIds=i-0123456789abcdef0,i-0fedcba9876543210;Operation=Install",
+		properties.Get("TargetMaps"),
+	)
+	assert.Equal(
+		t,
+		"i-0123456789abcdef0,i-0fedcba9876543210",
+		properties.Get("TargetInstanceIds"),
+	)
+	assert.Empty(t, properties.Get("Targets"))
+}
+
+func Test_Mock_SSMAssociation_List_Pagination(t *testing.T) {
+	listCalls := 0
+	taggedAssociationIDs := make([]string, 0, 2)
+	mockSvc := &mockSSMAssociationService{
+		listAssociations: func(input *ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error) {
+			listCalls++
+			require.NotNil(t, input.MaxResults)
+			assert.Equal(t, int64(50), *input.MaxResults)
+
+			switch listCalls {
+			case 1:
+				assert.Nil(t, input.NextToken)
+				return &ssm.ListAssociationsOutput{
+					Associations: []*ssm.Association{
+						{AssociationId: ptr.String("association-1")},
+					},
+					NextToken: ptr.String("next-page"),
+				}, nil
+			case 2:
+				assert.Equal(t, "next-page", ptr.ToString(input.NextToken))
+				return &ssm.ListAssociationsOutput{
+					Associations: []*ssm.Association{
+						{AssociationId: ptr.String("association-2")},
+					},
+				}, nil
+			default:
+				t.Fatalf("unexpected ListAssociations call %d", listCalls)
+				return &ssm.ListAssociationsOutput{}, nil
+			}
+		},
+		listTagsForResource: func(input *ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
+			taggedAssociationIDs = append(taggedAssociationIDs, ptr.ToString(input.ResourceId))
+			return &ssm.ListTagsForResourceOutput{}, nil
+		},
+	}
+
+	lister := &SSMAssociationLister{mockSvc: mockSvc}
+	resources, err := lister.List(context.TODO(), testListerOpts)
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	assert.Equal(t, 2, listCalls)
+	assert.Equal(t, []string{"association-1", "association-2"}, taggedAssociationIDs)
+	assert.Equal(t, "association-1", resources[0].(*SSMAssociation).String())
+	assert.Equal(t, "association-2", resources[1].(*SSMAssociation).String())
+}
+
+func Test_Mock_SSMAssociation_List_NilAssociationID(t *testing.T) {
+	mockSvc := &mockSSMAssociationService{
+		listAssociations: func(*ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error) {
+			return &ssm.ListAssociationsOutput{
+				Associations: []*ssm.Association{{}},
+			}, nil
+		},
+		listTagsForResource: func(*ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
+			t.Fatal("ListTagsForResource must not be called without an association ID")
+			return &ssm.ListTagsForResourceOutput{}, nil
+		},
+	}
+
+	lister := &SSMAssociationLister{mockSvc: mockSvc}
+	resources, err := lister.List(context.TODO(), testListerOpts)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Empty(t, resources[0].(*SSMAssociation).String())
+	assert.Empty(t, resources[0].(*SSMAssociation).Properties().Get("AssociationId"))
+}
+
+func Test_Mock_SSMAssociation_List_NilTagOutput(t *testing.T) {
+	mockSvc := &mockSSMAssociationService{
+		listAssociations: func(*ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error) {
+			return &ssm.ListAssociationsOutput{
+				Associations: []*ssm.Association{
+					{AssociationId: ptr.String("association-1")},
+				},
+			}, nil
+		},
+		listTagsForResource: func(*ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
+			return nil, nil //nolint:nilnil // Exercise defensive handling of a successful response with no output.
+		},
+	}
+
+	lister := &SSMAssociationLister{mockSvc: mockSvc}
+	resources, err := lister.List(context.TODO(), testListerOpts)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Empty(t, resources[0].(*SSMAssociation).Properties().Get("tag:Environment"))
+}
+
+func Test_Mock_SSMAssociation_Remove(t *testing.T) {
+	mockSvc := &mockSSMAssociationService{
+		deleteAssociation: func(input *ssm.DeleteAssociationInput) (*ssm.DeleteAssociationOutput, error) {
+			assert.Equal(t, "association-1", ptr.ToString(input.AssociationId))
+			return &ssm.DeleteAssociationOutput{}, nil
+		},
+	}
+	association := &SSMAssociation{
+		svc:           mockSvc,
+		AssociationID: ptr.String("association-1"),
+	}
+
+	assert.NoError(t, association.Remove(context.TODO()))
+}


### PR DESCRIPTION
## Summary

- Add filterable properties to `SSMAssociation`
- Fetch association tags so `tag:<Key>` filters work
- Expose association targets and target instance identifiers
- Add nil-safe handling, mock coverage, and generated property documentation

## Motivation

`SSMAssociation` previously exposed only its identifier through `String()` and
did not implement `Properties()`. This prevented users from protecting an
individual association by name, document, target, or tag without excluding the
entire resource type.

## Implementation

The resource now exposes:

- `AssociationId`
- `AssociationName`
- `DocumentName`
- `InstanceId`
- `Targets`
- `TargetMaps`
- `Target:<Key>` and `TargetMap:<Key>` properties
- `TargetInstanceIds`
- Resource tags as `tag:<Key>`

Tags are retrieved with `ListTagsForResource` using
`ResourceType=Association`.

If tag retrieval fails for an individual association, the lister logs a warning
and skips only that association. This avoids evaluating tag filters against
incomplete data without aborting discovery of every other association, following
the behavior discussed in #907.

Mock tests cover property extraction, tags, targets, target maps, pagination,
missing association names and IDs, missing tags, tag-retrieval failures, and
resource removal.

## Validation

- `go test -p 1 ./... -count=1`
- `go test -p 1 -timeout 60s -race -coverprofile=<temp-file> -covermode=atomic ./...`
- `go vet -p 1 ./...`
- `golangci-lint` v2.11.4 for `./resources`
- `mkdocs build`
- `git diff --check`

Closes #1014
Related to #907