### PR TITLE
fix(aws-eusc): add partition support for aws-eusc region

### DIFF
--- a/pkg/awsutil/account.go
+++ b/pkg/awsutil/account.go
@@ -1,18 +1,17 @@
 package awsutil
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"           //nolint:staticcheck
-	"github.com/aws/aws-sdk-go/aws/endpoints" //nolint:staticcheck
+	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gotidy/ptr"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/service/ec2" //nolint:staticcheck
 	"github.com/aws/aws-sdk-go/service/iam" //nolint:staticcheck
-	"github.com/aws/aws-sdk-go/service/sts" //nolint:staticcheck
 
 	"github.com/ekristen/aws-nuke/v3/pkg/config"
 )
@@ -29,6 +28,7 @@ type Account struct {
 }
 
 func NewAccount(creds *Credentials, customEndpoints config.CustomEndpoints) (*Account, error) {
+	ctx := context.Background()
 	creds.CustomEndpoints = customEndpoints
 	account := Account{
 		Credentials: creds,
@@ -48,50 +48,61 @@ func NewAccount(creds *Credentials, customEndpoints config.CustomEndpoints) (*Ac
 		return &account, nil
 	}
 
-	defaultSession, err := account.NewSession(DefaultRegionID, "")
+	// Use SDK v2 STS for GetCallerIdentity so that non-standard partitions
+	// (e.g. aws-eusc) are resolved via the v2 endpoint ruleset instead of
+	// the frozen v1 partition table.
+	stsConfig, err := account.NewConfig(ctx, DefaultRegionID, "sts")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create default session in %s", DefaultRegionID)
+		return nil, errors.Wrapf(err, "failed to create v2 config for sts in %s", DefaultRegionID)
 	}
-
-	identityOutput, err := sts.New(defaultSession, &aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint}).GetCallerIdentity(nil)
+	identityOutput, err := stsv2.NewFromConfig(*stsConfig).GetCallerIdentity(ctx, &stsv2.GetCallerIdentityInput{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed get caller identity")
 	}
 
-	regionsOutput, err := ec2.New(defaultSession).DescribeRegions(&ec2.DescribeRegionsInput{
-		AllRegions: ptr.Bool(true),
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get regions")
-	}
-
-	globalSession, err := account.NewSession(GlobalRegionID, "")
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create global session in %s", GlobalRegionID)
-	}
-
-	aliasesOutput, err := iam.New(globalSession).ListAccountAliases(nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed get account alias")
-	}
-
-	var aliases []string
-	for _, alias := range aliasesOutput.AccountAliases {
-		if alias != nil {
-			aliases = append(aliases, *alias)
+	// EC2 DescribeRegions uses SDK v1 and only works for standard partitions.
+	// For non-standard partitions (e.g. aws-eusc) this call may fail; that is
+	// non-fatal — regions from the config file are used directly in that case.
+	regions := []string{"global"}
+	var disabledRegions []string
+	defaultSession, sessionErr := account.NewSession(DefaultRegionID, "")
+	if sessionErr != nil {
+		logrus.Warnf("skipping region discovery: failed to create session in %s: %v", DefaultRegionID, sessionErr)
+	} else {
+		regionsOutput, regErr := ec2.New(defaultSession).DescribeRegions(&ec2.DescribeRegionsInput{
+			AllRegions: ptr.Bool(true),
+		})
+		if regErr != nil {
+			logrus.Warnf("skipping region discovery: EC2 DescribeRegions unavailable in %s: %v", DefaultRegionID, regErr)
+		} else {
+			for _, region := range regionsOutput.Regions {
+				logrus.Debugf("region: %s, status: %s",
+					ptr.ToString(region.RegionName), ptr.ToString(region.OptInStatus))
+				if ptr.ToString(region.OptInStatus) == "not-opted-in" {
+					disabledRegions = append(disabledRegions, *region.RegionName)
+				} else {
+					regions = append(regions, *region.RegionName)
+				}
+			}
 		}
 	}
 
-	regions := []string{"global"}
-	var disabledRegions []string
-	for _, region := range regionsOutput.Regions {
-		logrus.Debugf("region: %s, status: %s",
-			ptr.ToString(region.RegionName), ptr.ToString(region.OptInStatus))
-
-		if ptr.ToString(region.OptInStatus) == "not-opted-in" {
-			disabledRegions = append(disabledRegions, *region.RegionName)
+	// IAM ListAccountAliases uses the global IAM endpoint and may not be
+	// reachable from non-standard partitions. Failure is non-fatal.
+	var aliases []string
+	globalSession, globalErr := account.NewSession(GlobalRegionID, "")
+	if globalErr != nil {
+		logrus.Warnf("skipping alias lookup: failed to create global session: %v", globalErr)
+	} else {
+		aliasesOutput, aliasErr := iam.New(globalSession).ListAccountAliases(nil)
+		if aliasErr != nil {
+			logrus.Warnf("skipping alias lookup: IAM ListAccountAliases unavailable: %v", aliasErr)
 		} else {
-			regions = append(regions, *region.RegionName)
+			for _, alias := range aliasesOutput.AccountAliases {
+				if alias != nil {
+					aliases = append(aliases, *alias)
+				}
+			}
 		}
 	}
 

--- a/pkg/awsutil/session.go
+++ b/pkg/awsutil/session.go
@@ -37,7 +37,27 @@ var (
 
 	// DefaultAWSPartitionID The default aws partition. Can be customized for non AWS implementations
 	DefaultAWSPartitionID = "aws"
+
+	// knownPartitionPrefixes maps region-name prefixes to partition IDs for
+	// partitions not present in SDK v1's frozen endpoint table.
+	knownPartitionPrefixes = []struct {
+		prefix      string
+		partitionID string
+	}{
+		{"eusc-", "aws-eusc"},
+	}
 )
+
+// PartitionForRegion returns the partition ID for regions that SDK v1 does not know about.
+// Returns an empty string when the region is not matched.
+func PartitionForRegion(region string) string {
+	for _, p := range knownPartitionPrefixes {
+		if strings.HasPrefix(region, p.prefix) {
+			return p.partitionID
+		}
+	}
+	return ""
+}
 
 type Credentials struct {
 	Profile string

--- a/pkg/commands/account/account.go
+++ b/pkg/commands/account/account.go
@@ -42,17 +42,17 @@ func execute(_ context.Context, c *cli.Command) error {
 		awsutil.DefaultRegionID = defaultRegion
 
 		partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), defaultRegion)
-		if !ok {
-			if parsedConfig.CustomEndpoints.GetRegion(defaultRegion) == nil {
-				err = fmt.Errorf(
-					"the custom region '%s' must be specified in the configuration 'endpoints'"+
-						" to determine its partition", defaultRegion)
-				logrus.WithError(err).Errorf("unable to resolve partition for region: %s", defaultRegion)
-				return err
-			}
+		if ok {
+			awsutil.DefaultAWSPartitionID = partition.ID()
+		} else if partitionID := awsutil.PartitionForRegion(defaultRegion); partitionID != "" {
+			awsutil.DefaultAWSPartitionID = partitionID
+		} else if parsedConfig.CustomEndpoints.GetRegion(defaultRegion) == nil {
+			err = fmt.Errorf(
+				"the custom region '%s' must be specified in the configuration 'endpoints'"+
+					" to determine its partition", defaultRegion)
+			logrus.WithError(err).Errorf("unable to resolve partition for region: %s", defaultRegion)
+			return err
 		}
-
-		awsutil.DefaultAWSPartitionID = partition.ID()
 	}
 
 	// Create the AWS Account object. This will be used to get the account ID and aliases for the account.

--- a/pkg/commands/nuke/nuke.go
+++ b/pkg/commands/nuke/nuke.go
@@ -96,17 +96,17 @@ func execute(baseCtx context.Context, c *cli.Command) error { //nolint:funlen,go
 		awsutil.DefaultRegionID = defaultRegion
 
 		partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), defaultRegion)
-		if !ok {
-			if parsedConfig.CustomEndpoints.GetRegion(defaultRegion) == nil {
-				err = fmt.Errorf(
-					"the custom region '%s' must be specified in the configuration 'endpoints'"+
-						" to determine its partition", defaultRegion)
-				logger.WithError(err).Errorf("unable to resolve partition for region: %s", defaultRegion)
-				return err
-			}
+		if ok {
+			awsutil.DefaultAWSPartitionID = partition.ID()
+		} else if partitionID := awsutil.PartitionForRegion(defaultRegion); partitionID != "" {
+			awsutil.DefaultAWSPartitionID = partitionID
+		} else if parsedConfig.CustomEndpoints.GetRegion(defaultRegion) == nil {
+			err = fmt.Errorf(
+				"the custom region '%s' must be specified in the configuration 'endpoints'"+
+					" to determine its partition", defaultRegion)
+			logger.WithError(err).Errorf("unable to resolve partition for region: %s", defaultRegion)
+			return err
 		}
-
-		awsutil.DefaultAWSPartitionID = partition.ID()
 	}
 
 	// Create the AWS Account object. This will be used to get the account ID and aliases for the account.


### PR DESCRIPTION
## Summary

This PR adds support for the `aws-eusc` (AWS European Sovereign Cloud) partition, allowing aws-nuke to operate against regions like `eusc-de-east-1`.

### Problem

aws-nuke uses the frozen AWS SDK v1 endpoint table to resolve which partition a region belongs to. SDK v1 does not know the `aws-eusc` partition, so running aws-nuke with `--default-region eusc-de-east-1` failed immediately with:

> "the custom region 'eusc-de-east-1' must be specified in the configuration 'endpoints'..."

Additionally, `GetCallerIdentity` was called via SDK v1 STS, which constructs
`sts.amazonaws.com` (global, us-east-1 signing). eusc credentials are not valid
against that endpoint — the correct regional endpoint is
`sts.eusc-de-east-1.amazonwebservices.eu`.

### Changes

**`pkg/awsutil/session.go`**
- Add `PartitionForRegion(region string) string` as a fallback for partitions
  the frozen SDK v1 table does not know. Maps `eusc-*` prefix → `aws-eusc`.

**`pkg/commands/nuke/nuke.go` + `pkg/commands/account/account.go`**
- Use the new fallback between the v1 lookup and the custom-endpoints error,
  so eusc regions are accepted without requiring a custom endpoints block.
- Also fixes a zero-value bug: `partition.ID()` was called on the zero value
  when `endpoints.PartitionForRegion` returned `ok = false`.

**`pkg/awsutil/account.go`**
- Replace SDK v1 `sts.GetCallerIdentity` with SDK v2 so the correct regional
  eusc endpoint is used.
- Make `EC2 DescribeRegions` non-fatal: SDK v1 constructs the wrong domain
  (`amazonaws.com` instead of `amazonwebservices.eu`) for eusc — region
  discovery simply falls back to config-provided regions.
- Make `IAM ListAccountAliases` non-fatal: the global IAM endpoint is not
  reachable from eusc. The `--no-alias-check` flag + `bypass-alias-check-accounts` in the config handle this at the nuke level.

### Testing

Dry-run executed against a real `aws-eusc` account (`eusc-de-east-1`) using
exported SSO credentials. ~23 resource types responded successfully (EC2Volume, EKSCluster, LambdaFunction, S3Bucket, EFSFileSystem, BedrockAgent*, DocDB*, NetworkFirewall*, etc.). Resources that use SDK v1 (e.g. EC2Instance) still fail in eusc — that is a pre-existing limitation of the v1→v2 migration in progress, not introduced by this PR.

### Notes

- Users still need `--no-alias-check` and `bypass-alias-check-accounts` in
  their config for eusc, since IAM global endpoint is unreachable.
- SSO credentials must be exported as env vars (`aws configure export-credentials
  --format env`) because the Go SDK v2 SSO provider constructs the wrong portal
  URL for eusc.
- Relates to #906