### PR TITLE
fix: use aws-global region for IAM client in SSMQuickSetupConfigurationManager

### DIFF
--- a/resources/ssmquicksetup-configuration-manager.go
+++ b/resources/ssmquicksetup-configuration-manager.go
@@ -50,8 +50,11 @@ func (l *SSMQuickSetupConfigurationManagerLister) List(ctx context.Context, o in
 
 	for _, p := range res.ConfigurationManagersList {
 		resources = append(resources, &SSMQuickSetupConfigurationManager{
-			svc:          svc,
-			iamSvc:       iam.NewFromConfig(*opts.Config),
+			svc: svc,
+			// Pinned to aws-global; see awsutil.SkipRegionalForGlobalService.
+			iamSvc: iam.NewFromConfig(*opts.Config, func(o *iam.Options) {
+				o.Region = "aws-global"
+			}),
 			stsSvc:       sts.NewFromConfig(*opts.Config),
 			ARN:          p.ManagerArn,
 			Name:         p.Name,


### PR DESCRIPTION
CreateRoleToDelete fails with "service 'IAM' is global, but the session is not" when the scanner runs in a non-us-east-1 region.

Pin the IAM client to aws-global so the SkipRegionalForGlobalService middleware lets it through.
