### PR TITLE
fix(s3files): handling mock svc client

### DIFF
--- a/resources/s3files-access-point.go
+++ b/resources/s3files-access-point.go
@@ -24,18 +24,21 @@ func init() {
 }
 
 type S3FilesAccessPointLister struct {
-	svc S3FilesAPI
+	mockSvc S3FilesAPI
 }
 
 func (l *S3FilesAccessPointLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = s3files.NewFromConfig(*opts.Config)
+	var svc S3FilesAPI
+	if l.mockSvc == nil {
+		svc = s3files.NewFromConfig(*opts.Config)
+	} else {
+		svc = l.mockSvc
 	}
 
-	fsIDs, err := listS3FileSystems(ctx, l.svc)
+	fsIDs, err := listS3FileSystems(ctx, svc)
 	if err != nil {
 		return nil, err
 	}
@@ -46,14 +49,14 @@ func (l *S3FilesAccessPointLister) List(ctx context.Context, o interface{}) ([]r
 		}
 
 		for {
-			res, err := l.svc.ListAccessPoints(ctx, params)
+			res, err := svc.ListAccessPoints(ctx, params)
 			if err != nil {
 				return nil, err
 			}
 
 			for _, p := range res.AccessPoints {
 				resources = append(resources, &S3FilesAccessPoint{
-					svc:          l.svc,
+					svc:          svc,
 					ID:           p.AccessPointId,
 					FileSystemID: fsID,
 				})

--- a/resources/s3files-access-point_mock_test.go
+++ b/resources/s3files-access-point_mock_test.go
@@ -44,7 +44,7 @@ func Test_Mock_S3FilesAccessPoint_List(t *testing.T) {
 		},
 	}, nil)
 
-	lister := &S3FilesAccessPointLister{svc: mockSvc}
+	lister := &S3FilesAccessPointLister{mockSvc: mockSvc}
 
 	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)

--- a/resources/s3files-filesystem.go
+++ b/resources/s3files-filesystem.go
@@ -29,28 +29,31 @@ func init() {
 }
 
 type S3FilesFileSystemLister struct {
-	svc S3FilesAPI
+	mockSvc S3FilesAPI
 }
 
 func (l *S3FilesFileSystemLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = s3files.NewFromConfig(*opts.Config)
+	var svc S3FilesAPI
+	if l.mockSvc == nil {
+		svc = s3files.NewFromConfig(*opts.Config)
+	} else {
+		svc = l.mockSvc
 	}
 
 	params := &s3files.ListFileSystemsInput{}
 
 	for {
-		res, err := l.svc.ListFileSystems(ctx, params)
+		res, err := svc.ListFileSystems(ctx, params)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, p := range res.FileSystems {
 			resources = append(resources, &S3FilesFileSystem{
-				svc:  l.svc,
+				svc:  svc,
 				ID:   p.FileSystemId,
 				Name: p.Name,
 			})

--- a/resources/s3files-filesystem_mock_test.go
+++ b/resources/s3files-filesystem_mock_test.go
@@ -27,7 +27,7 @@ func Test_Mock_S3FilesFileSystem_List(t *testing.T) {
 		},
 	}, nil)
 
-	lister := &S3FilesFileSystemLister{svc: mockSvc}
+	lister := &S3FilesFileSystemLister{mockSvc: mockSvc}
 
 	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)
@@ -57,7 +57,7 @@ func Test_Mock_S3FilesFileSystem_List_Pagination(t *testing.T) {
 		}, nil),
 	)
 
-	lister := &S3FilesFileSystemLister{svc: mockSvc}
+	lister := &S3FilesFileSystemLister{mockSvc: mockSvc}
 
 	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)

--- a/resources/s3files-mount-target.go
+++ b/resources/s3files-mount-target.go
@@ -24,18 +24,21 @@ func init() {
 }
 
 type S3FilesMountTargetLister struct {
-	svc S3FilesAPI
+	mockSvc S3FilesAPI
 }
 
 func (l *S3FilesMountTargetLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = s3files.NewFromConfig(*opts.Config)
+	var svc S3FilesAPI
+	if l.mockSvc == nil {
+		svc = s3files.NewFromConfig(*opts.Config)
+	} else {
+		svc = l.mockSvc
 	}
 
-	fsIDs, err := listS3FileSystems(ctx, l.svc)
+	fsIDs, err := listS3FileSystems(ctx, svc)
 	if err != nil {
 		return nil, err
 	}
@@ -46,14 +49,14 @@ func (l *S3FilesMountTargetLister) List(ctx context.Context, o interface{}) ([]r
 		}
 
 		for {
-			res, err := l.svc.ListMountTargets(ctx, params)
+			res, err := svc.ListMountTargets(ctx, params)
 			if err != nil {
 				return nil, err
 			}
 
 			for _, p := range res.MountTargets {
 				resources = append(resources, &S3FilesMountTarget{
-					svc:          l.svc,
+					svc:          svc,
 					ID:           p.MountTargetId,
 					FileSystemID: fsID,
 				})

--- a/resources/s3files-mount-target_mock_test.go
+++ b/resources/s3files-mount-target_mock_test.go
@@ -42,7 +42,7 @@ func Test_Mock_S3FilesMountTarget_List(t *testing.T) {
 		MountTargets: []s3filestypes.ListMountTargetsDescription{},
 	}, nil)
 
-	lister := &S3FilesMountTargetLister{svc: mockSvc}
+	lister := &S3FilesMountTargetLister{mockSvc: mockSvc}
 
 	resources, err := lister.List(context.TODO(), testListerOpts)
 	a.Nil(err)


### PR DESCRIPTION
# Summary
Fix the handling of the svc client so that it creates a new for each region (also enabling mock tests).

This is related to [issues 996](https://github.com/ekristen/aws-nuke/issues/996)
