### PR TITLE
fix(timestreaminfluxdb): handling mock svc client

### DIFF
--- a/resources/timestreaminfluxdb-dbinstance.go
+++ b/resources/timestreaminfluxdb-dbinstance.go
@@ -26,20 +26,24 @@ func init() {
 }
 
 type TimestreamInfluxDBDbInstanceLister struct {
-	svc TimestreamInfluxDBAPI
+	mockSvc TimestreamInfluxDBAPI
 }
 
 func (l *TimestreamInfluxDBDbInstanceLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		opts := o.(*nuke.ListerOpts)
-		l.svc = timestreaminfluxdb.NewFromConfig(*opts.Config)
+	opts := o.(*nuke.ListerOpts)
+
+	var svc TimestreamInfluxDBAPI
+	if l.mockSvc == nil {
+		svc = timestreaminfluxdb.NewFromConfig(*opts.Config)
+	} else {
+		svc = l.mockSvc
 	}
 
 	params := &timestreaminfluxdb.ListDbInstancesInput{}
 	for {
-		resp, err := l.svc.ListDbInstances(ctx, params)
+		resp, err := svc.ListDbInstances(ctx, params)
 		if err != nil {
 			return nil, err
 		}
@@ -47,7 +51,7 @@ func (l *TimestreamInfluxDBDbInstanceLister) List(ctx context.Context, o interfa
 		for i := range resp.Items {
 			item := &resp.Items[i]
 			var tags map[string]string
-			tagsResp, err := l.svc.ListTagsForResource(ctx, &timestreaminfluxdb.ListTagsForResourceInput{
+			tagsResp, err := svc.ListTagsForResource(ctx, &timestreaminfluxdb.ListTagsForResourceInput{
 				ResourceArn: item.Arn,
 			})
 			if err == nil {
@@ -55,7 +59,7 @@ func (l *TimestreamInfluxDBDbInstanceLister) List(ctx context.Context, o interfa
 			}
 
 			resources = append(resources, &TimestreamInfluxDBDbInstance{
-				svc:    l.svc,
+				svc:    svc,
 				ID:     item.Id,
 				Name:   item.Name,
 				Arn:    item.Arn,

--- a/resources/timestreaminfluxdb-dbinstance_mock_test.go
+++ b/resources/timestreaminfluxdb-dbinstance_mock_test.go
@@ -60,7 +60,7 @@ func Test_Mock_TimestreamInfluxDBDbInstance_List(t *testing.T) {
 		}, nil)
 
 	lister := &TimestreamInfluxDBDbInstanceLister{
-		svc: mockSvc,
+		mockSvc: mockSvc,
 	}
 
 	resources, err := lister.List(context.TODO(), testListerOpts)


### PR DESCRIPTION
# Summary
Fix the handling of the svc client so that it creates a new for each region (also enabling mock tests).

This is related to https://github.com/ekristen/aws-nuke/issues/996