### PR TITLE
fix: Listing for some resources when global region is set together with others

### DIFF
--- a/resources/ram-resource-share.go
+++ b/resources/ram-resource-share.go
@@ -34,17 +34,17 @@ type RAMResourceShareLister struct {
 func (l *RAMResourceShareLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	var resources []resource.Resource
 
-	if l.svc == nil {
+	svc := l.svc
+	if svc == nil {
 		opts := o.(*nuke.ListerOpts)
-		svc := ram.NewFromConfig(*opts.Config)
-		l.svc = svc
+		svc = ram.NewFromConfig(*opts.Config)
 	}
 
 	params := &ram.GetResourceSharesInput{
 		ResourceOwner: "SELF",
 	}
 	for {
-		resp, err := l.svc.GetResourceShares(ctx, params)
+		resp, err := svc.GetResourceShares(ctx, params)
 
 		if err != nil {
 			return nil, err
@@ -52,7 +52,7 @@ func (l *RAMResourceShareLister) List(ctx context.Context, o interface{}) ([]res
 
 		for _, share := range resp.ResourceShares {
 			resources = append(resources, &RAMResourceShare{
-				svc:              l.svc,
+				svc:              svc,
 				Name:             share.Name,
 				OwningAccountID:  share.OwningAccountId,
 				ResourceShareARN: share.ResourceShareArn,

--- a/resources/route53-resolver-firewall-domain-list.go
+++ b/resources/route53-resolver-firewall-domain-list.go
@@ -33,20 +33,21 @@ func (l *Route53ResolverFirewallDomainListLister) List(ctx context.Context, o in
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = r53r.NewFromConfig(*opts.Config)
+	svc := l.svc
+	if svc == nil {
+		svc = r53r.NewFromConfig(*opts.Config)
 	}
 
 	params := &r53r.ListFirewallDomainListsInput{}
 	for {
-		resp, err := l.svc.ListFirewallDomainLists(ctx, params)
+		resp, err := svc.ListFirewallDomainLists(ctx, params)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, domainList := range resp.FirewallDomainLists {
 			resources = append(resources, &Route53ResolverFirewallDomainList{
-				svc:              l.svc,
+				svc:              svc,
 				Arn:              domainList.Arn,
 				CreatorRequestID: domainList.CreatorRequestId,
 				ID:               domainList.Id,

--- a/resources/route53-resolver-firewall-rule-group.go
+++ b/resources/route53-resolver-firewall-rule-group.go
@@ -34,30 +34,31 @@ func (l *Route53ResolverFirewallRuleGroupLister) List(ctx context.Context, o int
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = r53r.NewFromConfig(*opts.Config)
+	svc := l.svc
+	if svc == nil {
+		svc = r53r.NewFromConfig(*opts.Config)
 	}
 
-	vpcAssociations, vpcErr := ruleGroupsToAssociationIds(ctx, l.svc)
+	vpcAssociations, vpcErr := ruleGroupsToAssociationIds(ctx, svc)
 	if vpcErr != nil {
 		return nil, vpcErr
 	}
 
 	params := &r53r.ListFirewallRuleGroupsInput{}
 	for {
-		resp, err := l.svc.ListFirewallRuleGroups(ctx, params)
+		resp, err := svc.ListFirewallRuleGroups(ctx, params)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, firewallRuleGroup := range resp.FirewallRuleGroups {
-			firewallRules, ruleErr := getFirewallRules(ctx, l.svc, firewallRuleGroup.Id)
+			firewallRules, ruleErr := getFirewallRules(ctx, svc, firewallRuleGroup.Id)
 			if ruleErr != nil {
 				return nil, ruleErr
 			}
 
 			resources = append(resources, &Route53ResolverFirewallRuleGroup{
-				svc:               l.svc,
+				svc:               svc,
 				vpcAssociationIds: vpcAssociations[*firewallRuleGroup.Id],
 				rules:             firewallRules,
 				Arn:               firewallRuleGroup.Arn,

--- a/resources/route53-resolver-query-log-config.go
+++ b/resources/route53-resolver-query-log-config.go
@@ -34,25 +34,26 @@ func (l *Route53ResolverQueryLogConfigLister) List(ctx context.Context, o interf
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = r53r.NewFromConfig(*opts.Config)
+	svc := l.svc
+	if svc == nil {
+		svc = r53r.NewFromConfig(*opts.Config)
 	}
 
-	resourceAssociations, vpcErr := qlcsToAssociationIds(ctx, l.svc)
+	resourceAssociations, vpcErr := qlcsToAssociationIds(ctx, svc)
 	if vpcErr != nil {
 		return nil, vpcErr
 	}
 
 	params := &r53r.ListResolverQueryLogConfigsInput{}
 	for {
-		resp, err := l.svc.ListResolverQueryLogConfigs(ctx, params)
+		resp, err := svc.ListResolverQueryLogConfigs(ctx, params)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, qlc := range resp.ResolverQueryLogConfigs {
 			resources = append(resources, &Route53ResolverQueryLogConfig{
-				svc:                    l.svc,
+				svc:                    svc,
 				resourceAssociationIds: resourceAssociations[*qlc.Id],
 				Arn:                    qlc.Arn,
 				AssociationCount:       qlc.AssociationCount,

--- a/resources/s3files-access-point.go
+++ b/resources/s3files-access-point.go
@@ -31,11 +31,12 @@ func (l *S3FilesAccessPointLister) List(ctx context.Context, o interface{}) ([]r
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = s3files.NewFromConfig(*opts.Config)
+	svc := l.svc
+	if svc == nil {
+		svc = s3files.NewFromConfig(*opts.Config)
 	}
 
-	fsIDs, err := listS3FileSystems(ctx, l.svc)
+	fsIDs, err := listS3FileSystems(ctx, svc)
 	if err != nil {
 		return nil, err
 	}
@@ -46,14 +47,14 @@ func (l *S3FilesAccessPointLister) List(ctx context.Context, o interface{}) ([]r
 		}
 
 		for {
-			res, err := l.svc.ListAccessPoints(ctx, params)
+			res, err := svc.ListAccessPoints(ctx, params)
 			if err != nil {
 				return nil, err
 			}
 
 			for _, p := range res.AccessPoints {
 				resources = append(resources, &S3FilesAccessPoint{
-					svc:          l.svc,
+					svc:          svc,
 					ID:           p.AccessPointId,
 					FileSystemID: fsID,
 				})

--- a/resources/s3files-filesystem.go
+++ b/resources/s3files-filesystem.go
@@ -36,21 +36,22 @@ func (l *S3FilesFileSystemLister) List(ctx context.Context, o interface{}) ([]re
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = s3files.NewFromConfig(*opts.Config)
+	svc := l.svc
+	if svc == nil {
+		svc = s3files.NewFromConfig(*opts.Config)
 	}
 
 	params := &s3files.ListFileSystemsInput{}
 
 	for {
-		res, err := l.svc.ListFileSystems(ctx, params)
+		res, err := svc.ListFileSystems(ctx, params)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, p := range res.FileSystems {
 			resources = append(resources, &S3FilesFileSystem{
-				svc:  l.svc,
+				svc:  svc,
 				ID:   p.FileSystemId,
 				Name: p.Name,
 			})

--- a/resources/s3files-mount-target.go
+++ b/resources/s3files-mount-target.go
@@ -31,11 +31,12 @@ func (l *S3FilesMountTargetLister) List(ctx context.Context, o interface{}) ([]r
 	opts := o.(*nuke.ListerOpts)
 	var resources []resource.Resource
 
-	if l.svc == nil {
-		l.svc = s3files.NewFromConfig(*opts.Config)
+	svc := l.svc
+	if svc == nil {
+		svc = s3files.NewFromConfig(*opts.Config)
 	}
 
-	fsIDs, err := listS3FileSystems(ctx, l.svc)
+	fsIDs, err := listS3FileSystems(ctx, svc)
 	if err != nil {
 		return nil, err
 	}
@@ -46,14 +47,14 @@ func (l *S3FilesMountTargetLister) List(ctx context.Context, o interface{}) ([]r
 		}
 
 		for {
-			res, err := l.svc.ListMountTargets(ctx, params)
+			res, err := svc.ListMountTargets(ctx, params)
 			if err != nil {
 				return nil, err
 			}
 
 			for _, p := range res.MountTargets {
 				resources = append(resources, &S3FilesMountTarget{
-					svc:          l.svc,
+					svc:          svc,
 					ID:           p.MountTargetId,
 					FileSystemID: fsID,
 				})

--- a/resources/timestreaminfluxdb-dbinstance.go
+++ b/resources/timestreaminfluxdb-dbinstance.go
@@ -32,14 +32,15 @@ type TimestreamInfluxDBDbInstanceLister struct {
 func (l *TimestreamInfluxDBDbInstanceLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
 	var resources []resource.Resource
 
-	if l.svc == nil {
+	svc := l.svc
+	if svc == nil {
 		opts := o.(*nuke.ListerOpts)
-		l.svc = timestreaminfluxdb.NewFromConfig(*opts.Config)
+		svc = timestreaminfluxdb.NewFromConfig(*opts.Config)
 	}
 
 	params := &timestreaminfluxdb.ListDbInstancesInput{}
 	for {
-		resp, err := l.svc.ListDbInstances(ctx, params)
+		resp, err := svc.ListDbInstances(ctx, params)
 		if err != nil {
 			return nil, err
 		}
@@ -47,7 +48,7 @@ func (l *TimestreamInfluxDBDbInstanceLister) List(ctx context.Context, o interfa
 		for i := range resp.Items {
 			item := &resp.Items[i]
 			var tags map[string]string
-			tagsResp, err := l.svc.ListTagsForResource(ctx, &timestreaminfluxdb.ListTagsForResourceInput{
+			tagsResp, err := svc.ListTagsForResource(ctx, &timestreaminfluxdb.ListTagsForResourceInput{
 				ResourceArn: item.Arn,
 			})
 			if err == nil {
@@ -55,7 +56,7 @@ func (l *TimestreamInfluxDBDbInstanceLister) List(ctx context.Context, o interfa
 			}
 
 			resources = append(resources, &TimestreamInfluxDBDbInstance{
-				svc:    l.svc,
+				svc:    svc,
 				ID:     item.Id,
 				Name:   item.Name,
 				Arn:    item.Arn,


### PR DESCRIPTION
Fixes #996. Fix and PR description generated by Claude, content and fix verified by me.


**Root cause**: In libnuke, each resource type's Lister is a single singleton instance shared across every region scan for the whole run (`registry.GetLister()` always returns the same pointer). Eight resource listers cached their AWS SDK client on the Lister struct itself:

```go
if l.svc == nil {
    l.svc = <service>.NewFromConfig(*opts.Config)
}
```

Since `opts.Config` differs per region, whichever region ran first "won" and its client (with its region-specific middleware baked in) got reused for every other region for the rest of the run. When global was scanned before us-east-1, the us-east-1 lister ended up reusing the global-flagged client, so its regional API calls were skipped by the SkipGlobal middleware with "service is not global, but the session is".

Fix: In each affected lister, read the field into a local svc variable and only fall back to constructing a new client when it's nil, without ever writing back to l.svc:

```go
svc := l.svc
if svc == nil {
    svc = <service>.NewFromConfig(*opts.Config)
}
```

Run with v3.66.0 and 
```yaml
regions:
  - global
  - eu-west-1
  - us-east-1
```

```
aws-nuke run --config nuke-config.yaml --profile staging | grep S3File 
global - IAMPolicy - arn:aws:iam::123456789012:policy/service-role/S3FilesPolicy_032770 - [ARN: "arn:aws:iam::123456789012:policy/service-role/S3FilesPolicy_032770", CreateDate: "2026-07-27T14:52:47Z", Name: "S3FilesPolicy_032770", Path: "/service-role/", PolicyID: "…"] - would remove
…
```

Run with fixed binary:

```
~/projects/aws-nuke/aws-nuke run --config nuke-config.yaml --profile staging | grep S3File
global - IAMPolicy - arn:aws:iam::123456789012:policy/service-role/S3FilesPolicy_032770 - [ARN: "arn:aws:iam::123456789012:policy/service-role/S3FilesPolicy_032770", CreateDate: "2026-07-27T14:52:47Z", Name: "S3FilesPolicy_032770", Path: "/service-role/", PolicyID: "…"] - would remove
…
eu-west-1 - S3FilesMountTarget - fsmt-035636caaaaa22ca7 - [FileSystemID: "fs-0c651dbaaaaaaaaaa", ID: "fsmt-035636caaaaa22ca7"] - would remove
eu-west-1 - S3FilesMountTarget - fsmt-0db0ceaaaaaabc9a5 - [FileSystemID: "fs-0c651dbaaaaaaaaaa", ID: "fsmt-0db0ceaaaaaabc9a5"] - would remove
eu-west-1 - S3FilesMountTarget - fsmt-0356aaaaaaaaaf90b - [FileSystemID: "fs-0c651dbaaaaaaaaaa", ID: "fsmt-0356aaaaaaaaaf90b"] - would remove
eu-west-1 - S3FilesAccessPoint - fsap-0660baaaaaaaaaa87 - [FileSystemID: "fs-0c651dbaaaaaaaaaa", ID: "fsap-0660baaaaaaaaaa87"] - would remove
eu-west-1 - S3FilesAccessPoint - fsap-0b896aaaaad54c26d - [FileSystemID: "fs-0c651dbaaaaaaaaaa", ID: "fsap-0b896aaaaad54c26d"] - would remove
eu-west-1 - S3FilesFileSystem - fs-0c651dbaaaaaaaaaa (My files) - [ID: "fs-0c651dbaaaaaaaaaa", Name: "My files"] - would remove
```