### PR TITLE
fix: remove dependent resources prior to DMS subnet groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8
-	github.com/aws/aws-sdk-go-v2 v1.42.0
+	github.com/aws/aws-sdk-go-v2 v1.45.1
 	github.com/aws/aws-sdk-go-v2/config v1.28.11
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.71
 	github.com/aws/aws-sdk-go-v2/service/amp v1.36.0
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.44.12
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.65.0
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.17
+	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.69.0
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.41.7
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.15.5
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.1.2
@@ -46,7 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/textract v1.40.22
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5
-	github.com/aws/smithy-go v1.27.2
+	github.com/aws/smithy-go v1.28.1
 	github.com/ekristen/libnuke v1.3.0
 	github.com/fatih/color v1.19.0
 	github.com/golang/mock v1.6.0
@@ -66,8 +67,8 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
-github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
-github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
+github.com/aws/aws-sdk-go-v2 v1.45.1 h1:iIoG3NaLhV6UZpPXyPXlDj2I9oS8tV/nMcMnITCC6Ks=
+github.com/aws/aws-sdk-go-v2 v1.45.1/go.mod h1:bttEH6JqnUL8LepvDVfdrds/fZ5bCIxzpe3abyUrhDU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.28.11 h1:7Ekru0IkRHRnSRWGQLnLN6i0o1Jncd0rHo2T130+tEQ=
@@ -10,10 +10,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.17.71 h1:r2w4mQWnrTMJjOyIsZtGp3R3XGY
 github.com/aws/aws-sdk-go-v2/credentials v1.17.71/go.mod h1:E7VF3acIup4GB5ckzbKFrCK0vTvEQxOxgdq4U3vcMCY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33 h1:D9ixiWSG4lyUBL2DDNK924Px9V/NBVpML90MHqyTADY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.33/go.mod h1:caS/m4DI+cij2paz3rtProRBI4s/+TCiWoaWZuQ9010=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1 h1:pc138gM1CW+XPc60rEwUlwwuwWFQK16CI1T7v1F9Oec=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1/go.mod h1:1+koxpPIbfBdfzP6vojm5/zTpTQ/micYwlxIiNB3TxI=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 h1:K0JsbZQj+1h208Ro1zHeA4l7bMp0NvRffHQ91q8Ol1s=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1/go.mod h1:W3/vL6EtCIatICGy9ab29QhMuae+cOKPWcMxv02CO+Q=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvKgqdiXoTxAF4HQcQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -34,6 +34,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.65.0 h1:3yaFbUbuLfN8n1q01
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.65.0/go.mod h1:PobeppEnIjw4pcgjFryNDZCTH7AiqZw0yb5r98Gvf9c=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.17 h1:1dD+R6ZPvGnbDdLI0sBbP6lgCkmV5EGDQ/OMp3M1LK0=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.17/go.mod h1:SUPDeDwJztUv53XckbxoT5R6VqutnaCWFsN/p8M3M1s=
+github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.69.0 h1:JOVPEqqpMTdg5G/QS6raS7AdjaiUp5ml9A52YPEC4h0=
+github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.69.0/go.mod h1:9WmuNpQ1Pz6Kc3a+7X2u8swGwOiHDIepKFk0tI0n0ts=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.41.7 h1:PcREFcABD9rw3UFjPFvhg3JIwK56gW0AFqjBpZRgpQQ=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.41.7/go.mod h1:Ex1bFLSZE6w+gKwGRSROIRdSQhGa5aHXt9dE54BHSXw=
 github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.15.5 h1:3fuuyMVTd8rS7nKXZcAQPj7miksKiRImi3Lh1CEFUiU=
@@ -108,8 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6 h1:Cjn8vN7HcVipJ
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.20.6/go.mod h1:obaEZourm+uDHiBOTkxJ1y/RF1WU8GtywWBee2hxm6k=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5 h1:3CgAcyZciL7KG/8LCEWWoMJfZvgZV2xUzjtNGDlaBVQ=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.55.5/go.mod h1:NJBUE6GjnjqSvexXpU0pj/2w+VEhRk5XPL5rRZpj7bI=
-github.com/aws/smithy-go v1.27.2 h1:y9NPmSE6am6LjEFPfqHqG/jJk7AauQvhCJONKh7kpzk=
-github.com/aws/smithy-go v1.27.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.28.1 h1:R/nXH00c8qcfCzQVELtRw+eLQWtzv+VAIEFJ1/xxXlQ=
+github.com/aws/smithy-go v1.28.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/resources/databasemigrationservice-instance-profile.go
+++ b/resources/databasemigrationservice-instance-profile.go
@@ -1,0 +1,77 @@
+package resources
+
+import (
+	"context"
+
+	dmsv2 "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const DatabaseMigrationServiceInstanceProfileResource = "DatabaseMigrationServiceInstanceProfile"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     DatabaseMigrationServiceInstanceProfileResource,
+		Scope:    nuke.Account,
+		Resource: &DatabaseMigrationServiceInstanceProfile{},
+		Lister:   &DatabaseMigrationServiceInstanceProfileLister{},
+		DependsOn: []string{
+			DatabaseMigrationServiceMigrationProjectResource,
+		},
+	})
+}
+
+type DatabaseMigrationServiceInstanceProfileLister struct{}
+
+func (l *DatabaseMigrationServiceInstanceProfileLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := dmsv2.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	paginator := dmsv2.NewDescribeInstanceProfilesPaginator(svc, &dmsv2.DescribeInstanceProfilesInput{})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, instanceProfile := range output.InstanceProfiles {
+			resources = append(resources, &DatabaseMigrationServiceInstanceProfile{
+				svc:  svc,
+				ARN:  instanceProfile.InstanceProfileArn,
+				Name: instanceProfile.InstanceProfileName,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+type DatabaseMigrationServiceInstanceProfile struct {
+	ARN  *string
+	Name *string
+
+	svc *dmsv2.Client
+}
+
+func (r *DatabaseMigrationServiceInstanceProfile) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteInstanceProfile(ctx, &dmsv2.DeleteInstanceProfileInput{
+		InstanceProfileIdentifier: r.ARN,
+	})
+
+	return err
+}
+
+func (r *DatabaseMigrationServiceInstanceProfile) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *DatabaseMigrationServiceInstanceProfile) String() string {
+	return *r.ARN
+}

--- a/resources/databasemigrationservice-instance-profile_mock_test.go
+++ b/resources/databasemigrationservice-instance-profile_mock_test.go
@@ -1,0 +1,21 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/gotidy/ptr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabaseMigrationServiceInstanceProfileProperties(t *testing.T) {
+	resource := &DatabaseMigrationServiceInstanceProfile{
+		ARN:  ptr.String("arn:aws:dms:us-east-1:123456789012:instance-profile:profile"),
+		Name: ptr.String("profile"),
+	}
+
+	properties := resource.Properties()
+
+	assert.Equal(t, "arn:aws:dms:us-east-1:123456789012:instance-profile:profile", properties.Get("ARN"))
+	assert.Equal(t, "profile", properties.Get("Name"))
+	assert.Equal(t, "arn:aws:dms:us-east-1:123456789012:instance-profile:profile", resource.String())
+}

--- a/resources/databasemigrationservice-migration-project.go
+++ b/resources/databasemigrationservice-migration-project.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"context"
+
+	dmsv2 "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/aws-nuke/v3/pkg/nuke"
+)
+
+const DatabaseMigrationServiceMigrationProjectResource = "DatabaseMigrationServiceMigrationProject"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     DatabaseMigrationServiceMigrationProjectResource,
+		Scope:    nuke.Account,
+		Resource: &DatabaseMigrationServiceMigrationProject{},
+		Lister:   &DatabaseMigrationServiceMigrationProjectLister{},
+	})
+}
+
+type DatabaseMigrationServiceMigrationProjectLister struct{}
+
+func (l *DatabaseMigrationServiceMigrationProjectLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*nuke.ListerOpts)
+	svc := dmsv2.NewFromConfig(*opts.Config)
+	var resources []resource.Resource
+
+	paginator := dmsv2.NewDescribeMigrationProjectsPaginator(svc, &dmsv2.DescribeMigrationProjectsInput{})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, migrationProject := range output.MigrationProjects {
+			resources = append(resources, &DatabaseMigrationServiceMigrationProject{
+				svc:  svc,
+				ARN:  migrationProject.MigrationProjectArn,
+				Name: migrationProject.MigrationProjectName,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+type DatabaseMigrationServiceMigrationProject struct {
+	ARN  *string
+	Name *string
+
+	svc *dmsv2.Client
+}
+
+func (r *DatabaseMigrationServiceMigrationProject) Remove(ctx context.Context) error {
+	_, err := r.svc.DeleteMigrationProject(ctx, &dmsv2.DeleteMigrationProjectInput{
+		MigrationProjectIdentifier: r.ARN,
+	})
+
+	return err
+}
+
+func (r *DatabaseMigrationServiceMigrationProject) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *DatabaseMigrationServiceMigrationProject) String() string {
+	return *r.ARN
+}

--- a/resources/databasemigrationservice-migration-project.go
+++ b/resources/databasemigrationservice-migration-project.go
@@ -58,6 +58,31 @@ type DatabaseMigrationServiceMigrationProject struct {
 }
 
 func (r *DatabaseMigrationServiceMigrationProject) Remove(ctx context.Context) error {
+	paginator := dmsv2.NewDescribeMetadataModelConversionsPaginator(r.svc, &dmsv2.DescribeMetadataModelConversionsInput{
+		MigrationProjectIdentifier: r.ARN,
+	})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, request := range output.Requests {
+			if request.Status == nil || request.RequestIdentifier == nil || (*request.Status != "RECEIVED" && *request.Status != "IN_PROGRESS") {
+				continue
+			}
+
+			_, err := r.svc.CancelMetadataModelConversion(ctx, &dmsv2.CancelMetadataModelConversionInput{
+				MigrationProjectIdentifier: r.ARN,
+				RequestIdentifier:          request.RequestIdentifier,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	_, err := r.svc.DeleteMigrationProject(ctx, &dmsv2.DeleteMigrationProjectInput{
 		MigrationProjectIdentifier: r.ARN,
 	})

--- a/resources/databasemigrationservice-migration-project_mock_test.go
+++ b/resources/databasemigrationservice-migration-project_mock_test.go
@@ -1,0 +1,21 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/gotidy/ptr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabaseMigrationServiceMigrationProjectProperties(t *testing.T) {
+	resource := &DatabaseMigrationServiceMigrationProject{
+		ARN:  ptr.String("arn:aws:dms:us-east-1:123456789012:migration-project:project"),
+		Name: ptr.String("project"),
+	}
+
+	properties := resource.Properties()
+
+	assert.Equal(t, "arn:aws:dms:us-east-1:123456789012:migration-project:project", properties.Get("ARN"))
+	assert.Equal(t, "project", properties.Get("Name"))
+	assert.Equal(t, "arn:aws:dms:us-east-1:123456789012:migration-project:project", resource.String())
+}

--- a/resources/databasemigrationservice-subnetgroups.go
+++ b/resources/databasemigrationservice-subnetgroups.go
@@ -20,6 +20,9 @@ func init() {
 		Scope:    nuke.Account,
 		Resource: &DatabaseMigrationServiceSubnetGroup{},
 		Lister:   &DatabaseMigrationServiceSubnetGroupLister{},
+		DependsOn: []string{
+			DatabaseMigrationServiceInstanceProfileResource,
+		},
 	})
 }
 


### PR DESCRIPTION
These changes are to handle the removal of dependent DMS instance profile and project resources prior to attempting removal of DMS subnet groups.